### PR TITLE
chore: URL cleanup + ruff migration ahead of nemarOrg transfer

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,10 +24,10 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install black ruff
+          pip install ruff
 
-      - name: Run black format check
-        run: black --check src/ tests/
+      - name: Run ruff format check
+        run: ruff format --check src/ tests/
 
       - name: Run ruff lint
         run: ruff check src/ tests/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,7 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.6.9
+    hooks:
+      - id: ruff
+        args: [--fix, --unsafe-fixes]
+      - id: ruff-format

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ pytest tests/ -v                    # Fast tests
 pytest --cov=dataset_citations      # With coverage
 
 # Code quality
-black src/ tests/                   # Format
+ruff format src/ tests/             # Format
 ruff check --fix src/ tests/        # Lint
 ```
 
@@ -219,7 +219,7 @@ ruff check --fix src/ tests/        # Lint
 
 1. Fork & create feature branch
 2. Make changes with tests
-3. Run `pytest` and `black`
+3. Run `pytest` and `ruff format`
 4. Submit PR with issue reference
 
 **Guidelines**: Type hints • Docstrings • Tests • No mocks

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Python 3.11+](https://img.shields.io/badge/python-3.11+-blue.svg)](https://www.python.org/downloads/)
 [![License: CC BY-NC-SA 4.0](https://img.shields.io/badge/License-CC%20BY--NC--SA%204.0-lightgrey.svg)](https://creativecommons.org/licenses/by-nc-sa/4.0/)
-[![Tests](https://github.com/sccn/nemar-citations/actions/workflows/test.yml/badge.svg)](https://github.com/sccn/nemar-citations/actions)
+[![Tests](https://github.com/nemarOrg/nemar-citations/actions/workflows/test.yml/badge.svg)](https://github.com/nemarOrg/nemar-citations/actions)
 
 Automated BIDS dataset citation tracking system with AI-powered confidence scoring for 300+ neuroscience datasets.
 
@@ -15,7 +15,7 @@ Track and analyze citations for OpenNeuro datasets with a complete pipeline from
 ## Installation
 
 ```bash
-git clone https://github.com/sccn/nemar-citations.git
+git clone https://github.com/nemarOrg/nemar-citations.git
 cd nemar-citations
 pip install -e ".[dev,test]"
 ```
@@ -174,7 +174,7 @@ AI-powered relevance scoring (0.0-1.0) using sentence transformers to compare da
 
 ```bash
 # Setup
-git clone https://github.com/sccn/nemar-citations.git
+git clone https://github.com/nemarOrg/nemar-citations.git
 cd nemar-citations
 conda create -n dataset-citations python=3.11
 conda activate dataset-citations
@@ -213,7 +213,7 @@ ruff check --fix src/ tests/        # Lint
 
 **Debug**: Add `--verbose` flag to any command
 
