### PR TITLE
chore: bump minimum Python to 3.13, fix deploy pipeline

### DIFF
--- a/.github/workflows/deploy-dashboard.yml
+++ b/.github/workflows/deploy-dashboard.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.13"
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,9 +17,9 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.13'
 
       - name: Install dependencies
         run: |
@@ -37,14 +37,14 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.11', '3.12']
+        python-version: ['3.13']
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -73,7 +73,7 @@ jobs:
             --maxfail=5
 
       - name: Upload coverage to Codecov
-        if: matrix.python-version == '3.11'
+        if: matrix.python-version == '3.13'
         uses: codecov/codecov-action@v3
         with:
           file: ./coverage.xml
@@ -91,9 +91,9 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.13'
 
       - name: Install dependencies
         run: |
@@ -158,9 +158,9 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.13'
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/update_citations.yml
+++ b/.github/workflows/update_citations.yml
@@ -21,9 +21,9 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
-          python-version: '3.10' # Specify Python version
+          python-version: '3.13'
 
       - name: Install dependencies
         run: |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # NEMAR Citations
 
-[![Python 3.11+](https://img.shields.io/badge/python-3.11+-blue.svg)](https://www.python.org/downloads/)
+[![Python 3.13+](https://img.shields.io/badge/python-3.13+-blue.svg)](https://www.python.org/downloads/)
 [![License: CC BY-NC-SA 4.0](https://img.shields.io/badge/License-CC%20BY--NC--SA%204.0-lightgrey.svg)](https://creativecommons.org/licenses/by-nc-sa/4.0/)
 [![Tests](https://github.com/nemarOrg/nemar-citations/actions/workflows/test.yml/badge.svg)](https://github.com/nemarOrg/nemar-citations/actions)
 
@@ -20,7 +20,7 @@ cd nemar-citations
 pip install -e ".[dev,test]"
 ```
 
-**Requirements**: Python 3.11+ • ScraperAPI key • GitHub token (optional)
+**Requirements**: Python 3.13+ • ScraperAPI key • GitHub token (optional)
 
 ## Quick Start
 
@@ -176,7 +176,7 @@ AI-powered relevance scoring (0.0-1.0) using sentence transformers to compare da
 # Setup
 git clone https://github.com/nemarOrg/nemar-citations.git
 cd nemar-citations
-conda create -n dataset-citations python=3.11
+conda create -n dataset-citations python=3.13
 conda activate dataset-citations
 pip install -e ".[dev,test]"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,11 +30,10 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Information Analysis",
     "Topic :: Scientific/Engineering :: Medical Science Apps.",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.11",
-    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Operating System :: OS Independent",
 ]
-requires-python = ">=3.11"
+requires-python = ">=3.13"
 dependencies = [
     "pandas>=1.3.0",
     "scholarly>=1.7.0",
@@ -103,7 +102,7 @@ where = ["src"]
 
 [tool.ruff]
 line-length = 88
-target-version = "py311"
+target-version = "py313"
 extend-exclude = [
     ".git",
     ".mypy_cache",
@@ -122,7 +121,7 @@ extend-select = ["I"]
 known-first-party = ["dataset_citations"]
 
 [tool.mypy]
-python_version = "3.8"
+python_version = "3.13"
 warn_return_any = true
 warn_unused_configs = true
 disallow_untyped_defs = true


### PR DESCRIPTION
Closes #33.

## Why
`deploy-dashboard.yml` and `update_citations.yml` were pinned to Python 3.10 while `pyproject.toml` requires `>=3.11`, so every deploy fails at \`pip install -e .\`. Last failure: https://github.com/nemarOrg/nemar-citations/actions/runs/26019264871

Bumping floor to 3.13 to avoid carrying 3.11/3.12 forward unnecessarily.

## Commits
1. \`chore: bump minimum Python to 3.13 in pyproject\` — requires-python, classifiers (drop 3.11/3.12), ruff target-version, mypy python_version (was stale at 3.8)
2. \`ci: pin all workflows to Python 3.13 and setup-python@v5\` — deploy-dashboard, update_citations, test workflows. Collapsed test matrix to single 3.13 entry.
3. \`docs: README says Python 3.13+ to match floor\` — badge + requirements + conda example

## Verification plan after merge
- Watch test workflow CI (3.13)
- Re-trigger \`Deploy Citation Dashboard\` workflow_dispatch and confirm Cloudflare Pages deploy succeeds end-to-end