-**Support**: [GitHub Issues](https://github.com/sccn/nemar-citations/issues)
+**Support**: [GitHub Issues](https://github.com/nemarOrg/nemar-citations/issues)
 
 ## Contributing
 
@@ -237,7 +237,7 @@ If you use this software in your research, please cite:
   title={NEMAR Citations: Automated BIDS Dataset Citation Tracking System},
   author={Shirazi, Seyed Yahya},
   year={2025},
-  url={https://github.com/sccn/nemar-citations},
+  url={https://github.com/nemarOrg/nemar-citations},
   organization={Swartz Center for Computational Neuroscience (SCCN)}
 }
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,10 +70,10 @@ test = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/neuromechanist/dataset_citations"
-Repository = "https://github.com/neuromechanist/dataset_citations"
-Documentation = "https://github.com/neuromechanist/dataset_citations/blob/main/README.md"
-"Bug Reports" = "https://github.com/neuromechanist/dataset_citations/issues"
+Homepage = "https://github.com/nemarOrg/nemar-citations"
+Repository = "https://github.com/nemarOrg/nemar-citations"
+Documentation = "https://github.com/nemarOrg/nemar-citations/blob/main/README.md"
+"Bug Reports" = "https://github.com/nemarOrg/nemar-citations/issues"
 
 [project.scripts]
 dataset-citations-discover = "dataset_citations.cli.discover:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,8 +59,7 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
     "pytest>=6.0",
-    "black>=21.0",
-    "ruff>=0.1.0",
+    "ruff>=0.6.0",
     "mypy>=0.910",
     "pre-commit>=2.15",
 ]
@@ -102,27 +101,25 @@ dataset-citations-automate-visualization-updates = "dataset_citations.cli.automa
 [tool.setuptools.packages.find]
 where = ["src"]
 
-[tool.black]
+[tool.ruff]
 line-length = 88
-target-version = ['py38']
-include = '\.pyi?$'
-extend-exclude = '''
-/(
-  | \.git
-  | \.mypy_cache
-  | \.tox
-  | \.venv
-  | _build
-  | buck-out
-  | build
-  | dist
-)/
-'''
+target-version = "py311"
+extend-exclude = [
+    ".git",
+    ".mypy_cache",
+    ".tox",
+    ".venv",
+    "_build",
+    "buck-out",
+    "build",
+    "dist",
+]
 
-[tool.isort]
-profile = "black"
-multi_line_output = 3
-line_length = 88
+[tool.ruff.lint]
+extend-select = ["I"]
+
+[tool.ruff.lint.isort]
+known-first-party = ["dataset_citations"]
 
 [tool.mypy]
 python_version = "3.8"

--- a/src/dataset_citations/analysis/generate_network.py
+++ b/src/dataset_citations/analysis/generate_network.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python
 """Generate network analysis data from citation JSON files."""
 
-import json
 import csv
+import json
 import sys
+from collections import Counter, defaultdict
 from pathlib import Path
-from collections import defaultdict, Counter
 
 
 def generate_network(citations_dir: Path, output_dir: Path):

--- a/src/dataset_citations/analysis/generate_temporal.py
+++ b/src/dataset_citations/analysis/generate_temporal.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python
 """Generate temporal analysis data from citation JSON files."""
 
-import json
 import csv
+import json
 import sys
-from pathlib import Path
 from collections import defaultdict
+from pathlib import Path
 
 
 def generate_temporal(citations_dir: Path, output_dir: Path):

--- a/src/dataset_citations/analysis/generate_themes.py
+++ b/src/dataset_citations/analysis/generate_themes.py
@@ -3,12 +3,12 @@
 
 import json
 import sys
-from pathlib import Path
 from collections import defaultdict
+from pathlib import Path
 
 try:
-    from wordcloud import WordCloud
     import matplotlib.pyplot as plt
+    from wordcloud import WordCloud
 except ImportError:
     print("Installing required packages...")
     import subprocess
@@ -16,8 +16,8 @@ except ImportError:
     subprocess.check_call(
         [sys.executable, "-m", "pip", "install", "wordcloud", "matplotlib"]
     )
-    from wordcloud import WordCloud
     import matplotlib.pyplot as plt
+    from wordcloud import WordCloud
 
 
 def generate_themes(citations_dir: Path, output_dir: Path):
@@ -124,7 +124,7 @@ def generate_themes(citations_dir: Path, output_dir: Path):
     with open(output_dir / "comprehensive_theme_analysis.json", "w") as f:
         json.dump(theme_data, f, indent=2)
 
-    print(f'Theme analysis complete: {len(theme_data["themes"])} themes generated')
+    print(f"Theme analysis complete: {len(theme_data['themes'])} themes generated")
 
 
 if __name__ == "__main__":

--- a/src/dataset_citations/cli/analyze_networks.py
+++ b/src/dataset_citations/cli/analyze_networks.py
@@ -3,8 +3,8 @@
 import argparse
 import logging
 import os
-from pathlib import Path
 import sys
+from pathlib import Path
 
 import pandas as pd
 

--- a/src/dataset_citations/cli/analyze_temporal_themes.py
+++ b/src/dataset_citations/cli/analyze_temporal_themes.py
@@ -3,12 +3,12 @@ CLI command for temporal analysis of research theme evolution.
 """
 
 import argparse
-from collections import Counter, defaultdict
-from datetime import datetime
 import json
 import logging
-from pathlib import Path
 import pickle
+from collections import Counter, defaultdict
+from datetime import datetime
+from pathlib import Path
 from typing import Dict, List, Optional
 
 import numpy as np

--- a/src/dataset_citations/cli/analyze_umap.py
+++ b/src/dataset_citations/cli/analyze_umap.py
@@ -5,8 +5,8 @@ CLI command for UMAP analysis and research theme identification.
 import argparse
 import json
 import logging
-from pathlib import Path
 import time
+from pathlib import Path
 
 from ..embeddings.umap_analyzer import UMAPAnalyzer
 

--- a/src/dataset_citations/cli/automate_updates.py
+++ b/src/dataset_citations/cli/automate_updates.py
@@ -3,12 +3,12 @@ CLI command for automated embedding updates when new citations are added.
 """
 
 import argparse
-from datetime import datetime, timedelta
 import hashlib
 import json
 import logging
-from pathlib import Path
 import time
+from datetime import datetime, timedelta
+from pathlib import Path
 from typing import Dict, List, Optional
 
 from ..core.citation_utils import load_citations_from_json

--- a/src/dataset_citations/cli/discover.py
+++ b/src/dataset_citations/cli/discover.py
@@ -4,10 +4,10 @@ that contain EEG, iEEG, or MEG data, based on BIDS directory structures.
 """
 
 import argparse
-from datetime import datetime  # For rate limit logging and processed_date
 import logging
 import os
 import time
+from datetime import datetime  # For rate limit logging and processed_date
 
 import pandas as pd  # For lookup table
 import requests  # Using requests for simplicity, consider httpx for async later if needed

--- a/src/dataset_citations/cli/generate_embeddings.py
+++ b/src/dataset_citations/cli/generate_embeddings.py
@@ -5,8 +5,8 @@ CLI command for generating embeddings from existing dataset and citation data.
 import argparse
 import json
 import logging
-from pathlib import Path
 import time
+from pathlib import Path
 from typing import Optional
 
 from ..core.citation_utils import load_citations_from_json

--- a/src/dataset_citations/cli/manage_embeddings.py
+++ b/src/dataset_citations/cli/manage_embeddings.py
@@ -5,8 +5,8 @@ CLI command for embedding management and maintenance operations.
 import argparse
 import json
 import logging
-from pathlib import Path
 import time
+from pathlib import Path
 from typing import Dict
 
 from ..embeddings.storage_manager import EmbeddingStorageManager

--- a/src/dataset_citations/cli/migrate.py
+++ b/src/dataset_citations/cli/migrate.py
@@ -19,8 +19,8 @@ Email: shirazi@ieee.org
 import argparse
 import logging
 import os
-from pathlib import Path
 import sys
+from pathlib import Path
 
 import pandas as pd
 

--- a/src/dataset_citations/cli/regenerate.py
+++ b/src/dataset_citations/cli/regenerate.py
@@ -15,9 +15,9 @@ Email: shirazi@ieee.org
 """
 
 import argparse
-from datetime import datetime
 import logging
 import os
+from datetime import datetime
 from pathlib import Path
 
 import pandas as pd

--- a/src/dataset_citations/cli/update.py
+++ b/src/dataset_citations/cli/update.py
@@ -15,16 +15,18 @@ Email: shirazi@ieee.org
 # %% initialize
 import argparse
 import concurrent.futures  # Added for parallelism
-from datetime import datetime
 import logging  # Added import
 import os
+from datetime import datetime
 
 import pandas as pd
 
 from dataset_citations.core import (
     citation_utils,
-    getCitations as gc,
 )  # Added for JSON citation format support
+from dataset_citations.core import (
+    getCitations as gc,
+)
 
 # Configure basic logging for the script
 logging.basicConfig(

--- a/src/dataset_citations/core/citation_utils.py
+++ b/src/dataset_citations/core/citation_utils.py
@@ -13,10 +13,10 @@ GitHub: https://github.com/neuromechanist
 Email: shirazi@ieee.org
 """
 
-from datetime import datetime, timezone
 import json
 import logging
 import os
+from datetime import datetime, timezone
 from typing import Any, Dict, Optional
 
 import pandas as pd

--- a/src/dataset_citations/dashboard/assets/manager.py
+++ b/src/dataset_citations/dashboard/assets/manager.py
@@ -3,8 +3,8 @@ Asset management for dashboard files and resources.
 """
 
 import json
-from pathlib import Path
 import shutil
+from pathlib import Path
 from typing import Any, Dict, List
 
 

--- a/src/dataset_citations/dashboard/components/modals.py
+++ b/src/dataset_citations/dashboard/components/modals.py
@@ -2,8 +2,8 @@
 Modal content generation component for dashboard.
 """
 
-from collections import defaultdict
 import json
+from collections import defaultdict
 from pathlib import Path
 from typing import Any, Dict, List
 

--- a/src/dataset_citations/dashboard/components/network_data.py
+++ b/src/dataset_citations/dashboard/components/network_data.py
@@ -4,8 +4,8 @@ Extract and prepare network data including UMAP coordinates for visualization.
 
 import json
 import logging
-from pathlib import Path
 import pickle
+from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 logger = logging.getLogger(__name__)

--- a/src/dataset_citations/dashboard/core.py
+++ b/src/dataset_citations/dashboard/core.py
@@ -2,8 +2,8 @@
 Core dashboard generator orchestrating all components.
 """
 
-from datetime import datetime
 import logging
+from datetime import datetime
 from pathlib import Path
 from typing import Optional
 

--- a/src/dataset_citations/dashboard/data/aggregator.py
+++ b/src/dataset_citations/dashboard/data/aggregator.py
@@ -3,9 +3,9 @@ Data aggregation module for collecting and organizing analysis results.
 """
 
 import csv
-from datetime import datetime
 import json
 import logging
+from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 

--- a/src/dataset_citations/dashboard/templates/nemar_simple.py
+++ b/src/dataset_citations/dashboard/templates/nemar_simple.py
@@ -148,7 +148,7 @@ def generate_nemar_dashboard(
     <!-- Footer -->
     <footer class="footer">
         <div class="container text-center">
-            <p>&copy; 2025 <a href="https://github.com/sccn/nemar-citations" target="_blank">
+            <p>&copy; 2025 <a href="https://github.com/nemarOrg/nemar-citations" target="_blank">
                 <strong>NEMAR Dataset Citation Analysis</strong></a>, by <a href="https://neuromechanist.github.io" target="_blank">Seyed Yahya Shirazi</a></p>
             <p class="text-muted mb-2">
                 <a href="https://nemar.org" target="_blank"><strong>NEMAR</strong></a> 

--- a/src/dataset_citations/embeddings/embedding_registry.py
+++ b/src/dataset_citations/embeddings/embedding_registry.py
@@ -2,10 +2,10 @@
 Embedding registry system for tracking embedding versions and metadata.
 """
 
-from datetime import datetime
 import hashlib
 import json
 import logging
+from datetime import datetime
 from pathlib import Path
 from typing import Dict, List, Optional, Union
 

--- a/src/dataset_citations/embeddings/storage_manager.py
+++ b/src/dataset_citations/embeddings/storage_manager.py
@@ -2,11 +2,11 @@
 Embedding storage manager for file operations and embedding generation.
 """
 
-from datetime import datetime
 import hashlib
 import logging
-from pathlib import Path
 import pickle
+from datetime import datetime
+from pathlib import Path
 from typing import Dict, List, Optional, Union
 
 import numpy as np

--- a/src/dataset_citations/embeddings/umap_analyzer.py
+++ b/src/dataset_citations/embeddings/umap_analyzer.py
@@ -2,11 +2,11 @@
 UMAP analysis for thematic clustering and dimensionality reduction of embeddings.
 """
 
-from datetime import datetime
 import json
 import logging
-from pathlib import Path
 import pickle
+from datetime import datetime
+from pathlib import Path
 from typing import Any, Dict, Optional, Union
 
 import numpy as np

--- a/src/dataset_citations/graph/network_analysis.py
+++ b/src/dataset_citations/graph/network_analysis.py
@@ -1,8 +1,8 @@
 """Network analysis functions for dataset citations and author collaboration."""
 
-from collections import defaultdict
 import json
 import logging
+from collections import defaultdict
 from pathlib import Path
 from typing import Dict, List, Tuple
 

--- a/src/dataset_citations/graph/temporal.py
+++ b/src/dataset_citations/graph/temporal.py
@@ -1,8 +1,8 @@
 """Temporal analysis functions for dataset citations."""
 
-from collections import defaultdict
 import json
 import logging
+from collections import defaultdict
 from pathlib import Path
 from typing import Dict, List, Optional
 

--- a/src/dataset_citations/quality/confidence_scoring.py
+++ b/src/dataset_citations/quality/confidence_scoring.py
@@ -81,8 +81,8 @@ class CitationConfidenceScorer:
         """Load the sentence transformer model."""
         try:
             # Lazy import to avoid import errors during CLI help
-            from sentence_transformers import SentenceTransformer
             import torch
+            from sentence_transformers import SentenceTransformer
 
             logger.info(f"Loading sentence transformer model: {self.model_name}")
             logger.info(f"Using device: {self.device}")
@@ -101,8 +101,8 @@ class CitationConfidenceScorer:
             # Fallback to a smaller, more commonly available model
             logger.info("Falling back to all-MiniLM-L6-v2 model")
             try:
-                from sentence_transformers import SentenceTransformer
                 import torch
+                from sentence_transformers import SentenceTransformer
 
                 self.model = SentenceTransformer("all-MiniLM-L6-v2", device=self.device)
 

--- a/src/dataset_citations/quality/dataset_metadata.py
+++ b/src/dataset_citations/quality/dataset_metadata.py
@@ -13,10 +13,10 @@ GitHub: https://github.com/neuromechanist
 Email: shirazi@ieee.org
 """
 
-from datetime import datetime, timezone
 import json
 import logging
 import os
+from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 
 from github import Github

--- a/src/dataset_citations/test_end_to_end.py
+++ b/src/dataset_citations/test_end_to_end.py
@@ -8,10 +8,10 @@ to ensure the package structure works correctly before running on all datasets.
 
 import logging
 import os
-from pathlib import Path
 import shutil
 import sys
 import tempfile
+from pathlib import Path
 from typing import List
 
 # Configure logging
@@ -194,7 +194,8 @@ def test_citation_retrieval_with_secrets(
 
         logger.info("Found SCRAPERAPI_KEY in .secrets file")
 
-        from dataset_citations.core import citation_utils, getCitations as gc
+        from dataset_citations.core import citation_utils
+        from dataset_citations.core import getCitations as gc
 
         logger.info("Setting up proxy for citation retrieval...")
         gc.get_working_proxy()

--- a/tests/test_citation_utils.py
+++ b/tests/test_citation_utils.py
@@ -6,14 +6,14 @@ Tests all functions in citation_utils.py using real data without mocks.
 Uses existing citation JSON files as test data to ensure comprehensive coverage.
 """
 
-from datetime import datetime, timezone
 import json
 import os
-from pathlib import Path
 import shutil
 import sys
 import tempfile
 import unittest
+from datetime import datetime, timezone
+from pathlib import Path
 
 import pandas as pd
 

--- a/tests/test_dashboard_aggregator.py
+++ b/tests/test_dashboard_aggregator.py
@@ -4,9 +4,9 @@ Tests for the dashboard data aggregator module.
 
 import csv
 import json
-from pathlib import Path
 import shutil
 import tempfile
+from pathlib import Path
 from unittest import TestCase
 
 from dataset_citations.dashboard.data.aggregator import DataAggregator

--- a/tests/test_getCitations.py
+++ b/tests/test_getCitations.py
@@ -25,8 +25,8 @@ import sys
 import unittest
 from unittest.mock import patch
 
-from dotenv import load_dotenv
 import pandas as pd
+from dotenv import load_dotenv
 
 # Add src to path for imports
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))

--- a/tests/test_integration_workflow.py
+++ b/tests/test_integration_workflow.py
@@ -6,9 +6,9 @@ These tests use controlled real data to validate the entire pipeline.
 import csv
 import json
 import os
-from pathlib import Path
 import shutil
 import tempfile
+from pathlib import Path
 from unittest import TestCase, skipUnless
 
 from dataset_citations.dashboard.data.aggregator import DataAggregator


### PR DESCRIPTION
Closes #31.

Pre-transfer housekeeping so the repo lands clean in `nemarOrg/nemar-citations`.

## Commits (atomic)
1. `chore: point README URLs to nemarOrg ahead of transfer` — badges, clone URLs, issues link, citation BibTeX
2. `chore: migrate tooling from black/isort to ruff` — drop black dep, replace `[tool.black]`/`[tool.isort]` with `[tool.ruff]` (line-length 88, py311, `I` rules), CI swap to `ruff format --check`, add `.pre-commit-config.yaml`
3. `chore: update dashboard footer link to nemarOrg` — `src/dataset_citations/dashboard/templates/nemar_simple.py`
4. `style: apply ruff format and import sort across codebase` — mechanical autofix from new tooling (31 files, 48/-45)
5. `chore: repoint pyproject project.urls to nemarOrg` — fixes stale `neuromechanist/dataset_citations` refs

## Transfer plan (after merge)
- `gh api -X POST repos/sccn/nemar-citations/transfer -f new_owner=nemarOrg`
- GitHub auto-redirects old URLs, secrets carry over
- Cloudflare Pages deploy is API-token based (not OAuth), so survives transfer cleanly
- Local clones: `git remote set-url origin https://github.com/nemarOrg/nemar-citations.git`
- Smoke test: rerun `deploy-dashboard.yml` to confirm `dashboard.nemar.org/citations/` still serves

## Tested
- `ruff format --check src/ tests/` — clean
- `ruff check src/ tests/` — clean
- Pre-commit hook works locally (resolves ruff from PATH, no conda dep)

## Out of scope
- The transfer itself
- Test suite changes