### PR TITLE
Phase 2: opencite adapter + DOI source extractors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,28 @@
+# Changelog
+
+All notable changes to this project. The format loosely follows
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## [Unreleased]
+
+### Added
+- `src/dataset_citations/sources/` subpackage with `NemarMetadataSource` and
+  `BidsMetadataSource` for DOI-anchored citation discovery. Reads
+  `.nemar/metadata.json` from `nemarDatasets` (DataCite-style
+  `related_identifiers`) and `dataset_description.json` from
+  `OpenNeuroDatasets` (`DatasetDOI` / `HowToAcknowledge` /
+  `ReferencesAndLinks`).
+- `src/dataset_citations/backends/opencite_backend.py` — sync facade over
+  `opencite.citations.CitationExplorer` for looking up papers that cite a
+  given DOI / PMID / arXiv ID.
+- `FetchSuccess` / `FetchError` result wrappers so callers can distinguish
+  empty results from rate limits / network failures.
+- `opencite` declared as a git-ref dependency pinned to `v0.4.0` (PyPI lags;
+  switch tracked in #43 + neuromechanist/opencite#31).
+
+Not yet wired to any CLI — Phase 3 of epic #37 will add the
+`dataset-citations-update --backend opencite` path.
+
+### Changed
+- `pyproject.toml`: added `opencite` to `dependencies` and regenerated
+  `uv.lock`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ All notable changes to this project. The format loosely follows
   `related_identifiers`) and `dataset_description.json` from
   `OpenNeuroDatasets` (`DatasetDOI` / `HowToAcknowledge` /
   `ReferencesAndLinks`).
-- `src/dataset_citations/backends/opencite_backend.py` — sync facade over
+- `src/dataset_citations/backends/opencite_backend.py`, a sync facade over
   `opencite.citations.CitationExplorer` for looking up papers that cite a
   given DOI / PMID / arXiv ID.
 - `FetchSuccess` / `FetchError` result wrappers so callers can distinguish
@@ -20,7 +20,7 @@ All notable changes to this project. The format loosely follows
 - `opencite` declared as a git-ref dependency pinned to `v0.4.0` (PyPI lags;
   switch tracked in #43 + neuromechanist/opencite#31).
 
-Not yet wired to any CLI — Phase 3 of epic #37 will add the
+Not yet wired to any CLI; Phase 3 of epic #37 will add the
 `dataset-citations-update --backend opencite` path.
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ dependencies = [
     "scikit-learn>=1.0.0",
     "wordcloud>=1.8.0",
     "jinja2>=3.0.0",
+    "opencite @ git+https://github.com/neuromechanist/opencite.git@3e784ddd067b75e73fd0c69e02e82142be1afe11",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ dependencies = [
     "scikit-learn>=1.0.0",
     "wordcloud>=1.8.0",
     "jinja2>=3.0.0",
-    "opencite @ git+https://github.com/neuromechanist/opencite.git@3e784ddd067b75e73fd0c69e02e82142be1afe11",
+    "opencite @ git+https://github.com/neuromechanist/opencite.git@v0.4.0",
 ]
 
 [project.optional-dependencies]

--- a/src/dataset_citations/backends/__init__.py
+++ b/src/dataset_citations/backends/__init__.py
@@ -1,0 +1,11 @@
+"""Citation discovery backends.
+
+`OpenCiteBackend` is the sync-friendly entry point used by the Phase 3
+pipeline. Additional backends (e.g., a future Scholar replacement) can be
+added here; they all return `FetchResult[list[CitingWork]]` so callers stay
+backend-agnostic.
+"""
+
+from dataset_citations.backends.opencite_backend import OpenCiteBackend
+
+__all__ = ["OpenCiteBackend"]

--- a/src/dataset_citations/backends/opencite_backend.py
+++ b/src/dataset_citations/backends/opencite_backend.py
@@ -175,9 +175,7 @@ def classify_error(exc: BaseException, identifier: str) -> FetchError:
         return FetchError("not_found", msg)
     if "timeout" in text or "timed out" in text or "connect" in text:
         return FetchError("network", msg)
-    logger.exception(
-        "unclassified opencite failure for %s", identifier, exc_info=exc
-    )
+    logger.exception("unclassified opencite failure for %s", identifier, exc_info=exc)
     return FetchError("other", msg)
 
 

--- a/src/dataset_citations/backends/opencite_backend.py
+++ b/src/dataset_citations/backends/opencite_backend.py
@@ -99,7 +99,7 @@ class OpenCiteBackend:
             )
         except Exception as exc:
             # opencite raises bare Exception subclasses for HTTP / parse fails;
-            # narrow when neuromechanist/opencite#32 adds typed errors. We let
+            # narrow when neuromechanist/opencite#33 adds typed errors. We let
             # KeyboardInterrupt / SystemExit / asyncio.CancelledError escape.
             return classify_error(exc, ref.identifier)
 
@@ -155,7 +155,7 @@ def classify_error(exc: BaseException, identifier: str) -> FetchError:
 
     Uses httpx's `response.status_code` when the exception exposes one; falls
     back to substring matching of the stringified exception. Tracked for
-    cleanup in neuromechanist/opencite#32 (typed exceptions upstream).
+    cleanup in neuromechanist/opencite#33 (typed exceptions upstream).
     """
     msg = f"{type(exc).__name__}: {exc}"
     status = _status_code_of(exc)

--- a/src/dataset_citations/backends/opencite_backend.py
+++ b/src/dataset_citations/backends/opencite_backend.py
@@ -1,0 +1,135 @@
+"""Sync facade over `opencite.citations.CitationExplorer`.
+
+opencite is async-only; this module hides the asyncio boilerplate so the
+rest of the pipeline (sync, pandas-first) can stay sync. Batches reuse a
+single `CitationExplorer` session so we get connection pooling and one
+catalog warm-up per call.
+
+Errors are surfaced through `FetchResult`, never silently absorbed. The
+Phase 1 review found that an opencite rate limit was being cached as
+"this DOI has zero citing works"; here a rate limit returns
+`FetchError("rate_limit", ...)` and the caller decides whether to retry.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Iterable
+from typing import Any
+
+from opencite.citations import CitationExplorer
+from opencite.config import Config
+
+from dataset_citations.sources.models import (
+    CitingWork,
+    DoiReference,
+    FetchError,
+    FetchResult,
+    FetchSuccess,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class OpenCiteBackend:
+    """Resolve `DoiReference` anchors into lists of `CitingWork` via opencite."""
+
+    def __init__(
+        self,
+        config: Config | None = None,
+        *,
+        max_results_per_doi: int = 100,
+        concurrency: int = 4,
+    ) -> None:
+        self._config = config or Config.from_env()
+        self._max_results_per_doi = max_results_per_doi
+        self._concurrency = max(1, concurrency)
+
+    def get_citing_works(self, ref: DoiReference) -> FetchResult[list[CitingWork]]:
+        """Look up citing works for a single anchor."""
+        return asyncio.run(self._batch_async([ref]))[ref.identifier]
+
+    def get_citing_works_batch(
+        self, refs: Iterable[DoiReference]
+    ) -> dict[str, FetchResult[list[CitingWork]]]:
+        """Look up citing works for many anchors, reusing one opencite session."""
+        ref_list = list(refs)
+        if not ref_list:
+            return {}
+        return asyncio.run(self._batch_async(ref_list))
+
+    async def _batch_async(
+        self, refs: list[DoiReference]
+    ) -> dict[str, FetchResult[list[CitingWork]]]:
+        results: dict[str, FetchResult[list[CitingWork]]] = {}
+        semaphore = asyncio.Semaphore(self._concurrency)
+        async with CitationExplorer(self._config) as explorer:
+
+            async def run_one(ref: DoiReference) -> None:
+                async with semaphore:
+                    results[ref.identifier] = await self._lookup(explorer, ref)
+
+            await asyncio.gather(*(run_one(r) for r in refs))
+        return results
+
+    async def _lookup(
+        self, explorer: CitationExplorer, ref: DoiReference
+    ) -> FetchResult[list[CitingWork]]:
+        try:
+            result = await explorer.citing_papers(
+                ref.identifier,
+                max_results=self._max_results_per_doi,
+                sort="citations",
+            )
+        except Exception as exc:  # opencite uses bare exceptions for HTTP fails
+            return _classify_error(exc, ref.identifier)
+
+        works = [
+            _paper_to_citing_work(paper, ref)
+            for paper in (result.papers or [])
+            if paper.title
+        ]
+        return FetchSuccess(works)
+
+
+def _paper_to_citing_work(paper: Any, ref: DoiReference) -> CitingWork:
+    ids = paper.ids
+    venue = paper.source_venue.name if paper.source_venue else None
+    authors = tuple(a.name for a in (paper.authors or []) if getattr(a, "name", None))
+    return CitingWork(
+        title=paper.title,
+        doi=ids.doi or None,
+        pmid=ids.pmid or None,
+        openalex_id=ids.openalex_id or None,
+        year=paper.year,
+        authors=authors,
+        venue=venue,
+        abstract=paper.abstract or None,
+        citation_count=(
+            paper.citation_count if paper.citation_count is not None else None
+        ),
+        source_doi=ref.identifier,
+        source_relation=ref.relation_type,
+    )
+
+
+def _classify_error(exc: BaseException, identifier: str) -> FetchError:
+    """Map opencite / httpx exceptions to FetchError reasons.
+
+    opencite raises bare exceptions whose `str()` includes status codes for
+    HTTP failures; falling back to substring matching is the best we can do
+    without depending on opencite internals.
+    """
+    msg = f"{type(exc).__name__}: {exc}"
+    text = str(exc).lower()
+    if "429" in text or "rate" in text:
+        return FetchError("rate_limit", msg)
+    if "404" in text or "not found" in text:
+        return FetchError("not_found", msg)
+    if "401" in text or "403" in text or "auth" in text:
+        return FetchError("auth", msg)
+    if "timeout" in text or "timed out" in text or "connect" in text:
+        return FetchError("network", msg)
+    logger.exception("opencite lookup failed for %s", identifier)
+    return FetchError("other", msg)

--- a/src/dataset_citations/backends/opencite_backend.py
+++ b/src/dataset_citations/backends/opencite_backend.py
@@ -67,11 +67,25 @@ class OpenCiteBackend:
         semaphore = asyncio.Semaphore(self._concurrency)
         async with CitationExplorer(self._config) as explorer:
 
-            async def run_one(ref: DoiReference) -> None:
+            async def run_one(ref: DoiReference) -> FetchResult[list[CitingWork]]:
                 async with semaphore:
-                    results[ref.identifier] = await self._lookup(explorer, ref)
+                    return await self._lookup(explorer, ref)
 
-            await asyncio.gather(*(run_one(r) for r in refs))
+            # return_exceptions=True isolates a single failing lookup from the
+            # whole batch; we convert each leak-through to FetchError below.
+            outcomes = await asyncio.gather(
+                *(run_one(r) for r in refs), return_exceptions=True
+            )
+        for ref, outcome in zip(refs, outcomes, strict=True):
+            if isinstance(outcome, BaseException):
+                logger.exception(
+                    "uncaught exception in opencite lookup for %s",
+                    ref.identifier,
+                    exc_info=outcome,
+                )
+                results[ref.identifier] = classify_error(outcome, ref.identifier)
+            else:
+                results[ref.identifier] = outcome
         return results
 
     async def _lookup(
@@ -83,8 +97,11 @@ class OpenCiteBackend:
                 max_results=self._max_results_per_doi,
                 sort="citations",
             )
-        except Exception as exc:  # opencite uses bare exceptions for HTTP fails
-            return _classify_error(exc, ref.identifier)
+        except Exception as exc:
+            # opencite raises bare Exception subclasses for HTTP / parse fails;
+            # narrow when neuromechanist/opencite#32 adds typed errors. We let
+            # KeyboardInterrupt / SystemExit / asyncio.CancelledError escape.
+            return classify_error(exc, ref.identifier)
 
         works = [
             _paper_to_citing_work(paper, ref)
@@ -126,22 +143,59 @@ def _to_author(a: Any) -> Author:
     )
 
 
-def _classify_error(exc: BaseException, identifier: str) -> FetchError:
-    """Map opencite / httpx exceptions to FetchError reasons.
+def classify_error(exc: BaseException, identifier: str) -> FetchError:
+    """Map an opencite / httpx exception to a FetchError reason.
 
-    opencite raises bare exceptions whose `str()` includes status codes for
-    HTTP failures; falling back to substring matching is the best we can do
-    without depending on opencite internals.
+    Precedence order (first match wins):
+      rate_limit -> auth -> not_found -> network -> other.
+    Rate-limit and auth signatures are checked first so that an upstream
+    error message that happens to mention 'not found' or 'connect' (e.g.,
+    'Cannot connect to host: not found in DNS' on a 429 reroute) is still
+    routed to the correct bucket.
+
+    Uses httpx's `response.status_code` when the exception exposes one; falls
+    back to substring matching of the stringified exception. Tracked for
+    cleanup in neuromechanist/opencite#32 (typed exceptions upstream).
     """
     msg = f"{type(exc).__name__}: {exc}"
-    text = str(exc).lower()
-    if "429" in text or "rate" in text:
+    status = _status_code_of(exc)
+    if status == 429:
         return FetchError("rate_limit", msg)
+    if status in (401, 403):
+        return FetchError("auth", msg)
+    if status == 404:
+        return FetchError("not_found", msg)
+
+    text = str(exc).lower()
+    if "429" in text or "rate limit" in text or "too many requests" in text:
+        return FetchError("rate_limit", msg)
+    if "401" in text or "403" in text or "unauthorized" in text or "forbidden" in text:
+        return FetchError("auth", msg)
     if "404" in text or "not found" in text:
         return FetchError("not_found", msg)
-    if "401" in text or "403" in text or "auth" in text:
-        return FetchError("auth", msg)
     if "timeout" in text or "timed out" in text or "connect" in text:
         return FetchError("network", msg)
-    logger.exception("opencite lookup failed for %s", identifier)
+    logger.exception(
+        "unclassified opencite failure for %s", identifier, exc_info=exc
+    )
     return FetchError("other", msg)
+
+
+def _status_code_of(exc: BaseException) -> int | None:
+    """Return the HTTP status code an exception carries, or None.
+
+    Handles httpx.HTTPStatusError-style exceptions where the response attr
+    exposes `.status_code`, plus the convention some libraries use of
+    setting `exc.status_code` directly.
+    """
+    response = getattr(exc, "response", None)
+    code = getattr(response, "status_code", None)
+    if isinstance(code, int):
+        return code
+    code = getattr(exc, "status_code", None)
+    if isinstance(code, int):
+        return code
+    code = getattr(exc, "status", None)
+    if isinstance(code, int):
+        return code
+    return None

--- a/src/dataset_citations/backends/opencite_backend.py
+++ b/src/dataset_citations/backends/opencite_backend.py
@@ -22,6 +22,7 @@ from opencite.citations import CitationExplorer
 from opencite.config import Config
 
 from dataset_citations.sources.models import (
+    Author,
     CitingWork,
     DoiReference,
     FetchError,
@@ -96,7 +97,9 @@ class OpenCiteBackend:
 def _paper_to_citing_work(paper: Any, ref: DoiReference) -> CitingWork:
     ids = paper.ids
     venue = paper.source_venue.name if paper.source_venue else None
-    authors = tuple(a.name for a in (paper.authors or []) if getattr(a, "name", None))
+    authors = tuple(
+        _to_author(a) for a in (paper.authors or []) if getattr(a, "name", None)
+    )
     return CitingWork(
         title=paper.title,
         doi=ids.doi or None,
@@ -111,6 +114,15 @@ def _paper_to_citing_work(paper: Any, ref: DoiReference) -> CitingWork:
         ),
         source_doi=ref.identifier,
         source_relation=ref.relation_type,
+    )
+
+
+def _to_author(a: Any) -> Author:
+    return Author(
+        name=a.name,
+        family=getattr(a, "family_name", None) or None,
+        given=getattr(a, "given_name", None) or None,
+        orcid=getattr(a, "orcid", None) or None,
     )
 
 

--- a/src/dataset_citations/sources/__init__.py
+++ b/src/dataset_citations/sources/__init__.py
@@ -1,0 +1,35 @@
+"""DOI source extractors for the opencite-backed citation pipeline.
+
+`nemar_metadata` reads `.nemar/metadata.json` from nm-prefixed nemarDatasets
+repos. `bids_metadata` reads `dataset_description.json` from legacy
+OpenNeuroDatasets ds-prefixed repos. Both return `FetchResult[list[DoiReference]]`
+so callers distinguish errors from "no DOIs found".
+"""
+
+from dataset_citations.sources.bids_metadata import BidsMetadataSource
+from dataset_citations.sources.doi import (
+    extract_identifiers,
+    is_openneuro_dataset_doi,
+    normalize_doi,
+    validate_identifier,
+)
+from dataset_citations.sources.models import (
+    DoiReference,
+    FetchError,
+    FetchResult,
+    FetchSuccess,
+)
+from dataset_citations.sources.nemar_metadata import NemarMetadataSource
+
+__all__ = [
+    "BidsMetadataSource",
+    "DoiReference",
+    "FetchError",
+    "FetchResult",
+    "FetchSuccess",
+    "NemarMetadataSource",
+    "extract_identifiers",
+    "is_openneuro_dataset_doi",
+    "normalize_doi",
+    "validate_identifier",
+]

--- a/src/dataset_citations/sources/__init__.py
+++ b/src/dataset_citations/sources/__init__.py
@@ -6,7 +6,10 @@ OpenNeuroDatasets ds-prefixed repos. Both return `FetchResult[list[DoiReference]
 so callers distinguish errors from "no DOIs found".
 """
 
-from dataset_citations.sources.bids_metadata import BidsMetadataSource
+from dataset_citations.sources.bids_metadata import (
+    BidsMetadataSource,
+    parse_bids_description,
+)
 from dataset_citations.sources.doi import (
     extract_identifiers,
     is_openneuro_dataset_doi,
@@ -19,7 +22,10 @@ from dataset_citations.sources.models import (
     FetchResult,
     FetchSuccess,
 )
-from dataset_citations.sources.nemar_metadata import NemarMetadataSource
+from dataset_citations.sources.nemar_metadata import (
+    NemarMetadataSource,
+    parse_nemar_metadata,
+)
 
 __all__ = [
     "BidsMetadataSource",
@@ -31,5 +37,7 @@ __all__ = [
     "extract_identifiers",
     "is_openneuro_dataset_doi",
     "normalize_doi",
+    "parse_bids_description",
+    "parse_nemar_metadata",
     "validate_identifier",
 ]

--- a/src/dataset_citations/sources/__init__.py
+++ b/src/dataset_citations/sources/__init__.py
@@ -17,10 +17,13 @@ from dataset_citations.sources.doi import (
     validate_identifier,
 )
 from dataset_citations.sources.models import (
+    Author,
+    CitingWork,
     DoiReference,
     FetchError,
     FetchResult,
     FetchSuccess,
+    RelationType,
 )
 from dataset_citations.sources.nemar_metadata import (
     NemarMetadataSource,
@@ -28,12 +31,15 @@ from dataset_citations.sources.nemar_metadata import (
 )
 
 __all__ = [
+    "Author",
     "BidsMetadataSource",
+    "CitingWork",
     "DoiReference",
     "FetchError",
     "FetchResult",
     "FetchSuccess",
     "NemarMetadataSource",
+    "RelationType",
     "extract_identifiers",
     "is_openneuro_dataset_doi",
     "normalize_doi",

--- a/src/dataset_citations/sources/bids_metadata.py
+++ b/src/dataset_citations/sources/bids_metadata.py
@@ -1,0 +1,138 @@
+"""Fetch and parse `dataset_description.json` for OpenNeuroDatasets ds-repos.
+
+Legacy ds-prefixed datasets predate `.nemar/metadata.json` so there's no
+structured `relation_type`. We extract DOIs/PMIDs/arXiv IDs from three free-
+text fields and assign relation types heuristically:
+  - `DatasetDOI`           -> IsIdenticalTo  (skipped from lookup if OpenNeuro)
+  - `HowToAcknowledge`     -> IsDerivedFrom  (field literally requests citing it)
+  - `ReferencesAndLinks`   -> References
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+from github import Github
+from github.GithubException import GithubException
+
+from dataset_citations.sources.doi import (
+    extract_identifiers,
+    is_openneuro_dataset_doi,
+    normalize_doi,
+    validate_identifier,
+)
+from dataset_citations.sources.models import (
+    DoiReference,
+    FetchError,
+    FetchResult,
+    FetchSuccess,
+    IdentifierType,
+)
+
+logger = logging.getLogger(__name__)
+
+_FIELD_RELATION: dict[str, str] = {
+    "DatasetDOI": "IsIdenticalTo",
+    "HowToAcknowledge": "IsDerivedFrom",
+    "ReferencesAndLinks": "References",
+}
+
+
+class BidsMetadataSource:
+    """Reads `dataset_description.json` from an OpenNeuroDatasets ds-repo and
+    returns DOI/PMID/arXiv references suitable for opencite lookup."""
+
+    def __init__(self, github_token: str | None = None) -> None:
+        self.github = Github(github_token) if github_token else Github()
+
+    def get_doi_references(
+        self, dataset_id: str, org: str = "OpenNeuroDatasets"
+    ) -> FetchResult[list[DoiReference]]:
+        try:
+            repo = self.github.get_repo(f"{org}/{dataset_id}")
+        except GithubException as e:
+            return _github_error(e, f"{org}/{dataset_id}")
+
+        try:
+            content = repo.get_contents("dataset_description.json")
+        except GithubException as e:
+            if getattr(e, "status", None) == 404:
+                return FetchError("not_found", "dataset_description.json missing")
+            return _github_error(e, "dataset_description.json")
+
+        if isinstance(content, list):
+            return FetchError("parse", "expected file, got directory listing")
+        try:
+            payload: Any = json.loads(content.decoded_content.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError) as e:
+            return FetchError("parse", f"invalid JSON: {e}")
+        if not isinstance(payload, dict):
+            return FetchError("parse", "dataset_description.json root is not an object")
+
+        return FetchSuccess(_references_from_description(payload))
+
+
+def _references_from_description(desc: dict[str, Any]) -> list[DoiReference]:
+    refs: list[DoiReference] = []
+    seen: set[tuple[str, str]] = set()
+
+    for field_name, relation in _FIELD_RELATION.items():
+        value = desc.get(field_name)
+        for ident, kind in _identifiers_from_value(value):
+            if kind == "doi" and is_openneuro_dataset_doi(ident):
+                # Keep for record linkage only — not sent to opencite.
+                continue
+            key = (ident, relation)
+            if key in seen:
+                continue
+            seen.add(key)
+            refs.append(
+                DoiReference(
+                    identifier=ident,
+                    identifier_type=kind,
+                    relation_type=relation,
+                    source="openneuro_description",
+                    source_field=field_name,
+                )
+            )
+    return refs
+
+
+def _identifiers_from_value(
+    value: Any,
+) -> list[tuple[str, IdentifierType]]:
+    """Recurse through a JSON value collecting all identifier hits."""
+    out: list[tuple[str, IdentifierType]] = []
+    if value is None:
+        return out
+    if isinstance(value, list):
+        for item in value:
+            out.extend(_identifiers_from_value(item))
+        return out
+    if isinstance(value, dict):
+        for v in value.values():
+            out.extend(_identifiers_from_value(v))
+        return out
+    if not isinstance(value, str):
+        return out
+    # Whole-string DOI shortcut: catches `DatasetDOI: "doi:10.x/y"`.
+    cleaned = normalize_doi(value)
+    if validate_identifier(cleaned) and cleaned.startswith("10."):
+        out.append((cleaned, "doi"))
+        return out
+    for ident, kind in extract_identifiers(value):
+        out.append((ident, kind))  # type: ignore[arg-type]
+    return out
+
+
+def _github_error(exc: GithubException, path: str) -> FetchError:
+    status = getattr(exc, "status", None)
+    if status == 404:
+        return FetchError("not_found", f"{path} not found")
+    if status == 401 or status == 403:
+        return FetchError("auth", f"{path}: {exc}")
+    if status == 429:
+        return FetchError("rate_limit", f"{path}: {exc}")
+    return FetchError("other", f"{path}: {exc}")

--- a/src/dataset_citations/sources/bids_metadata.py
+++ b/src/dataset_citations/sources/bids_metadata.py
@@ -71,7 +71,16 @@ class BidsMetadataSource:
         if not isinstance(payload, dict):
             return FetchError("parse", "dataset_description.json root is not an object")
 
-        return FetchSuccess(_references_from_description(payload))
+        return FetchSuccess(parse_bids_description(payload))
+
+
+def parse_bids_description(desc: dict[str, Any]) -> list[DoiReference]:
+    """Pure function: convert parsed `dataset_description.json` into DoiReferences.
+
+    Exposed for unit testing with fixture files. The GitHub-fetching class
+    delegates here after decoding bytes to JSON.
+    """
+    return _references_from_description(desc)
 
 
 def _references_from_description(desc: dict[str, Any]) -> list[DoiReference]:

--- a/src/dataset_citations/sources/bids_metadata.py
+++ b/src/dataset_citations/sources/bids_metadata.py
@@ -29,11 +29,12 @@ from dataset_citations.sources.models import (
     FetchResult,
     FetchSuccess,
     IdentifierType,
+    RelationType,
 )
 
 logger = logging.getLogger(__name__)
 
-_FIELD_RELATION: dict[str, str] = {
+_FIELD_RELATION: dict[str, RelationType] = {
     "DatasetDOI": "IsIdenticalTo",
     "HowToAcknowledge": "IsDerivedFrom",
     "ReferencesAndLinks": "References",

--- a/src/dataset_citations/sources/bids_metadata.py
+++ b/src/dataset_citations/sources/bids_metadata.py
@@ -65,6 +65,11 @@ class BidsMetadataSource:
 
         if isinstance(content, list):
             return FetchError("parse", "expected file, got directory listing")
+        if not hasattr(content, "decoded_content"):
+            return FetchError(
+                "parse",
+                f"unexpected get_contents return shape: {type(content).__name__}",
+            )
         try:
             payload: Any = json.loads(content.decoded_content.decode("utf-8"))
         except (UnicodeDecodeError, json.JSONDecodeError) as e:

--- a/src/dataset_citations/sources/bids_metadata.py
+++ b/src/dataset_citations/sources/bids_metadata.py
@@ -97,7 +97,7 @@ def _references_from_description(desc: dict[str, Any]) -> list[DoiReference]:
         value = desc.get(field_name)
         for ident, kind in _identifiers_from_value(value):
             if kind == "doi" and is_openneuro_dataset_doi(ident):
-                # Keep for record linkage only — not sent to opencite.
+                # Keep for record linkage only; not sent to opencite.
                 continue
             key = (ident, relation)
             if key in seen:

--- a/src/dataset_citations/sources/doi.py
+++ b/src/dataset_citations/sources/doi.py
@@ -1,0 +1,131 @@
+"""DOI / PMID / arXiv identifier helpers.
+
+`normalize_doi` strips the common prefixes (`doi:`, `https://doi.org/`, ...),
+lowercases the result, and trims trailing punctuation that often hitchhikes
+from prose (`.,;)`). `validate_identifier` rejects strings with control
+characters, newlines, or shapes that obviously aren't valid identifiers.
+`extract_identifiers` walks free text and returns the DOIs, PMIDs, and
+arXiv IDs it can confidently find.
+"""
+
+from __future__ import annotations
+
+import re
+
+# DOIs always start with "10." and a registrant code, then a `/`, then a suffix.
+# We allow the common punctuation classes inside the suffix but balance any
+# trailing parens via post-processing in `_balance_parens`.
+_DOI_BARE = re.compile(r"10\.\d{4,9}/[-._;()/:\w]+", re.IGNORECASE)
+
+_PMID_URL = re.compile(
+    r"(?:pubmed\.ncbi\.nlm\.nih\.gov/|pubmed/)(\d{1,9})", re.IGNORECASE
+)
+_PMID_TAG = re.compile(r"\bpmid[:\s]+(\d{1,9})\b", re.IGNORECASE)
+
+_ARXIV_TAG = re.compile(r"\barxiv[:\s]+(\d{4}\.\d{4,5}(?:v\d+)?)\b", re.IGNORECASE)
+_ARXIV_DOI = re.compile(r"10\.48550/arxiv\.(\S+)", re.IGNORECASE)
+
+_OPENNEURO_DOI = re.compile(r"^10\.18112/openneuro\.", re.IGNORECASE)
+
+_CONTROL_CHARS = re.compile(r"[\x00-\x1f\x7f]")
+
+
+def normalize_doi(s: str) -> str:
+    """Return a lowercase, prefix-stripped DOI string.
+
+    Does not validate; pair with `validate_identifier` before persisting.
+    """
+    s = s.strip()
+    for prefix in (
+        "doi:",
+        "DOI:",
+        "https://doi.org/",
+        "http://doi.org/",
+        "https://dx.doi.org/",
+        "http://dx.doi.org/",
+    ):
+        if s.startswith(prefix):
+            s = s[len(prefix) :]
+    s = _balance_parens(s).rstrip(".,;:")
+    return s.strip().lower()
+
+
+def _balance_parens(s: str) -> str:
+    """Trim trailing `)` characters that don't have a matching `(` in the
+    string. Helps with DOIs captured from prose like ``see (10.x/y)``."""
+    opens = s.count("(")
+    closes = s.count(")")
+    while closes > opens and s.endswith(")"):
+        s = s[:-1]
+        closes -= 1
+    return s
+
+
+def validate_identifier(identifier: str) -> bool:
+    """Reject identifiers with control characters, newlines, or obvious junk.
+
+    A `True` result does not guarantee the identifier resolves to a record;
+    it just guarantees the string is safe to write to CSVs / pass to APIs.
+    """
+    if not identifier or len(identifier) > 256:
+        return False
+    if _CONTROL_CHARS.search(identifier):
+        return False
+    if identifier.startswith("pmid:"):
+        return identifier[5:].isdigit()
+    if identifier.startswith("arxiv:"):
+        # tolerate version suffix like 2106.15928v2
+        suffix = identifier[6:]
+        return bool(re.fullmatch(r"\d{4}\.\d{4,5}(?:v\d+)?", suffix))
+    # Otherwise treat as DOI shape.
+    return bool(re.fullmatch(r"10\.\d{4,9}/\S+", identifier))
+
+
+def is_openneuro_dataset_doi(identifier: str) -> bool:
+    """True for OpenNeuro `DatasetDOI` strings that are not indexed in OpenAlex.
+
+    These are useful for record linkage but should not be sent to opencite —
+    OpenAlex / Semantic Scholar return zero results for them.
+    """
+    return bool(_OPENNEURO_DOI.match(identifier))
+
+
+def extract_identifiers(text: str | None) -> list[tuple[str, str]]:
+    """Walk free text and return `(identifier, identifier_type)` pairs.
+
+    `identifier_type` is one of `"doi"`, `"pmid"`, `"arxiv"`. Order of
+    detection matters: arXiv DOI shorthand (10.48550/arxiv.X) is rewritten
+    to the canonical `arxiv:X` form before the bare DOI regex runs, so we
+    don't double-extract.
+    """
+    if not text:
+        return []
+    out: list[tuple[str, str]] = []
+    seen: set[tuple[str, str]] = set()
+
+    def _add(value: str, kind: str) -> None:
+        norm = value.lower() if kind != "doi" else normalize_doi(value)
+        ident = norm if kind == "doi" else f"{kind}:{norm}"
+        if not validate_identifier(ident):
+            return
+        key = (ident, kind)
+        if key in seen:
+            return
+        seen.add(key)
+        out.append((ident, kind))
+
+    for m in _ARXIV_DOI.finditer(text):
+        _add(m.group(1), "arxiv")
+    for m in _ARXIV_TAG.finditer(text):
+        _add(m.group(1), "arxiv")
+
+    for m in _PMID_URL.finditer(text):
+        _add(m.group(1), "pmid")
+    for m in _PMID_TAG.finditer(text):
+        _add(m.group(1), "pmid")
+
+    masked = _ARXIV_DOI.sub("", text)
+    for m in _DOI_BARE.finditer(masked):
+        _add(m.group(0), "doi")
+
+    return out

--- a/src/dataset_citations/sources/doi.py
+++ b/src/dataset_citations/sources/doi.py
@@ -84,7 +84,7 @@ def validate_identifier(identifier: str) -> bool:
 def is_openneuro_dataset_doi(identifier: str) -> bool:
     """True for OpenNeuro `DatasetDOI` strings that are not indexed in OpenAlex.
 
-    These are useful for record linkage but should not be sent to opencite —
+    These are useful for record linkage but should not be sent to opencite;
     OpenAlex / Semantic Scholar return zero results for them.
     """
     return bool(_OPENNEURO_DOI.match(identifier))

--- a/src/dataset_citations/sources/models.py
+++ b/src/dataset_citations/sources/models.py
@@ -1,0 +1,73 @@
+"""Typed records and result wrappers shared by source extractors and backends.
+
+`FetchResult` is a discriminated union: either `FetchSuccess(value)` or
+`FetchError(reason, detail)`. Callers must check `result.ok` (or use
+isinstance) before accessing the value. This is the project's answer to the
+Phase 1 review finding that broad except blocks conflated transient failures
+with legitimately empty results.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Generic, Literal, TypeVar
+
+IdentifierType = Literal["doi", "pmid", "arxiv"]
+SourceKind = Literal["nemar_metadata", "openneuro_description"]
+FetchErrorReason = Literal[
+    "not_found", "auth", "network", "parse", "rate_limit", "other"
+]
+
+
+@dataclass(frozen=True, slots=True)
+class DoiReference:
+    """One DOI/PMID/arXiv anchor extracted from a dataset's metadata."""
+
+    identifier: str
+    identifier_type: IdentifierType
+    relation_type: str
+    source: SourceKind
+    source_field: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class CitingWork:
+    """One citing paper, normalized from an opencite Paper and tagged with the
+    source DOI / relation it was discovered through."""
+
+    title: str
+    doi: str | None
+    pmid: str | None
+    openalex_id: str | None
+    year: int | None
+    authors: tuple[str, ...]
+    venue: str | None
+    abstract: str | None
+    citation_count: int | None
+    source_doi: str
+    source_relation: str
+
+
+T = TypeVar("T")
+
+
+@dataclass(frozen=True, slots=True)
+class FetchSuccess(Generic[T]):
+    value: T
+
+    @property
+    def ok(self) -> Literal[True]:
+        return True
+
+
+@dataclass(frozen=True, slots=True)
+class FetchError:
+    reason: FetchErrorReason
+    detail: str
+
+    @property
+    def ok(self) -> Literal[False]:
+        return False
+
+
+FetchResult = FetchSuccess[T] | FetchError

--- a/src/dataset_citations/sources/models.py
+++ b/src/dataset_citations/sources/models.py
@@ -10,24 +10,62 @@ with legitimately empty results.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Generic, Literal, TypeVar
+from typing import Callable, Generic, Literal, Never, TypeVar
 
 IdentifierType = Literal["doi", "pmid", "arxiv"]
 SourceKind = Literal["nemar_metadata", "openneuro_description"]
+RelationType = Literal["References", "IsDerivedFrom", "IsIdenticalTo", "IsVersionOf"]
 FetchErrorReason = Literal[
     "not_found", "auth", "network", "parse", "rate_limit", "other"
 ]
 
+_IDENTIFIER_PREFIX: dict[IdentifierType, str] = {
+    "pmid": "pmid:",
+    "arxiv": "arxiv:",
+    "doi": "10.",
+}
+
+
+@dataclass(frozen=True, slots=True)
+class Author:
+    """Structured author record.
+
+    `name` is the display string (typically family + given). `family` and
+    `given` are optional; downstream consumers may show them when present.
+    """
+
+    name: str
+    family: str | None = None
+    given: str | None = None
+    orcid: str | None = None
+
 
 @dataclass(frozen=True, slots=True)
 class DoiReference:
-    """One DOI/PMID/arXiv anchor extracted from a dataset's metadata."""
+    """One DOI/PMID/arXiv anchor extracted from a dataset's metadata.
+
+    Construction-time invariants:
+      - identifier is non-empty
+      - identifier matches the prefix expected for identifier_type
+        ("pmid:" / "arxiv:" / "10."). Producers must normalize first.
+    """
 
     identifier: str
     identifier_type: IdentifierType
-    relation_type: str
+    relation_type: RelationType
     source: SourceKind
     source_field: str | None = None
+
+    def __post_init__(self) -> None:
+        if not self.identifier:
+            raise ValueError("DoiReference.identifier may not be empty")
+        expected_prefix = _IDENTIFIER_PREFIX[self.identifier_type]
+        if not self.identifier.startswith(expected_prefix):
+            raise ValueError(
+                f"identifier {self.identifier!r} does not match "
+                f"identifier_type={self.identifier_type!r} "
+                f"(expected prefix {expected_prefix!r})"
+            )
 
 
 @dataclass(frozen=True, slots=True)
@@ -40,15 +78,22 @@ class CitingWork:
     pmid: str | None
     openalex_id: str | None
     year: int | None
-    authors: tuple[str, ...]
+    authors: tuple[Author, ...]
     venue: str | None
     abstract: str | None
     citation_count: int | None
     source_doi: str
-    source_relation: str
+    source_relation: RelationType
+
+    def __post_init__(self) -> None:
+        if not self.title:
+            raise ValueError("CitingWork.title may not be empty")
+        if not self.source_doi:
+            raise ValueError("CitingWork.source_doi may not be empty")
 
 
 T = TypeVar("T")
+U = TypeVar("U")
 
 
 @dataclass(frozen=True, slots=True)
@@ -59,6 +104,15 @@ class FetchSuccess(Generic[T]):
     def ok(self) -> Literal[True]:
         return True
 
+    def map(self, fn: Callable[[T], U]) -> FetchSuccess[U]:
+        return FetchSuccess(fn(self.value))
+
+    def unwrap(self) -> T:
+        return self.value
+
+    def unwrap_or(self, default: T) -> T:  # noqa: ARG002 - Result-style API
+        return self.value
+
 
 @dataclass(frozen=True, slots=True)
 class FetchError:
@@ -68,6 +122,15 @@ class FetchError:
     @property
     def ok(self) -> Literal[False]:
         return False
+
+    def map(self, fn: Callable[[U], U]) -> "FetchError":  # noqa: ARG002
+        return self
+
+    def unwrap(self) -> Never:
+        raise RuntimeError(f"unwrap on FetchError({self.reason}): {self.detail}")
+
+    def unwrap_or(self, default: U) -> U:
+        return default
 
 
 FetchResult = FetchSuccess[T] | FetchError

--- a/src/dataset_citations/sources/nemar_metadata.py
+++ b/src/dataset_citations/sources/nemar_metadata.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 import json
 import logging
-from typing import Any
+from typing import Any, cast, get_args
 
 from github import Github
 from github.GithubException import GithubException
@@ -26,13 +26,12 @@ from dataset_citations.sources.models import (
     FetchError,
     FetchResult,
     FetchSuccess,
+    RelationType,
 )
 
 logger = logging.getLogger(__name__)
 
-_CITATION_RELATIONS = frozenset(
-    {"References", "IsDerivedFrom", "IsIdenticalTo", "IsVersionOf"}
-)
+_CITATION_RELATIONS: frozenset[RelationType] = frozenset(get_args(RelationType))
 
 
 class NemarMetadataSource:
@@ -115,7 +114,7 @@ def _entry_to_reference(entry: Any) -> DoiReference | None:
     return DoiReference(
         identifier=normalized,
         identifier_type="doi",
-        relation_type=relation,
+        relation_type=cast(RelationType, relation),
         source="nemar_metadata",
         source_field="related_identifiers",
     )

--- a/src/dataset_citations/sources/nemar_metadata.py
+++ b/src/dataset_citations/sources/nemar_metadata.py
@@ -73,14 +73,22 @@ class NemarMetadataSource:
 
         if not isinstance(payload, dict):
             return FetchError("parse", "metadata.json root is not an object")
+        return FetchSuccess(parse_nemar_metadata(payload))
 
-        related = payload.get("related_identifiers") or []
-        refs: list[DoiReference] = []
-        for entry in related:
-            ref = _entry_to_reference(entry)
-            if ref is not None:
-                refs.append(ref)
-        return FetchSuccess(refs)
+
+def parse_nemar_metadata(payload: dict[str, Any]) -> list[DoiReference]:
+    """Pure function: convert parsed `.nemar/metadata.json` into DoiReferences.
+
+    Exposed for unit testing with fixture files. The GitHub-fetching class
+    delegates here after decoding bytes to JSON.
+    """
+    related = payload.get("related_identifiers") or []
+    refs: list[DoiReference] = []
+    for entry in related:
+        ref = _entry_to_reference(entry)
+        if ref is not None:
+            refs.append(ref)
+    return refs
 
 
 def _entry_to_reference(entry: Any) -> DoiReference | None:

--- a/src/dataset_citations/sources/nemar_metadata.py
+++ b/src/dataset_citations/sources/nemar_metadata.py
@@ -65,6 +65,11 @@ class NemarMetadataSource:
 
         if isinstance(content, list):
             return FetchError("parse", "expected file, got directory listing")
+        if not hasattr(content, "decoded_content"):
+            return FetchError(
+                "parse",
+                f"unexpected get_contents return shape: {type(content).__name__}",
+            )
         try:
             payload: Any = json.loads(content.decoded_content.decode("utf-8"))
         except (UnicodeDecodeError, json.JSONDecodeError) as e:

--- a/src/dataset_citations/sources/nemar_metadata.py
+++ b/src/dataset_citations/sources/nemar_metadata.py
@@ -1,0 +1,124 @@
+"""Fetch and parse `.nemar/metadata.json` for nm-prefixed nemarDatasets repos.
+
+The file follows a DataCite-style schema (v2.0) with a `related_identifiers`
+block. We honor a fixed allow-list of `relation_type` values that map to
+"citations of related work belong to this dataset" semantics: References,
+IsDerivedFrom, IsIdenticalTo, IsVersionOf. We skip URL-typed identifiers
+(they exist for human navigation, not literature lookup).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+from github import Github
+from github.GithubException import GithubException
+
+from dataset_citations.sources.doi import (
+    is_openneuro_dataset_doi,
+    normalize_doi,
+    validate_identifier,
+)
+from dataset_citations.sources.models import (
+    DoiReference,
+    FetchError,
+    FetchResult,
+    FetchSuccess,
+)
+
+logger = logging.getLogger(__name__)
+
+_CITATION_RELATIONS = frozenset(
+    {"References", "IsDerivedFrom", "IsIdenticalTo", "IsVersionOf"}
+)
+
+
+class NemarMetadataSource:
+    """Reads `.nemar/metadata.json` from a nemarDatasets repo and returns the
+    DOI references suitable for opencite lookup."""
+
+    def __init__(self, github_token: str | None = None) -> None:
+        self.github = Github(github_token) if github_token else Github()
+
+    def get_doi_references(
+        self, dataset_id: str, org: str = "nemarDatasets"
+    ) -> FetchResult[list[DoiReference]]:
+        """Return DOI/PMID anchors for one nm-dataset, or a FetchError.
+
+        Empty success (`FetchSuccess([])`) means the metadata file was parsed
+        but contained no DOI-typed related_identifiers in our allow-list.
+        That is distinct from `FetchError("not_found", ...)` (no metadata
+        file).
+        """
+        try:
+            repo = self.github.get_repo(f"{org}/{dataset_id}")
+        except GithubException as e:
+            return _github_error(e, f"{org}/{dataset_id}")
+
+        try:
+            content = repo.get_contents(".nemar/metadata.json")
+        except GithubException as e:
+            if getattr(e, "status", None) == 404:
+                return FetchError("not_found", ".nemar/metadata.json missing")
+            return _github_error(e, ".nemar/metadata.json")
+
+        if isinstance(content, list):
+            return FetchError("parse", "expected file, got directory listing")
+        try:
+            payload: Any = json.loads(content.decoded_content.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError) as e:
+            return FetchError("parse", f"invalid JSON: {e}")
+
+        if not isinstance(payload, dict):
+            return FetchError("parse", "metadata.json root is not an object")
+
+        related = payload.get("related_identifiers") or []
+        refs: list[DoiReference] = []
+        for entry in related:
+            ref = _entry_to_reference(entry)
+            if ref is not None:
+                refs.append(ref)
+        return FetchSuccess(refs)
+
+
+def _entry_to_reference(entry: Any) -> DoiReference | None:
+    if not isinstance(entry, dict):
+        return None
+    relation = entry.get("relation_type")
+    if relation not in _CITATION_RELATIONS:
+        return None
+    identifier_type = entry.get("identifier_type")
+    raw = entry.get("identifier")
+    if not isinstance(raw, str) or not raw.strip():
+        return None
+    if identifier_type != "DOI":
+        # URL / handle / other types: skip for opencite lookup.
+        return None
+
+    normalized = normalize_doi(raw)
+    if not validate_identifier(normalized):
+        logger.warning("skipping malformed DOI %r in .nemar/metadata.json", raw)
+        return None
+    if is_openneuro_dataset_doi(normalized):
+        # OpenNeuro DatasetDOIs are not indexed in OpenAlex; skip from lookup set.
+        return None
+    return DoiReference(
+        identifier=normalized,
+        identifier_type="doi",
+        relation_type=relation,
+        source="nemar_metadata",
+        source_field="related_identifiers",
+    )
+
+
+def _github_error(exc: GithubException, path: str) -> FetchError:
+    status = getattr(exc, "status", None)
+    if status == 404:
+        return FetchError("not_found", f"{path} not found")
+    if status == 401 or status == 403:
+        return FetchError("auth", f"{path}: {exc}")
+    if status == 429:
+        return FetchError("rate_limit", f"{path}: {exc}")
+    return FetchError("other", f"{path}: {exc}")

--- a/tests/test_backends_opencite.py
+++ b/tests/test_backends_opencite.py
@@ -1,0 +1,100 @@
+"""Tests for OpenCiteBackend.
+
+Live opencite lookups are gated behind RUN_INTEGRATION_TESTS=1 because they
+hit external APIs (OpenAlex, Semantic Scholar) and depend on network /
+rate limits. The default test suite skips them.
+"""
+
+from __future__ import annotations
+
+import os
+from unittest import TestCase, skipUnless
+
+from dataset_citations.backends import OpenCiteBackend
+from dataset_citations.sources.models import (
+    DoiReference,
+    FetchError,
+    FetchSuccess,
+)
+
+
+def _ref(identifier: str, identifier_type: str = "doi") -> DoiReference:
+    return DoiReference(
+        identifier=identifier,
+        identifier_type=identifier_type,  # type: ignore[arg-type]
+        relation_type="References",
+        source="nemar_metadata",
+        source_field="related_identifiers",
+    )
+
+
+@skipUnless(
+    os.getenv("RUN_INTEGRATION_TESTS"),
+    "live opencite calls; set RUN_INTEGRATION_TESTS=1 to enable",
+)
+class OpenCiteBackendIntegration(TestCase):
+    def setUp(self) -> None:
+        self.backend = OpenCiteBackend(max_results_per_doi=10)
+
+    def test_citing_works_for_known_doi(self) -> None:
+        ref = _ref("10.1038/sdata.2015.1")
+        result = self.backend.get_citing_works(ref)
+        self.assertIsInstance(result, FetchSuccess)
+        assert isinstance(result, FetchSuccess)
+        self.assertGreater(len(result.value), 0)
+        first = result.value[0]
+        self.assertTrue(first.title)
+        self.assertEqual(first.source_doi, ref.identifier)
+        self.assertEqual(first.source_relation, "References")
+
+    def test_unknown_identifier_returns_error(self) -> None:
+        ref = _ref("10.99999/this-doi-does-not-exist-xyzabc")
+        result = self.backend.get_citing_works(ref)
+        self.assertIsInstance(result, FetchError)
+
+    def test_batch_lookup(self) -> None:
+        refs = [
+            _ref("10.1038/sdata.2015.1"),
+            _ref("10.1038/sdata.2017.181"),
+        ]
+        out = self.backend.get_citing_works_batch(refs)
+        self.assertEqual(set(out.keys()), {r.identifier for r in refs})
+
+
+class OpenCiteBackendUnitTests(TestCase):
+    """Cheap tests that exercise the backend's error-classification path
+    without hitting the network."""
+
+    def test_empty_batch_returns_empty_dict(self) -> None:
+        backend = OpenCiteBackend()
+        self.assertEqual(backend.get_citing_works_batch([]), {})
+
+    def test_classify_error_rate_limit(self) -> None:
+        from dataset_citations.backends.opencite_backend import _classify_error
+
+        err = _classify_error(RuntimeError("HTTP 429 too many requests"), "x")
+        self.assertEqual(err.reason, "rate_limit")
+
+    def test_classify_error_not_found(self) -> None:
+        from dataset_citations.backends.opencite_backend import _classify_error
+
+        err = _classify_error(RuntimeError("HTTP 404 not found"), "x")
+        self.assertEqual(err.reason, "not_found")
+
+    def test_classify_error_auth(self) -> None:
+        from dataset_citations.backends.opencite_backend import _classify_error
+
+        err = _classify_error(RuntimeError("HTTP 401 unauthorized"), "x")
+        self.assertEqual(err.reason, "auth")
+
+    def test_classify_error_network(self) -> None:
+        from dataset_citations.backends.opencite_backend import _classify_error
+
+        err = _classify_error(TimeoutError("connection timeout"), "x")
+        self.assertEqual(err.reason, "network")
+
+    def test_classify_error_other(self) -> None:
+        from dataset_citations.backends.opencite_backend import _classify_error
+
+        err = _classify_error(RuntimeError("totally unexpected"), "x")
+        self.assertEqual(err.reason, "other")

--- a/tests/test_backends_opencite.py
+++ b/tests/test_backends_opencite.py
@@ -69,32 +69,32 @@ class OpenCiteBackendUnitTests(TestCase):
         backend = OpenCiteBackend()
         self.assertEqual(backend.get_citing_works_batch([]), {})
 
-    def test_classify_error_rate_limit(self) -> None:
-        from dataset_citations.backends.opencite_backend import _classify_error
+    def testclassify_error_rate_limit(self) -> None:
+        from dataset_citations.backends.opencite_backend import classify_error
 
-        err = _classify_error(RuntimeError("HTTP 429 too many requests"), "x")
+        err = classify_error(RuntimeError("HTTP 429 too many requests"), "x")
         self.assertEqual(err.reason, "rate_limit")
 
-    def test_classify_error_not_found(self) -> None:
-        from dataset_citations.backends.opencite_backend import _classify_error
+    def testclassify_error_not_found(self) -> None:
+        from dataset_citations.backends.opencite_backend import classify_error
 
-        err = _classify_error(RuntimeError("HTTP 404 not found"), "x")
+        err = classify_error(RuntimeError("HTTP 404 not found"), "x")
         self.assertEqual(err.reason, "not_found")
 
-    def test_classify_error_auth(self) -> None:
-        from dataset_citations.backends.opencite_backend import _classify_error
+    def testclassify_error_auth(self) -> None:
+        from dataset_citations.backends.opencite_backend import classify_error
 
-        err = _classify_error(RuntimeError("HTTP 401 unauthorized"), "x")
+        err = classify_error(RuntimeError("HTTP 401 unauthorized"), "x")
         self.assertEqual(err.reason, "auth")
 
-    def test_classify_error_network(self) -> None:
-        from dataset_citations.backends.opencite_backend import _classify_error
+    def testclassify_error_network(self) -> None:
+        from dataset_citations.backends.opencite_backend import classify_error
 
-        err = _classify_error(TimeoutError("connection timeout"), "x")
+        err = classify_error(TimeoutError("connection timeout"), "x")
         self.assertEqual(err.reason, "network")
 
-    def test_classify_error_other(self) -> None:
-        from dataset_citations.backends.opencite_backend import _classify_error
+    def testclassify_error_other(self) -> None:
+        from dataset_citations.backends.opencite_backend import classify_error
 
-        err = _classify_error(RuntimeError("totally unexpected"), "x")
+        err = classify_error(RuntimeError("totally unexpected"), "x")
         self.assertEqual(err.reason, "other")

--- a/tests/test_data/sources/bids/ds000117.description.json
+++ b/tests/test_data/sources/bids/ds000117.description.json
@@ -1,0 +1,20 @@
+{
+    "Name": "Multisubject, multimodal face processing",
+    "License": "CC0",
+    "Authors": [
+        "Wakeman, DG",
+        "Henson, RN"
+    ],
+    "Acknowledgements": "This work was supported by the UK Medical Research Council (SUAG/010\nRG91365) and Elekta Ltd. We would also like to acknowledge the contribution of Andre van der Kouwe and the A.A. Martinos Center for Biomedical Imaging (MGH) for providing the Multi-Echo FLASH sequences used in this work.",
+    "HowToAcknowledge": "Cite this paper: https://www.ncbi.nlm.nih.gov/pubmed/25977808 and consider including the following message: 'This data was obtained from the OpenNeuro database. Its accession number is ds000117'",
+    "Funding": [
+        "UK Medical Research Council (SUAG/010 RG91365), Elekta Ltd."
+    ],
+    "ReferencesAndLinks": [
+        "https://www.ncbi.nlm.nih.gov/pubmed/25977808",
+        "https://openfmri.org/dataset/ds000117/",
+        "ftp://ftp.mrc-cbu.cam.ac.uk/personal/rik.henson/wakemandg_hensonrn/Publications/"
+    ],
+    "BIDSVersion": "1.0.2",
+    "DatasetDOI": "doi:10.18112/openneuro.ds000117.v1.1.0"
+}

--- a/tests/test_data/sources/bids/ds002001.description.json
+++ b/tests/test_data/sources/bids/ds002001.description.json
@@ -1,0 +1,10 @@
+{
+    "License": "PD",
+    "Name": "Rivalry_Tagging",
+    "BIDSVersion": "1.1.1",
+    "Authors": [
+        "Janine Mendola",
+        "Elizabeth Bock"
+    ],
+    "DatasetDOI": "10.18112/openneuro.ds002001.v1.0.0"
+}

--- a/tests/test_data/sources/nemar/nm000103.metadata.json
+++ b/tests/test_data/sources/nemar/nm000103.metadata.json
@@ -1,0 +1,167 @@
+{
+  "version": "2.0",
+  "pipeline_stage": "validated",
+  "title": "Healthy Brain Network EEG - Not for Commercial Use",
+  "description": "The Healthy Brain Network EEG dataset comprises high-resolution electroencephalogram recordings and behavioral responses from child and adolescent participants collected during structured EEG tasks. The dataset includes hierarchical event descriptors for systematic meta-analysis, behavioral questionnaire-derived factors (P-factor, attention, internalizing/externalizing behaviors), and quality control metrics. This BIDS-formatted resource advances understanding of neurodevelopmental and mental health phenotypes through integrated neurophysiological and behavioral assessment. Additional funding sources are acknowledged at https://childmind.org/science/global-open-science/healthy-brain-network/#donors",
+  "methods_description": "EEG data were collected during various cognitive and behavioral tasks from HBN participants. Behavioral responses including reaction times and accuracy were recorded concurrently with EEG acquisition. Events are annotated using Hierarchical Event Descriptors (HED version 8.3.0) to enable systematic meta-analysis. Quality control procedures verified data integrity, task completeness, and preprocessing readiness.",
+  "license": "CC-BY-NC-SA 4.0",
+  "dataset_type": "raw",
+  "authors": {
+    "Seyed Yahya Shirazi": {
+      "orcid": "0000-0001-5557-259X",
+      "affiliations": [
+        {
+          "name": "Swartz Center for Computational Neuroscience, Institute for Neural Computation, University of California San Diego",
+          "identifier": "https://ror.org/0168r3w48",
+          "scheme": "ROR"
+        }
+      ]
+    },
+    "Alexandre Franco": {
+      "orcid": "0000-0002-1552-1090",
+      "affiliations": [
+        {
+          "name": "Child Mind Institute"
+        },
+        {
+          "name": "Center for Brain Imaging and Neuromodulation, Nathan Kline Institute"
+        },
+        {
+          "name": "Department of Psychiatry, NYU Grossman School of Medicine"
+        }
+      ]
+    },
+    "Maurício Scopel Hoffmann": {
+      "orcid": "0000-0003-4232-3169",
+      "affiliations": [
+        {
+          "name": "Department of Neuropsychiatry, Universidade Federal de Santa Maria"
+        },
+        {
+          "name": "Graduate Program in Psychiatry and Behavioral Sciences, Universidade Federal do Rio Grande do Sul"
+        },
+        {
+          "name": "Care Policy and Evaluation Centre, London School of Economics and Political Science"
+        }
+      ]
+    },
+    "Nathalia B. Esper": {
+      "orcid": "0000-0003-3218-9226",
+      "affiliations": [
+        {
+          "name": "Child Mind Institute"
+        }
+      ]
+    },
+    "Dung Truong": {
+      "orcid": "0000-0003-4540-3551",
+      "affiliations": [
+        {
+          "name": "Swartz Center for Computational Neuroscience, Institute for Neural Computation, University of California San Diego",
+          "identifier": "https://ror.org/0168r3w48",
+          "scheme": "ROR"
+        }
+      ]
+    },
+    "Arnaud Delorme": {
+      "orcid": "0000-0002-0799-3557",
+      "affiliations": [
+        {
+          "name": "Swartz Center for Computational Neuroscience, Institute for Neural Computation, University of California San Diego",
+          "identifier": "https://ror.org/0168r3w48",
+          "scheme": "ROR"
+        }
+      ]
+    },
+    "Michael Milham": {
+      "orcid": "0000-0003-3532-1210",
+      "affiliations": [
+        {
+          "name": "Child Mind Institute"
+        },
+        {
+          "name": "Center for Brain Imaging and Neuromodulation, Nathan Kline Institute"
+        }
+      ]
+    },
+    "Scott Makeig": {
+      "orcid": "0000-0002-9048-8438",
+      "affiliations": [
+        {
+          "name": "Swartz Center for Computational Neuroscience, Institute for Neural Computation, University of California San Diego",
+          "identifier": "https://ror.org/0168r3w48",
+          "scheme": "ROR"
+        }
+      ]
+    }
+  },
+  "keywords": [
+    {
+      "term": "EEG"
+    },
+    {
+      "term": "child and adolescent mental health"
+    },
+    {
+      "term": "neurodevelopment"
+    },
+    {
+      "term": "behavioral assessment"
+    },
+    {
+      "term": "hierarchical event descriptors"
+    },
+    {
+      "term": "internalizing and externalizing behaviors"
+    },
+    {
+      "term": "HED"
+    },
+    {
+      "term": "Healthy Brain Network"
+    }
+  ],
+  "related_identifiers": [
+    {
+      "identifier": "10.1038/sdata.2017.181",
+      "identifier_type": "DOI",
+      "relation_type": "References"
+    },
+    {
+      "identifier": "10.1038/sdata.2017.40",
+      "identifier_type": "DOI",
+      "relation_type": "References"
+    },
+    {
+      "identifier": "https://github.com/nemarDatasets/nm000103",
+      "identifier_type": "URL",
+      "relation_type": "IsDescribedBy"
+    },
+    {
+      "identifier": "https://nemar.org/dataexplorer/detail?dataset_id=nm000103",
+      "identifier_type": "URL",
+      "relation_type": "IsDescribedBy"
+    },
+    {
+      "identifier": "10.5281/zenodo.17306881",
+      "identifier_type": "DOI",
+      "relation_type": "IsIdenticalTo"
+    }
+  ],
+  "funding_references": [
+    {
+      "funder_name": "See https://childmind.org/science/global-open-science/healthy-brain-network/#donors"
+    },
+    {
+      "funder_name": "NIH",
+      "award_number": "R01MH125934",
+      "award_title": "BIDS data preparation"
+    }
+  ],
+  "resource_type_general": "Dataset",
+  "resource_type_specific": "EEG Dataset",
+  "modalities": [
+    "eeg"
+  ],
+  "source_hash": "ff03a22a5148723b5891a5281901803d634a3f8803ad35fe550b9ad30897757d"
+}

--- a/tests/test_data/sources/nemar/nm000115.metadata.json
+++ b/tests/test_data/sources/nemar/nm000115.metadata.json
@@ -1,0 +1,68 @@
+{
+  "version": "2.0",
+  "pipeline_stage": "validated",
+  "authors": {
+    "Bangyan Zhou": {},
+    "Xiaopei Wu": {},
+    "Zongtan Lv": {},
+    "Lei Zhang": {},
+    "Xiaojin Guo": {}
+  },
+  "related_identifiers": [
+    {
+      "identifier": "10.1371/journal.pone.0162657",
+      "identifier_type": "DOI",
+      "relation_type": "IsDerivedFrom"
+    },
+    {
+      "identifier": "https://github.com/nemarDatasets/nm000115",
+      "identifier_type": "URL",
+      "relation_type": "IsDescribedBy"
+    },
+    {
+      "identifier": "https://nemar.org/dataexplorer/detail?dataset_id=nm000115",
+      "identifier_type": "URL",
+      "relation_type": "IsDescribedBy"
+    },
+    {
+      "identifier": "10.21105/joss.01896",
+      "identifier_type": "DOI",
+      "relation_type": "References"
+    },
+    {
+      "identifier": "10.1038/s41597-019-0104-8",
+      "identifier_type": "DOI",
+      "relation_type": "References"
+    }
+  ],
+  "title": "Zhou2016",
+  "license": "CC-BY-4.0",
+  "dataset_type": "raw",
+  "resource_type_general": "Dataset",
+  "modalities": [
+    "eeg"
+  ],
+  "resource_type_specific": "EEG Dataset",
+  "description": "This dataset comprises EEG recordings from four subjects performing motor imagery tasks (left hand, right hand, and feet) across three sessions. The data includes 14-channel EEG recordings sampled at 250 Hz, with a total of 450 trials per subject. The dataset was originally collected to investigate automated trial selection methods for optimization of motor imagery-based brain-computer interfaces and has been reformatted into BIDS format.",
+  "methods_description": "EEG was recorded from 14 channels placed according to the extended 10/20 system (Fp1, Fp2, FC3, FCz, FC4, C3, Cz, C4, CP3, CPz, CP4, O1, Oz, O2) at a sampling frequency of 250 Hz with 50 Hz power line frequency. Each trial began with an auditory cue followed by a 5-second visual arrow stimulus indicating the motor imagery task, then a 4-second rest period. Four participants completed three recording sessions, each containing two runs with 75 trials per run (25 trials per class).",
+  "keywords": [
+    {
+      "term": "EEG"
+    },
+    {
+      "term": "motor imagery"
+    },
+    {
+      "term": "brain-computer interface"
+    },
+    {
+      "term": "trial selection"
+    },
+    {
+      "term": "Electroencephalography",
+      "subject_scheme": "MeSH",
+      "value_uri": "http://id.nlm.nih.gov/mesh/D004569"
+    }
+  ],
+  "source_hash": "e45cc54c1418fe676e8714528fdc5a081076f3fa8b63f66e70c0f35787a84672"
+}

--- a/tests/test_sources_bids_metadata.py
+++ b/tests/test_sources_bids_metadata.py
@@ -32,7 +32,7 @@ class ParseDs000117(TestCase):
         self.assertGreater(len(self.refs), 0)
 
     def test_openneuro_dataset_doi_dropped(self) -> None:
-        # ds000117's DatasetDOI is 10.18112/openneuro.ds000117.* — not indexed
+        # ds000117's DatasetDOI is 10.18112/openneuro.ds000117.*; not indexed
         # in OpenAlex, must not appear in the output.
         identifiers = {r.identifier for r in self.refs}
         for ident in identifiers:
@@ -62,7 +62,7 @@ class ParseDs000117(TestCase):
 
 
 class ParseDs002001(TestCase):
-    """ds002001 has only DatasetDOI (OpenNeuro) — the output should be empty
+    """ds002001 has only DatasetDOI (OpenNeuro); the output should be empty
     once we strip OpenNeuro DOIs that aren't indexed in OpenAlex."""
 
     def setUp(self) -> None:

--- a/tests/test_sources_bids_metadata.py
+++ b/tests/test_sources_bids_metadata.py
@@ -126,3 +126,17 @@ class ParseSyntheticEdgeCases(TestCase):
 
     def test_empty_description(self) -> None:
         self.assertEqual(parse_bids_description({}), [])
+
+    def test_recurses_into_dict_valued_field(self) -> None:
+        # Some BIDS authors put structured content in HowToAcknowledge.
+        refs = parse_bids_description(
+            {
+                "HowToAcknowledge": {
+                    "text": "Please cite this paper",
+                    "citation": "https://doi.org/10.1038/sdata.2015.1",
+                },
+            }
+        )
+        self.assertEqual(len(refs), 1)
+        self.assertEqual(refs[0].identifier, "10.1038/sdata.2015.1")
+        self.assertEqual(refs[0].relation_type, "IsDerivedFrom")

--- a/tests/test_sources_bids_metadata.py
+++ b/tests/test_sources_bids_metadata.py
@@ -1,0 +1,128 @@
+"""Tests for bids_metadata parsing.
+
+Loads real dataset_description.json snapshots from
+tests/test_data/sources/bids/ and runs them through the pure
+parse_bids_description function. No mocks, no network.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest import TestCase
+
+from dataset_citations.sources.bids_metadata import parse_bids_description
+
+FIXTURE_DIR = Path(__file__).parent / "test_data" / "sources" / "bids"
+
+
+def load_fixture(name: str) -> dict:
+    return json.loads((FIXTURE_DIR / name).read_text())
+
+
+class ParseDs000117(TestCase):
+    """ds000117 has DatasetDOI, HowToAcknowledge with a PubMed link, and
+    ReferencesAndLinks with a DOI URL."""
+
+    def setUp(self) -> None:
+        self.payload = load_fixture("ds000117.description.json")
+        self.refs = parse_bids_description(self.payload)
+
+    def test_emits_at_least_one_doi_or_pmid(self) -> None:
+        self.assertGreater(len(self.refs), 0)
+
+    def test_openneuro_dataset_doi_dropped(self) -> None:
+        # ds000117's DatasetDOI is 10.18112/openneuro.ds000117.* — not indexed
+        # in OpenAlex, must not appear in the output.
+        identifiers = {r.identifier for r in self.refs}
+        for ident in identifiers:
+            self.assertFalse(
+                ident.startswith("10.18112/openneuro."),
+                f"OpenNeuro DatasetDOI {ident} should be excluded",
+            )
+
+    def test_pmid_extracted_from_howtoacknowledge(self) -> None:
+        # ds000117 references pmid:25977808 in both HowToAcknowledge and
+        # ReferencesAndLinks, so we expect the PMID to surface twice with
+        # different relation tags. The HowToAcknowledge -> IsDerivedFrom
+        # mapping must show up at least once.
+        pmid_refs = [
+            r
+            for r in self.refs
+            if r.identifier_type == "pmid" and r.identifier == "pmid:25977808"
+        ]
+        self.assertGreater(len(pmid_refs), 0)
+        howto_refs = [r for r in pmid_refs if r.source_field == "HowToAcknowledge"]
+        self.assertEqual(len(howto_refs), 1)
+        self.assertEqual(howto_refs[0].relation_type, "IsDerivedFrom")
+
+    def test_source_is_openneuro_description(self) -> None:
+        for ref in self.refs:
+            self.assertEqual(ref.source, "openneuro_description")
+
+
+class ParseDs002001(TestCase):
+    """ds002001 has only DatasetDOI (OpenNeuro) — the output should be empty
+    once we strip OpenNeuro DOIs that aren't indexed in OpenAlex."""
+
+    def setUp(self) -> None:
+        self.payload = load_fixture("ds002001.description.json")
+        self.refs = parse_bids_description(self.payload)
+
+    def test_no_extractable_references(self) -> None:
+        self.assertEqual(self.refs, [])
+
+
+class ParseSyntheticEdgeCases(TestCase):
+    def test_dataset_doi_inferred_as_isidenticalto(self) -> None:
+        # Non-OpenNeuro DatasetDOI: should be kept as IsIdenticalTo.
+        refs = parse_bids_description(
+            {
+                "DatasetDOI": "doi:10.5281/zenodo.1234567",
+            }
+        )
+        self.assertEqual(len(refs), 1)
+        self.assertEqual(refs[0].relation_type, "IsIdenticalTo")
+        self.assertEqual(refs[0].source_field, "DatasetDOI")
+
+    def test_referencesandlinks_inferred_as_references(self) -> None:
+        refs = parse_bids_description(
+            {
+                "ReferencesAndLinks": [
+                    "https://doi.org/10.1038/sdata.2015.1",
+                    "https://example.com/no-doi-here",
+                ],
+            }
+        )
+        self.assertEqual(len(refs), 1)
+        self.assertEqual(refs[0].identifier, "10.1038/sdata.2015.1")
+        self.assertEqual(refs[0].relation_type, "References")
+        self.assertEqual(refs[0].source_field, "ReferencesAndLinks")
+
+    def test_deduplicates_across_fields_within_same_relation(self) -> None:
+        # Same DOI showing up in multiple ReferencesAndLinks entries should
+        # only emit one DoiReference for that (identifier, relation) pair.
+        refs = parse_bids_description(
+            {
+                "ReferencesAndLinks": [
+                    "10.1038/sdata.2015.1",
+                    "doi:10.1038/sdata.2015.1",
+                ],
+            }
+        )
+        self.assertEqual(len(refs), 1)
+
+    def test_pmid_in_referencesandlinks(self) -> None:
+        refs = parse_bids_description(
+            {
+                "ReferencesAndLinks": [
+                    "https://www.ncbi.nlm.nih.gov/pubmed/25977808",
+                ],
+            }
+        )
+        self.assertEqual(len(refs), 1)
+        self.assertEqual(refs[0].identifier, "pmid:25977808")
+        self.assertEqual(refs[0].relation_type, "References")
+
+    def test_empty_description(self) -> None:
+        self.assertEqual(parse_bids_description({}), [])

--- a/tests/test_sources_doi.py
+++ b/tests/test_sources_doi.py
@@ -1,0 +1,117 @@
+"""Tests for src/dataset_citations/sources/doi.py helpers.
+
+Pure-function unit tests. No network, no mocks.
+"""
+
+from __future__ import annotations
+
+from unittest import TestCase
+
+from dataset_citations.sources.doi import (
+    extract_identifiers,
+    is_openneuro_dataset_doi,
+    normalize_doi,
+    validate_identifier,
+)
+
+
+class NormalizeDoiTests(TestCase):
+    def test_strips_doi_prefix(self) -> None:
+        self.assertEqual(
+            normalize_doi("doi:10.1038/SDATA.2015.1"), "10.1038/sdata.2015.1"
+        )
+
+    def test_strips_full_url(self) -> None:
+        self.assertEqual(
+            normalize_doi("https://doi.org/10.1038/sdata.2015.1"),
+            "10.1038/sdata.2015.1",
+        )
+        self.assertEqual(
+            normalize_doi("http://dx.doi.org/10.1038/sdata.2015.1"),
+            "10.1038/sdata.2015.1",
+        )
+
+    def test_trims_trailing_punctuation(self) -> None:
+        self.assertEqual(normalize_doi("10.1038/sdata.2015.1."), "10.1038/sdata.2015.1")
+        self.assertEqual(normalize_doi("10.1038/sdata.2015.1,"), "10.1038/sdata.2015.1")
+        self.assertEqual(normalize_doi("10.1038/sdata.2015.1;"), "10.1038/sdata.2015.1")
+
+    def test_balances_trailing_parens(self) -> None:
+        # "see (10.1038/sdata.2015.1)" parsed; the trailing `)` should drop.
+        self.assertEqual(normalize_doi("10.1038/sdata.2015.1)"), "10.1038/sdata.2015.1")
+
+    def test_keeps_internal_parens(self) -> None:
+        self.assertEqual(normalize_doi("10.1234/foo(bar)baz"), "10.1234/foo(bar)baz")
+
+
+class ValidateIdentifierTests(TestCase):
+    def test_accepts_valid_doi(self) -> None:
+        self.assertTrue(validate_identifier("10.1038/sdata.2015.1"))
+
+    def test_accepts_pmid(self) -> None:
+        self.assertTrue(validate_identifier("pmid:25977808"))
+
+    def test_accepts_arxiv_with_version(self) -> None:
+        self.assertTrue(validate_identifier("arxiv:2106.15928v2"))
+
+    def test_rejects_newline(self) -> None:
+        self.assertFalse(validate_identifier("10.1038/sdata\n.2015.1"))
+
+    def test_rejects_carriage_return(self) -> None:
+        self.assertFalse(validate_identifier("10.1038/sdata.2015.1\r"))
+
+    def test_rejects_empty(self) -> None:
+        self.assertFalse(validate_identifier(""))
+
+    def test_rejects_oversized(self) -> None:
+        self.assertFalse(validate_identifier("10.1234/" + "x" * 300))
+
+    def test_rejects_garbage(self) -> None:
+        self.assertFalse(validate_identifier("not a doi"))
+
+
+class IsOpenneuroDatasetDoiTests(TestCase):
+    def test_matches_openneuro_pattern(self) -> None:
+        self.assertTrue(is_openneuro_dataset_doi("10.18112/openneuro.ds000117.v1.1.0"))
+
+    def test_rejects_regular_doi(self) -> None:
+        self.assertFalse(is_openneuro_dataset_doi("10.1038/sdata.2015.1"))
+
+
+class ExtractIdentifiersTests(TestCase):
+    def test_extracts_doi(self) -> None:
+        results = extract_identifiers("See 10.1038/sdata.2015.1 for details.")
+        self.assertIn(("10.1038/sdata.2015.1", "doi"), results)
+
+    def test_extracts_pmid_from_url(self) -> None:
+        text = "Cite https://www.ncbi.nlm.nih.gov/pubmed/25977808"
+        self.assertEqual(extract_identifiers(text), [("pmid:25977808", "pmid")])
+
+    def test_extracts_pmid_from_short_url(self) -> None:
+        self.assertEqual(
+            extract_identifiers("pubmed/12345678"),
+            [("pmid:12345678", "pmid")],
+        )
+
+    def test_extracts_arxiv_from_tag(self) -> None:
+        self.assertIn(
+            ("arxiv:2106.15928v2", "arxiv"),
+            extract_identifiers("see arxiv:2106.15928v2"),
+        )
+
+    def test_extracts_arxiv_from_doi_shorthand(self) -> None:
+        # 10.48550/arxiv.X is the canonical arXiv DOI; we should record it as
+        # arxiv:X and not double-extract as a bare DOI.
+        results = extract_identifiers("arxiv: 10.48550/arxiv.1602.00904")
+        kinds = {kind for _, kind in results}
+        self.assertIn("arxiv", kinds)
+        self.assertNotIn("doi", kinds)
+
+    def test_deduplicates(self) -> None:
+        text = "see 10.1038/sdata.2015.1 and again https://doi.org/10.1038/sdata.2015.1"
+        results = extract_identifiers(text)
+        self.assertEqual(len([r for r in results if r[1] == "doi"]), 1)
+
+    def test_empty_returns_empty(self) -> None:
+        self.assertEqual(extract_identifiers(""), [])
+        self.assertEqual(extract_identifiers(None), [])

--- a/tests/test_sources_doi.py
+++ b/tests/test_sources_doi.py
@@ -40,6 +40,14 @@ class NormalizeDoiTests(TestCase):
         # "see (10.1038/sdata.2015.1)" parsed; the trailing `)` should drop.
         self.assertEqual(normalize_doi("10.1038/sdata.2015.1)"), "10.1038/sdata.2015.1")
 
+    def test_balances_multiple_trailing_parens(self) -> None:
+        # Stripping multiple unmatched trailing parens.
+        self.assertEqual(normalize_doi("10.1234/foo)))"), "10.1234/foo")
+
+    def test_balances_paren_with_one_match_kept(self) -> None:
+        # Inner `(` matches the first `)`; the second `)` is stray and drops.
+        self.assertEqual(normalize_doi("10.1234/foo(bar))"), "10.1234/foo(bar)")
+
     def test_keeps_internal_parens(self) -> None:
         self.assertEqual(normalize_doi("10.1234/foo(bar)baz"), "10.1234/foo(bar)baz")
 

--- a/tests/test_sources_github_error.py
+++ b/tests/test_sources_github_error.py
@@ -1,0 +1,62 @@
+"""Tests for the `_github_error` mapper used by both source modules.
+
+We construct real `GithubException` instances (no mocks) and assert the
+FetchError reasons match the project's retry contract.
+"""
+
+from __future__ import annotations
+
+from unittest import TestCase
+
+from github.GithubException import GithubException
+
+from dataset_citations.sources.bids_metadata import _github_error as bids_github_error
+from dataset_citations.sources.nemar_metadata import (
+    _github_error as nemar_github_error,
+)
+
+
+def _exc(status: int) -> GithubException:
+    return GithubException(status, {"message": "boom"}, headers={})
+
+
+class NemarGithubErrorMappingTests(TestCase):
+    def test_404_is_not_found(self) -> None:
+        err = nemar_github_error(_exc(404), ".nemar/metadata.json")
+        self.assertEqual(err.reason, "not_found")
+
+    def test_401_is_auth(self) -> None:
+        err = nemar_github_error(_exc(401), ".nemar/metadata.json")
+        self.assertEqual(err.reason, "auth")
+
+    def test_403_is_auth(self) -> None:
+        err = nemar_github_error(_exc(403), ".nemar/metadata.json")
+        self.assertEqual(err.reason, "auth")
+
+    def test_429_is_rate_limit(self) -> None:
+        err = nemar_github_error(_exc(429), ".nemar/metadata.json")
+        self.assertEqual(err.reason, "rate_limit")
+
+    def test_500_is_other(self) -> None:
+        err = nemar_github_error(_exc(500), ".nemar/metadata.json")
+        self.assertEqual(err.reason, "other")
+
+
+class BidsGithubErrorMappingTests(TestCase):
+    """The bids source has its own _github_error helper; verify parity."""
+
+    def test_404_is_not_found(self) -> None:
+        err = bids_github_error(_exc(404), "dataset_description.json")
+        self.assertEqual(err.reason, "not_found")
+
+    def test_401_is_auth(self) -> None:
+        err = bids_github_error(_exc(401), "dataset_description.json")
+        self.assertEqual(err.reason, "auth")
+
+    def test_429_is_rate_limit(self) -> None:
+        err = bids_github_error(_exc(429), "dataset_description.json")
+        self.assertEqual(err.reason, "rate_limit")
+
+    def test_500_is_other(self) -> None:
+        err = bids_github_error(_exc(500), "dataset_description.json")
+        self.assertEqual(err.reason, "other")

--- a/tests/test_sources_nemar_metadata.py
+++ b/tests/test_sources_nemar_metadata.py
@@ -1,0 +1,149 @@
+"""Tests for nemar_metadata parsing.
+
+Loads real .nemar/metadata.json snapshots from tests/test_data/sources/nemar/
+and runs them through the pure parse_nemar_metadata function. No mocks, no
+network.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest import TestCase
+
+from dataset_citations.sources.nemar_metadata import parse_nemar_metadata
+
+FIXTURE_DIR = Path(__file__).parent / "test_data" / "sources" / "nemar"
+
+
+def load_fixture(name: str) -> dict:
+    return json.loads((FIXTURE_DIR / name).read_text())
+
+
+class ParseNm000103(TestCase):
+    """nm000103 (Healthy Brain Network EEG) — has References, IsDerivedFrom,
+    IsDescribedBy, IsIdenticalTo entries."""
+
+    def setUp(self) -> None:
+        self.payload = load_fixture("nm000103.metadata.json")
+        self.refs = parse_nemar_metadata(self.payload)
+
+    def test_emits_only_citation_relation_types(self) -> None:
+        rel_types = {r.relation_type for r in self.refs}
+        self.assertNotIn("IsDescribedBy", rel_types)
+        self.assertNotIn("IsSupplementedBy", rel_types)
+        self.assertTrue(
+            rel_types.issubset(
+                {"References", "IsDerivedFrom", "IsIdenticalTo", "IsVersionOf"}
+            )
+        )
+
+    def test_skips_url_identifiers(self) -> None:
+        # All emitted references must be DOI-typed; URL entries are dropped.
+        for ref in self.refs:
+            self.assertEqual(ref.identifier_type, "doi")
+
+    def test_includes_known_references_dois(self) -> None:
+        identifiers = {r.identifier for r in self.refs}
+        self.assertIn("10.1038/sdata.2017.181", identifiers)
+        self.assertIn("10.1038/sdata.2017.40", identifiers)
+
+    def test_isidenticalto_zenodo_kept(self) -> None:
+        ids = [r for r in self.refs if r.identifier == "10.5281/zenodo.17306881"]
+        self.assertEqual(len(ids), 1)
+        self.assertEqual(ids[0].relation_type, "IsIdenticalTo")
+
+    def test_source_field(self) -> None:
+        for ref in self.refs:
+            self.assertEqual(ref.source, "nemar_metadata")
+            self.assertEqual(ref.source_field, "related_identifiers")
+
+
+class ParseNm000115(TestCase):
+    """Second fixture for relation_type variety."""
+
+    def setUp(self) -> None:
+        self.payload = load_fixture("nm000115.metadata.json")
+        self.refs = parse_nemar_metadata(self.payload)
+
+    def test_emits_at_least_one_reference(self) -> None:
+        self.assertGreater(len(self.refs), 0)
+        # IsDescribedBy is excluded; we expect to see References or related.
+        rel_types = {r.relation_type for r in self.refs}
+        self.assertTrue(rel_types & {"References", "IsDerivedFrom", "IsIdenticalTo"})
+
+
+class ParseSyntheticEdgeCases(TestCase):
+    """Hand-crafted edge cases that aren't easy to find in the real fixtures."""
+
+    def test_missing_related_identifiers(self) -> None:
+        refs = parse_nemar_metadata({"version": "2.0"})
+        self.assertEqual(refs, [])
+
+    def test_empty_related_identifiers(self) -> None:
+        refs = parse_nemar_metadata({"related_identifiers": []})
+        self.assertEqual(refs, [])
+
+    def test_filters_isdescribedby(self) -> None:
+        refs = parse_nemar_metadata(
+            {
+                "related_identifiers": [
+                    {
+                        "identifier": "https://example.com",
+                        "identifier_type": "URL",
+                        "relation_type": "IsDescribedBy",
+                    },
+                    {
+                        "identifier": "10.1038/foo.bar",
+                        "identifier_type": "DOI",
+                        "relation_type": "References",
+                    },
+                ]
+            }
+        )
+        self.assertEqual(len(refs), 1)
+        self.assertEqual(refs[0].identifier, "10.1038/foo.bar")
+
+    def test_skips_openneuro_dataset_doi(self) -> None:
+        refs = parse_nemar_metadata(
+            {
+                "related_identifiers": [
+                    {
+                        "identifier": "10.18112/openneuro.ds000117.v1.0.0",
+                        "identifier_type": "DOI",
+                        "relation_type": "IsIdenticalTo",
+                    },
+                ]
+            }
+        )
+        self.assertEqual(refs, [])
+
+    def test_skips_malformed_identifier(self) -> None:
+        refs = parse_nemar_metadata(
+            {
+                "related_identifiers": [
+                    {
+                        "identifier": "10.1038/foo\nbar",
+                        "identifier_type": "DOI",
+                        "relation_type": "References",
+                    },
+                ]
+            }
+        )
+        self.assertEqual(refs, [])
+
+    def test_handles_non_dict_entry(self) -> None:
+        refs = parse_nemar_metadata(
+            {
+                "related_identifiers": [
+                    "not a dict",
+                    None,
+                    {
+                        "identifier": "10.1038/sdata.2015.1",
+                        "identifier_type": "DOI",
+                        "relation_type": "References",
+                    },
+                ]
+            }
+        )
+        self.assertEqual(len(refs), 1)

--- a/tests/test_sources_nemar_metadata.py
+++ b/tests/test_sources_nemar_metadata.py
@@ -147,3 +147,19 @@ class ParseSyntheticEdgeCases(TestCase):
             }
         )
         self.assertEqual(len(refs), 1)
+
+    def test_isversionof_kept(self) -> None:
+        # IsVersionOf is in the citation-relations allow-list; should survive.
+        refs = parse_nemar_metadata(
+            {
+                "related_identifiers": [
+                    {
+                        "identifier": "10.1038/older.2014.5",
+                        "identifier_type": "DOI",
+                        "relation_type": "IsVersionOf",
+                    },
+                ]
+            }
+        )
+        self.assertEqual(len(refs), 1)
+        self.assertEqual(refs[0].relation_type, "IsVersionOf")

--- a/tests/test_sources_nemar_metadata.py
+++ b/tests/test_sources_nemar_metadata.py
@@ -21,8 +21,8 @@ def load_fixture(name: str) -> dict:
 
 
 class ParseNm000103(TestCase):
-    """nm000103 (Healthy Brain Network EEG) — has References, IsDerivedFrom,
-    IsDescribedBy, IsIdenticalTo entries."""
+    """nm000103 (Healthy Brain Network EEG) carries References, IsDescribedBy,
+    and IsIdenticalTo entries (verified against the checked-in fixture)."""
 
     def setUp(self) -> None:
         self.payload = load_fixture("nm000103.metadata.json")

--- a/uv.lock
+++ b/uv.lock
@@ -553,7 +553,7 @@ requires-dist = [
     { name = "matplotlib", specifier = ">=3.5.0" },
     { name = "neo4j", specifier = ">=5.0.0" },
     { name = "networkx", specifier = ">=3.0.0" },
-    { name = "opencite", git = "https://github.com/neuromechanist/opencite.git?rev=3e784ddd067b75e73fd0c69e02e82142be1afe11" },
+    { name = "opencite", git = "https://github.com/neuromechanist/opencite.git?rev=v0.4.0" },
     { name = "pandas", specifier = ">=1.3.0" },
     { name = "plotly", specifier = ">=5.0.0" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=2.15" },
@@ -1527,7 +1527,7 @@ wheels = [
 [[package]]
 name = "opencite"
 version = "0.4.0"
-source = { git = "https://github.com/neuromechanist/opencite.git?rev=3e784ddd067b75e73fd0c69e02e82142be1afe11#3e784ddd067b75e73fd0c69e02e82142be1afe11" }
+source = { git = "https://github.com/neuromechanist/opencite.git?rev=v0.4.0#3e784ddd067b75e73fd0c69e02e82142be1afe11" }
 dependencies = [
     { name = "httpx" },
     { name = "markit-mistral" },

--- a/uv.lock
+++ b/uv.lock
@@ -29,6 +29,15 @@ wheels = [
 ]
 
 [[package]]
+name = "annotated-types"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
+]
+
+[[package]]
 name = "anyio"
 version = "4.13.0"
 source = { registry = "https://pypi.org/simple" }
@@ -232,6 +241,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "coloredlogs"
+version = "15.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "humanfriendly" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cc/c7/eed8f27100517e8c0e6b923d5f0845d0cb99763da6fdee00478f91db7325/coloredlogs-15.0.1.tar.gz", hash = "sha256:7c991aa71a4577af2f82600d8f8f3a89f936baeaf9b50a9c197da014e5bf16b0", size = 278520, upload-time = "2021-06-11T10:22:45.202Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/06/3d6badcf13db419e25b07041d9c7b4a2c331d3f4e7134445ec5df57714cd/coloredlogs-15.0.1-py2.py3-none-any.whl", hash = "sha256:612ee75c546f53e92e70049c9dbfcc18c935a2b9a53b66085ce9ef6a6e5c0934", size = 46018, upload-time = "2021-06-11T10:22:42.561Z" },
 ]
 
 [[package]]
@@ -496,6 +517,7 @@ dependencies = [
     { name = "matplotlib" },
     { name = "neo4j" },
     { name = "networkx" },
+    { name = "opencite" },
     { name = "pandas" },
     { name = "plotly" },
     { name = "pygithub" },
@@ -531,6 +553,7 @@ requires-dist = [
     { name = "matplotlib", specifier = ">=3.5.0" },
     { name = "neo4j", specifier = ">=5.0.0" },
     { name = "networkx", specifier = ">=3.0.0" },
+    { name = "opencite", git = "https://github.com/neuromechanist/opencite.git?rev=3e784ddd067b75e73fd0c69e02e82142be1afe11" },
     { name = "pandas", specifier = ">=1.3.0" },
     { name = "plotly", specifier = ">=5.0.0" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=2.15" },
@@ -551,6 +574,15 @@ requires-dist = [
     { name = "wordcloud", specifier = ">=1.8.0" },
 ]
 provides-extras = ["dev", "test"]
+
+[[package]]
+name = "defusedxml"
+version = "0.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/d5/c66da9b79e5bdb124974bfe172b4daf3c984ebd9c2a06e2b8a4dc7331c72/defusedxml-0.7.1.tar.gz", hash = "sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69", size = 75520, upload-time = "2021-03-08T10:59:26.269Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/6c/aa3f2f849e01cb6a001cd8554a88d4c77c5c1a31c95bdf1cf9301e6d9ef4/defusedxml-0.7.1-py2.py3-none-any.whl", hash = "sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61", size = 25604, upload-time = "2021-03-08T10:59:24.45Z" },
+]
 
 [[package]]
 name = "deprecated"
@@ -583,6 +615,15 @@ wheels = [
 ]
 
 [[package]]
+name = "eval-type-backport"
+version = "0.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fb/a3/cafafb4558fd638aadfe4121dc6cefb8d743368c085acb2f521df0f3d9d7/eval_type_backport-0.3.1.tar.gz", hash = "sha256:57e993f7b5b69d271e37482e62f74e76a0276c82490cf8e4f0dffeb6b332d5ed", size = 9445, upload-time = "2025-12-02T11:51:42.987Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cf/22/fdc2e30d43ff853720042fa15baa3e6122722be1a7950a98233ebb55cd71/eval_type_backport-0.3.1-py3-none-any.whl", hash = "sha256:279ab641905e9f11129f56a8a78f493518515b83402b860f6f06dd7c011fdfa8", size = 6063, upload-time = "2025-12-02T11:51:41.665Z" },
+]
+
+[[package]]
 name = "fake-useragent"
 version = "2.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -598,6 +639,14 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b5/fe/997687a931ab51049acce6fa1f23e8f01216374ea81374ddee763c493db5/filelock-3.29.0.tar.gz", hash = "sha256:69974355e960702e789734cb4871f884ea6fe50bd8404051a3530bc07809cf90", size = 57571, upload-time = "2026-04-19T15:39:10.068Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/81/47/dd9a212ef6e343a6857485ffe25bba537304f1913bdbed446a23f7f592e1/filelock-3.29.0-py3-none-any.whl", hash = "sha256:96f5f6344709aa1572bbf631c640e4ebeeb519e08da902c39a001882f30ac258", size = 39812, upload-time = "2026-04-19T15:39:08.752Z" },
+]
+
+[[package]]
+name = "flatbuffers"
+version = "25.12.19"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/2d/d2a548598be01649e2d46231d151a6c56d10b964d94043a335ae56ea2d92/flatbuffers-25.12.19-py2.py3-none-any.whl", hash = "sha256:7634f50c427838bb021c2d66a3d1168e9d199b0607e6329399f04846d42e20b4", size = 26661, upload-time = "2025-12-19T23:16:13.622Z" },
 ]
 
 [[package]]
@@ -743,6 +792,18 @@ wheels = [
 ]
 
 [[package]]
+name = "humanfriendly"
+version = "10.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyreadline3", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cc/3f/2c29224acb2e2df4d2046e4c73ee2662023c58ff5b113c4c1adac0886c43/humanfriendly-10.0.tar.gz", hash = "sha256:6b0b831ce8f15f7300721aa49829fc4e83921a9a301cc7f606be6686a2288ddc", size = 360702, upload-time = "2021-09-17T21:40:43.31Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f0/0f/310fb31e39e2d734ccaa2c0fb981ee41f7bd5056ce9bc29b2248bd569169/humanfriendly-10.0-py2.py3-none-any.whl", hash = "sha256:1697e1a8a8f550fd43c2865cd84542fc175a61dcb779b6fee18cf6b6ccba1477", size = 86794, upload-time = "2021-09-17T21:40:39.897Z" },
+]
+
+[[package]]
 name = "identify"
 version = "2.6.19"
 source = { registry = "https://pypi.org/simple" }
@@ -797,6 +858,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/41/f2/d34e8b3a08a9cc79a50b2208a93dce981fe615b64d5a4d4abee421d898df/joblib-1.5.3.tar.gz", hash = "sha256:8561a3269e6801106863fd0d6d84bb737be9e7631e33aaed3fb9ce5953688da3", size = 331603, upload-time = "2025-12-15T08:41:46.427Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7b/91/984aca2ec129e2757d1e4e3c81c3fcda9d0f85b74670a094cc443d9ee949/joblib-1.5.3-py3-none-any.whl", hash = "sha256:5fc3c5039fc5ca8c0276333a188bbd59d6b7ab37fe6632daa76bc7f9ec18e713", size = 309071, upload-time = "2025-12-15T08:41:44.973Z" },
+]
+
+[[package]]
+name = "jsonpath-python"
+version = "1.1.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/98/18/4ca8742534a5993ff383f7602e325ce2d5d7cc93d72ac5e1cdedbea8a458/jsonpath_python-1.1.6.tar.gz", hash = "sha256:dded9932b4ec41fb8726e09c83afa4e6be618f938c2db287cc2a81723c639671", size = 88178, upload-time = "2026-05-07T01:26:34.482Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/55/8a/1270a6803bd821cbfcdda387eaa13cb41a7b1f7b9bd145979b3bfb9d6cb7/jsonpath_python-1.1.6-py3-none-any.whl", hash = "sha256:a1c50afd8d3fbbaf47a4873bc890dcb3c15da96f5c020327977d844d8731a2d4", size = 14453, upload-time = "2026-05-07T01:26:33.306Z" },
 ]
 
 [[package]]
@@ -949,6 +1019,24 @@ wheels = [
 ]
 
 [[package]]
+name = "magika"
+version = "0.6.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "numpy" },
+    { name = "onnxruntime" },
+    { name = "python-dotenv" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a3/f3/3d1dcdd7b9c41d589f5cff252d32ed91cdf86ba84391cfc81d9d8773571d/magika-0.6.3.tar.gz", hash = "sha256:7cc52aa7359af861957043e2bf7265ed4741067251c104532765cd668c0c0cb1", size = 3042784, upload-time = "2025-10-30T15:22:34.499Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a2/e4/35c323beb3280482c94299d61626116856ac2d4ec16ecef50afc4fdd4291/magika-0.6.3-py3-none-any.whl", hash = "sha256:eda443d08006ee495e02083b32e51b98cb3696ab595a7d13900d8e2ef506ec9d", size = 2969474, upload-time = "2025-10-30T15:22:25.298Z" },
+    { url = "https://files.pythonhosted.org/packages/25/8f/132b0d7cd51c02c39fd52658a5896276c30c8cc2fd453270b19db8c40f7e/magika-0.6.3-py3-none-macosx_11_0_arm64.whl", hash = "sha256:86901e64b05dde5faff408c9b8245495b2e1fd4c226e3393d3d2a3fee65c504b", size = 13358841, upload-time = "2025-10-30T15:22:27.413Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/03/5ed859be502903a68b7b393b17ae0283bf34195cfcca79ce2dc25b9290e7/magika-0.6.3-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:3d9661eedbdf445ac9567e97e7ceefb93545d77a6a32858139ea966b5806fb64", size = 15367335, upload-time = "2025-10-30T15:22:29.907Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/9e/f8ee7d644affa3b80efdd623a3d75865c8f058f3950cb87fb0c48e3559bc/magika-0.6.3-py3-none-win_amd64.whl", hash = "sha256:e57f75674447b20cab4db928ae58ab264d7d8582b55183a0b876711c2b2787f3", size = 12692831, upload-time = "2025-10-30T15:22:32.063Z" },
+]
+
+[[package]]
 name = "markdown-it-py"
 version = "4.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -958,6 +1046,53 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/06/ff/7841249c247aa650a76b9ee4bbaeae59370dc8bfd2f6c01f3630c35eb134/markdown_it_py-4.2.0.tar.gz", hash = "sha256:04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49", size = 82454, upload-time = "2026-05-07T12:08:28.36Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl", hash = "sha256:9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a", size = 91687, upload-time = "2026-05-07T12:08:27.182Z" },
+]
+
+[[package]]
+name = "markdownify"
+version = "1.2.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "beautifulsoup4" },
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3f/bc/c8c8eea5335341306b0fa7e1cb33c5e1c8d24ef70ddd684da65f41c49c92/markdownify-1.2.2.tar.gz", hash = "sha256:b274f1b5943180b031b699b199cbaeb1e2ac938b75851849a31fd0c3d6603d09", size = 18816, upload-time = "2025-11-16T19:21:18.565Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/ce/f1e3e9d959db134cedf06825fae8d5b294bd368aacdd0831a3975b7c4d55/markdownify-1.2.2-py3-none-any.whl", hash = "sha256:3f02d3cc52714084d6e589f70397b6fc9f2f3a8531481bf35e8cc39f975e186a", size = 15724, upload-time = "2025-11-16T19:21:17.622Z" },
+]
+
+[[package]]
+name = "markit-mistral"
+version = "0.2.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mistralai" },
+    { name = "pillow" },
+    { name = "pypdf2" },
+    { name = "python-magic" },
+    { name = "requests" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4a/0a/03f4376a761398d4a2ace4ca9a28a4162cb7681718d4eacb19eb1755329c/markit_mistral-0.2.3.tar.gz", hash = "sha256:b9565c6357cd040936af9a6a735e76b43d92b51208f74c004e17c42061444ecd", size = 3637756, upload-time = "2026-02-23T07:05:03.348Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ff/52/4644178790963efdefa9281fa8bb532a917df2f2ac4a40a2cd9faf70ea7e/markit_mistral-0.2.3-py3-none-any.whl", hash = "sha256:4afb1151f7157f05de8e9c225c26d624f3053dcbd6b8d9087556dc0ea23c30f3", size = 29245, upload-time = "2026-02-23T07:05:01.623Z" },
+]
+
+[[package]]
+name = "markitdown"
+version = "0.1.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "beautifulsoup4" },
+    { name = "charset-normalizer" },
+    { name = "defusedxml" },
+    { name = "magika" },
+    { name = "markdownify" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/83/93/3b93c291c99d09f64f7535ba74c1c6a3507cf49cffd38983a55de6f834b6/markitdown-0.1.5.tar.gz", hash = "sha256:4c956ff1528bf15e1814542035ec96e989206d19d311bb799f4df973ecafc31a", size = 45099, upload-time = "2026-02-20T19:45:23.886Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b1/8b/fd7e042455a829a1ede0bc8e9e3061aa6c7c4cf745385526ef62ff1b5a5b/markitdown-0.1.5-py3-none-any.whl", hash = "sha256:5180a9a841e20fc01c2c09dbc5d039638429bbebcdc2af1b2615c3c427840434", size = 63402, upload-time = "2026-02-20T19:45:27.195Z" },
 ]
 
 [[package]]
@@ -1069,12 +1204,38 @@ wheels = [
 ]
 
 [[package]]
+name = "mistralai"
+version = "1.5.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "eval-type-backport" },
+    { name = "httpx" },
+    { name = "jsonpath-python" },
+    { name = "pydantic" },
+    { name = "python-dateutil" },
+    { name = "typing-inspect" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/53/8d/88b7c48878864f37c554a131d37352a4ed0ea3918df3e8cb625407ff374a/mistralai-1.5.2.tar.gz", hash = "sha256:f39e6e51e8939aac2602e4badcb18712cbee2df33d86100c559333e609b92d17", size = 133473, upload-time = "2025-03-19T18:40:29.617Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7c/97/5b428225ca4524b9722c8e1b2812c35f958ec5bb6a58c274c6c07a136da8/mistralai-1.5.2-py3-none-any.whl", hash = "sha256:5b1112acebbcad1afd7732ce0bd60614975b64999801c555c54768ac41f506ae", size = 278149, upload-time = "2025-03-19T18:40:28.232Z" },
+]
+
+[[package]]
 name = "mpmath"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e0/47/dd32fa426cc72114383ac549964eecb20ecfd886d1e5ccf5340b55b02f57/mpmath-1.3.0.tar.gz", hash = "sha256:7a28eb2a9774d00c7bc92411c19a89209d5da7c4c9a9e227be8330a23a25b91f", size = 508106, upload-time = "2023-03-07T16:47:11.061Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/43/e3/7d92a15f894aa0c9c4b49b8ee9ac9850d6e63b03c9c32c0367a13ae62209/mpmath-1.3.0-py3-none-any.whl", hash = "sha256:a0b2b9fe80bbcd81a6647ff13108738cfb482d481d826cc0e02f5b35e5c88d2c", size = 536198, upload-time = "2023-03-07T16:47:09.197Z" },
+]
+
+[[package]]
+name = "mypy-extensions"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
 ]
 
 [[package]]
@@ -1343,6 +1504,38 @@ wheels = [
 ]
 
 [[package]]
+name = "onnxruntime"
+version = "1.20.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "coloredlogs" },
+    { name = "flatbuffers" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "protobuf" },
+    { name = "sympy" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f7/71/c5d980ac4189589267a06f758bd6c5667d07e55656bed6c6c0580733ad07/onnxruntime-1.20.1-cp313-cp313-macosx_13_0_universal2.whl", hash = "sha256:cc01437a32d0042b606f462245c8bbae269e5442797f6213e36ce61d5abdd8cc", size = 31007574, upload-time = "2024-11-21T00:49:23.225Z" },
+    { url = "https://files.pythonhosted.org/packages/81/0d/13bbd9489be2a6944f4a940084bfe388f1100472f38c07080a46fbd4ab96/onnxruntime-1.20.1-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fb44b08e017a648924dbe91b82d89b0c105b1adcfe31e90d1dc06b8677ad37be", size = 11951459, upload-time = "2024-11-21T00:49:26.269Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/ea/4454ae122874fd52bbb8a961262de81c5f932edeb1b72217f594c700d6ef/onnxruntime-1.20.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bda6aebdf7917c1d811f21d41633df00c58aff2bef2f598f69289c1f1dabc4b3", size = 13331620, upload-time = "2024-11-21T00:49:28.875Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/e0/50db43188ca1c945decaa8fc2a024c33446d31afed40149897d4f9de505f/onnxruntime-1.20.1-cp313-cp313-win_amd64.whl", hash = "sha256:d30367df7e70f1d9fc5a6a68106f5961686d39b54d3221f760085524e8d38e16", size = 11331758, upload-time = "2024-11-21T00:49:31.417Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/55/3821c5fd60b52a6c82a00bba18531793c93c4addfe64fbf061e235c5617a/onnxruntime-1.20.1-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c9158465745423b2b5d97ed25aa7740c7d38d2993ee2e5c3bfacb0c4145c49d8", size = 11950342, upload-time = "2024-11-21T00:49:34.164Z" },
+    { url = "https://files.pythonhosted.org/packages/14/56/fd990ca222cef4f9f4a9400567b9a15b220dee2eafffb16b2adbc55c8281/onnxruntime-1.20.1-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0df6f2df83d61f46e842dbcde610ede27218947c33e994545a22333491e72a3b", size = 13337040, upload-time = "2024-11-21T00:49:37.271Z" },
+]
+
+[[package]]
+name = "opencite"
+version = "0.4.0"
+source = { git = "https://github.com/neuromechanist/opencite.git?rev=3e784ddd067b75e73fd0c69e02e82142be1afe11#3e784ddd067b75e73fd0c69e02e82142be1afe11" }
+dependencies = [
+    { name = "httpx" },
+    { name = "markit-mistral" },
+    { name = "markitdown" },
+    { name = "pyalex" },
+]
+
+[[package]]
 name = "outcome"
 version = "1.3.0.post0"
 source = { registry = "https://pypi.org/simple" }
@@ -1513,12 +1706,111 @@ wheels = [
 ]
 
 [[package]]
+name = "protobuf"
+version = "7.34.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6b/6b/a0e95cad1ad7cc3f2c6821fcab91671bd5b78bd42afb357bb4765f29bc41/protobuf-7.34.1.tar.gz", hash = "sha256:9ce42245e704cc5027be797c1db1eb93184d44d1cdd71811fb2d9b25ad541280", size = 454708, upload-time = "2026-03-20T17:34:47.036Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/11/3325d41e6ee15bf1125654301211247b042563bcc898784351252549a8ad/protobuf-7.34.1-cp310-abi3-macosx_10_9_universal2.whl", hash = "sha256:d8b2cc79c4d8f62b293ad9b11ec3aebce9af481fa73e64556969f7345ebf9fc7", size = 429247, upload-time = "2026-03-20T17:34:37.024Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/9d/aa69df2724ff63efa6f72307b483ce0827f4347cc6d6df24b59e26659fef/protobuf-7.34.1-cp310-abi3-manylinux2014_aarch64.whl", hash = "sha256:5185e0e948d07abe94bb76ec9b8416b604cfe5da6f871d67aad30cbf24c3110b", size = 325753, upload-time = "2026-03-20T17:34:38.751Z" },
+    { url = "https://files.pythonhosted.org/packages/92/e8/d174c91fd48e50101943f042b09af9029064810b734e4160bbe282fa1caa/protobuf-7.34.1-cp310-abi3-manylinux2014_s390x.whl", hash = "sha256:403b093a6e28a960372b44e5eb081775c9b056e816a8029c61231743d63f881a", size = 340198, upload-time = "2026-03-20T17:34:39.871Z" },
+    { url = "https://files.pythonhosted.org/packages/53/1b/3b431694a4dc6d37b9f653f0c64b0a0d9ec074ee810710c0c3da21d67ba7/protobuf-7.34.1-cp310-abi3-manylinux2014_x86_64.whl", hash = "sha256:8ff40ce8cd688f7265326b38d5a1bed9bfdf5e6723d49961432f83e21d5713e4", size = 324267, upload-time = "2026-03-20T17:34:41.1Z" },
+    { url = "https://files.pythonhosted.org/packages/85/29/64de04a0ac142fb685fd09999bc3d337943fb386f3a0ec57f92fd8203f97/protobuf-7.34.1-cp310-abi3-win32.whl", hash = "sha256:34b84ce27680df7cca9f231043ada0daa55d0c44a2ddfaa58ec1d0d89d8bf60a", size = 426628, upload-time = "2026-03-20T17:34:42.536Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/87/cb5e585192a22b8bd457df5a2c16a75ea0db9674c3a0a39fc9347d84e075/protobuf-7.34.1-cp310-abi3-win_amd64.whl", hash = "sha256:e97b55646e6ce5cbb0954a8c28cd39a5869b59090dfaa7df4598a7fba869468c", size = 437901, upload-time = "2026-03-20T17:34:44.112Z" },
+    { url = "https://files.pythonhosted.org/packages/88/95/608f665226bca68b736b79e457fded9a2a38c4f4379a4a7614303d9db3bc/protobuf-7.34.1-py3-none-any.whl", hash = "sha256:bb3812cd53aefea2b028ef42bd780f5b96407247f20c6ef7c679807e9d188f11", size = 170715, upload-time = "2026-03-20T17:34:45.384Z" },
+]
+
+[[package]]
+name = "pyalex"
+version = "0.21"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "requests" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c7/8a/5e270c3d6021a873667be7469fb95b00e0584593d57b7773ef0db6841cef/pyalex-0.21.tar.gz", hash = "sha256:39f470885187e0e411798d34163453361a3834c4dae53f0a18f272475b749741", size = 52593, upload-time = "2026-02-23T14:11:13.421Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/b6/714246176f5ad319dc1d06607a093570bc3d2c37de6d5583e106762883a5/pyalex-0.21-py3-none-any.whl", hash = "sha256:988c37eb31ee3d23176b431d37f7e18c37817317d976237abcc6f3c02f92396f", size = 15761, upload-time = "2026-02-23T14:11:12.523Z" },
+]
+
+[[package]]
 name = "pycparser"
 version = "3.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
+]
+
+[[package]]
+name = "pydantic"
+version = "2.13.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/18/a5/b60d21ac674192f8ab0ba4e9fd860690f9b4a6e51ca5df118733b487d8d6/pydantic-2.13.4.tar.gz", hash = "sha256:c40756b57adaa8b1efeeced5c196f3f3b7c435f90e84ea7f443901bec8099ef6", size = 844775, upload-time = "2026-05-06T13:43:05.343Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/7b/122376b1fd3c62c1ed9dc80c931ace4844b3c55407b6fb2d199377c9736f/pydantic-2.13.4-py3-none-any.whl", hash = "sha256:45a282cde31d808236fd7ea9d919b128653c8b38b393d1c4ab335c62924d9aba", size = 472262, upload-time = "2026-05-06T13:43:02.641Z" },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.46.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9d/56/921726b776ace8d8f5db44c4ef961006580d91dc52b803c489fafd1aa249/pydantic_core-2.46.4.tar.gz", hash = "sha256:62f875393d7f270851f20523dd2e29f082bcc82292d66db2b64ea71f64b6e1c1", size = 471464, upload-time = "2026-05-06T13:37:06.98Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/a2/5d30b469c5267a17b39dec53208222f76a8d351dfac4af661888c5aee77d/pydantic_core-2.46.4-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:5d5902252db0d3cedf8d4a1bc68f70eeb430f7e4c7104c8c476753519b423008", size = 2106306, upload-time = "2026-05-06T13:37:48.029Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/81/4fa520eaffa8bd7d1525e644cd6d39e7d60b1592bc5b516693c7340b50f1/pydantic_core-2.46.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c94f0688e7b8d0a67abf40e57a7eaaecd17cc9586706a31b76c031f63df052b4", size = 1951906, upload-time = "2026-05-06T13:37:17.012Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d5/fd02da45b659668b05923b17ba3a0100a0a3d5541e3bd8fcc4ecb711309e/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f027324c56cd5406ca49c124b0db10e56c69064fec039acc571c29020cc87c76", size = 1976802, upload-time = "2026-05-06T13:37:35.113Z" },
+    { url = "https://files.pythonhosted.org/packages/21/f2/95727e1368be3d3ed485eaab7adbd7dda408f33f7a36e8b48e0144002b91/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e739fee756ba1010f8bcccb534252e85a35fe45ae92c295a06059ce58b74ccd3", size = 2052446, upload-time = "2026-05-06T13:37:12.313Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/86/5d99feea3f77c7234b8718075b23db11532773c1a0dbd9b9490215dc2eeb/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9d56801be94b86a9da183e5f3766e6310752b99ff647e38b09a9500d88e46e76", size = 2232757, upload-time = "2026-05-06T13:39:01.149Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/3a/508ac615935ef7588cf6d9e9b91309fdc2da751af865e02a9098de88258c/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2412e734dcb48da14d4e4006b82b46b74f2518b8a26ee7e58c6844a6cd6d03c4", size = 2309275, upload-time = "2026-05-06T13:37:41.406Z" },
+    { url = "https://files.pythonhosted.org/packages/07/f8/41db9de19d7987d6b04715a02b3b40aea467000275d9d758ffaa31af7d50/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9551187363ffc0de2a00b2e47c25aeaeb1020b69b668762966df15fc5659dd5a", size = 2094467, upload-time = "2026-05-06T13:39:18.847Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/e2/f35033184cb11d0052daf4416e8e10a502ea2ac006fc4f459aee872727d1/pydantic_core-2.46.4-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:0186750b482eefa11d7f435892b09c5c606193ef3375bcf94aa00ae6bfb66262", size = 2134417, upload-time = "2026-05-06T13:40:17.944Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/7b/6ceeb1cc90e193862f444ebe373d8fdf613f0a82572dde03fb10734c6c71/pydantic_core-2.46.4-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5855698a4856556d86e8e6cd8434bc3ac0314ee8e12089ae0e143f64c6256e4e", size = 2179782, upload-time = "2026-05-06T13:40:32.618Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/f2/c8d7773ede6af08036423a00ae0ceffce266c3c52a096c435d68c896083f/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:cbaf13819775b7f769bf4a1f066cb6df7a28d4480081a589828ef190226881cd", size = 2188782, upload-time = "2026-05-06T13:36:51.018Z" },
+    { url = "https://files.pythonhosted.org/packages/59/31/0c864784e31f09f05cdd87606f08923b9c9e7f6e51dd27f20f62f975ce9f/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:633147d34cf4550417f12e2b1a0383973bdf5cdfde212cb09e9a581cf10820be", size = 2328334, upload-time = "2026-05-06T13:40:37.764Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/eb/4f6c8a41efa30baa755590f4141abf3a8c370fab610915733e74134a7270/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:82cf5301172168103724d49a1444d3378cb20cdee30b116a1bd6031236298a5d", size = 2372986, upload-time = "2026-05-06T13:39:34.152Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/24/b375a480d53113860c299764bfe9f349a3dc9108b3adc0d7f0d786492ebf/pydantic_core-2.46.4-cp313-cp313-win32.whl", hash = "sha256:9fa8ae11da9e2b3126c6426f147e0fba88d96d65921799bb30c6abd1cb2c97fb", size = 1973693, upload-time = "2026-05-06T13:37:55.072Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/e8/cff247591966f2d22ec8c003cd7587e27b7ba7b81ab2fb888e3ab75dc285/pydantic_core-2.46.4-cp313-cp313-win_amd64.whl", hash = "sha256:6b3ace8194b0e5204818c92802dcdca7fc6d88aabbb799d7c795540d9cd6d292", size = 2071819, upload-time = "2026-05-06T13:38:49.139Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/1a/f4aee670d5670e9e148e0c82c7db98d780be566c6e6a97ee8035528ca0b3/pydantic_core-2.46.4-cp313-cp313-win_arm64.whl", hash = "sha256:184c081504d17f1c1066e430e117142b2c77d9448a97f7b65c6ac9fd9aee238d", size = 2027411, upload-time = "2026-05-06T13:40:45.796Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/74/228a26ddad29c6672b805d9fd78e8d251cd04004fa7eed0e622096cd0250/pydantic_core-2.46.4-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:428e04521a40150c85216fc8b85e8d39fece235a9cf5e383761238c7fa9b96fb", size = 2102079, upload-time = "2026-05-06T13:38:41.019Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/1f/8970b150a4b4365623ae00fc88603491f763c627311ae8031e3111356d6e/pydantic_core-2.46.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:23ace664830ee0bfe014a0c7bc248b1f7f25ed7ad103852c317624a1083af462", size = 1952179, upload-time = "2026-05-06T13:36:59.812Z" },
+    { url = "https://files.pythonhosted.org/packages/95/30/5211a831ae054928054b2f79731661087a2bc5c01e825c672b3a4a8f1b3e/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce5c1d2a8b27468f433ca974829c44060b8097eedc39933e3c206a90ee49c4a9", size = 1978926, upload-time = "2026-05-06T13:37:39.933Z" },
+    { url = "https://files.pythonhosted.org/packages/57/e9/689668733b1eb67adeef047db3c2e8788fcf65a7fd9c9e2b46b7744fe245/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7283d57845ecf5a163403eb0702dfc220cc4fbdd18919cb5ccea4f95ee1cdab4", size = 2046785, upload-time = "2026-05-06T13:38:01.995Z" },
+    { url = "https://files.pythonhosted.org/packages/60/d9/6715260422ff50a2109878fd24d948a6c3446bb2664f34ee78cd972b3acd/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8daafc69c93ee8a0204506a3b6b30f586ef54028f52aeeeb5c4cfc5184fd5914", size = 2228733, upload-time = "2026-05-06T13:40:50.371Z" },
+    { url = "https://files.pythonhosted.org/packages/18/ae/fdb2f64316afca925640f8e70bb1a564b0ec2721c1389e25b8eb4bf9a299/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cd2213145bcc2ba85884d0ac63d222fece9209678f77b9b4d76f054c561adb28", size = 2307534, upload-time = "2026-05-06T13:37:21.531Z" },
+    { url = "https://files.pythonhosted.org/packages/89/1d/8eff589b45bb8190a9d12c49cfad0f176a5cbd1534908a6b5125e2886239/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7a5f930472650a82629163023e630d160863fce524c616f4e5186e5de9d9a49b", size = 2099732, upload-time = "2026-05-06T13:39:31.942Z" },
+    { url = "https://files.pythonhosted.org/packages/06/d5/ee5a3366637fee41dee51a1fc91562dcf12ddbc68fda34e6b253da2324bb/pydantic_core-2.46.4-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:c1b3f518abeca3aa13c712fd202306e145abf59a18b094a6bafb2d2bbf59192c", size = 2129627, upload-time = "2026-05-06T13:37:25.033Z" },
+    { url = "https://files.pythonhosted.org/packages/94/33/2414be571d2c6a6c4d08be21f9292b6d3fdb08949a97b6dfe985017821db/pydantic_core-2.46.4-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1a7dd0b3ee80d90150e3495a3a13ac34dbcbfd4f012996a6a1d8900e91b5c0fb", size = 2179141, upload-time = "2026-05-06T13:37:14.046Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/79/7daa95be995be0eecc4cf75064cb33f9bbbfe3fe0158caf2f0d4a996a5c7/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:3fb702cd90b0446a3a1c5e470bfa0dd23c0233b676a9099ddcc964fa6ca13898", size = 2184325, upload-time = "2026-05-06T13:36:53.615Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/cb/d0a382f5c0de8a222dc61c65348e0ce831b1f68e0a018450d31c2cace3a5/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:b8458003118a712e66286df6a707db01c52c0f52f7db8e4a38f0da1d3b94fc4e", size = 2323990, upload-time = "2026-05-06T13:40:29.971Z" },
+    { url = "https://files.pythonhosted.org/packages/05/db/d9ba624cc4a5aced1598e88c04fdbd8310c8a69b9d38b9a3d39ce3a61ed7/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:372429a130e469c9cd698925ce5fc50940b7a1336b0d82038e63d5bbc4edc519", size = 2369978, upload-time = "2026-05-06T13:37:23.027Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/20/d15df15ba918c423461905802bfd2981c3af0bfa0e40d05e13edbfa48bc3/pydantic_core-2.46.4-cp314-cp314-win32.whl", hash = "sha256:85bb3611ff1802f3ee7fdd7dbff26b56f343fb432d57a4728fdd49b6ef35e2f4", size = 1966354, upload-time = "2026-05-06T13:38:03.499Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/b6/6b8de4c0a7d7ab3004c439c80c5c1e0a3e8d78bbae19379b01960383d9e5/pydantic_core-2.46.4-cp314-cp314-win_amd64.whl", hash = "sha256:811ff8e9c313ab425368bcbb36e5c4ebd7108c2bbf4e4089cfbb0b01eff63fac", size = 2072238, upload-time = "2026-05-06T13:39:40.807Z" },
+    { url = "https://files.pythonhosted.org/packages/32/36/51eb763beec1f4cf59b1db243a7dcc39cbb41230f050a09b9d69faaf0a48/pydantic_core-2.46.4-cp314-cp314-win_arm64.whl", hash = "sha256:bfec22eab3c8cc2ceec0248aec886624116dc079afa027ecc8ad4a7e62010f8a", size = 2018251, upload-time = "2026-05-06T13:37:26.72Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/91/855af51d625b23aa987116a19e231d2aaef9c4a415273ddc189b79a45fee/pydantic_core-2.46.4-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:af8244b2bef6aaad6d92cda81372de7f8c8d36c9f0c3ea36e827c60e7d9467a0", size = 2099593, upload-time = "2026-05-06T13:39:47.682Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/1b/8784a54c65edb5f49f0a14d6977cf1b209bba85a4c77445b255c2de58ab3/pydantic_core-2.46.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5a4330cdbc57162e4b3aa303f588ba752257694c9c9be3e7ebb11b4aca659b5d", size = 1935226, upload-time = "2026-05-06T13:40:40.428Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/e7/1955d28d1afc56dd4b3ad7cc0cf39df1b9852964cf16e5d13912756d6d6b/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:29c61fc04a3d840155ff08e475a04809278972fe6aef51e2720554e96367e34b", size = 1974605, upload-time = "2026-05-06T13:37:32.029Z" },
+    { url = "https://files.pythonhosted.org/packages/93/e2/3fedbf0ba7a22850e6e9fd78117f1c0f10f950182344d8a6c535d468fdd8/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c50f2528cf200c5eed56faf3f4e22fcd5f38c157a8b78576e6ba3168ec35f000", size = 2030777, upload-time = "2026-05-06T13:38:55.239Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/61/46be275fcaaba0b4f5b9669dd852267ce1ff616592dccf7a7845588df091/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0cbe8b01f948de4286c74cdd6c667aceb38f5c1e26f0693b3983d9d74887c65e", size = 2236641, upload-time = "2026-05-06T13:37:08.096Z" },
+    { url = "https://files.pythonhosted.org/packages/60/db/12e93e46a8bac9988be3c016860f83293daea8c716c029c9ace279036f2f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:617d7e2ca7dcb8c5cf6bcb8c59b8832c94b36196bbf1cbd1bfb56ed341905edd", size = 2286404, upload-time = "2026-05-06T13:40:20.221Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/4a/4d8b19008f38d31c53b8219cfedc2e3d5de5fe99d90076b7e767de29274f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7027560ee92211647d0d34e3f7cd6f50da56399d26a9c8ad0da286d3869a53f3", size = 2109219, upload-time = "2026-05-06T13:38:12.153Z" },
+    { url = "https://files.pythonhosted.org/packages/88/70/3cbc40978fefb7bb09c6708d40d4ad1a5d70fd7213c3d17f971de868ec1f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:f99626688942fb746e545232e7726926f3be91b5975f8b55327665fafda991c7", size = 2110594, upload-time = "2026-05-06T13:40:02.971Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/20/b8d36736216e29491125531685b2f9e61aa5b4b2599893f8268551da3338/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fc3e9034a63de20e15e8ade85358bc6efc614008cab72898b4b4952bea0509ff", size = 2159542, upload-time = "2026-05-06T13:39:27.506Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/a2/367df868eb584dacf6bf82a389272406d7178e301c4ac82545ab98bc2dd9/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:97e7cf2be5c77b7d1a9713a05605d49460d02c6078d38d8bef3cbe323c548424", size = 2168146, upload-time = "2026-05-06T13:38:31.93Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/b8/4460f77f7e201893f649a29ab355dddd3beee8a97bcb1a320db414f9a06e/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:3bf92c5d0e00fefaab325a4d27828fe6b6e2a21848686b5b60d2d9eeb09d76c6", size = 2306309, upload-time = "2026-05-06T13:37:44.717Z" },
+    { url = "https://files.pythonhosted.org/packages/64/c4/be2639293acd87dc8ddbcec41a73cee9b2ebf996fe6d892a1a74e88ad3f7/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:3ecbc122d18468d06ca279dc26a8c2e2d5acb10943bb35e36ae92096dc3b5565", size = 2369736, upload-time = "2026-05-06T13:37:05.645Z" },
+    { url = "https://files.pythonhosted.org/packages/30/a6/9f9f380dbb301f67023bf8f707aaa75daadf84f7152d95c410fd7e81d994/pydantic_core-2.46.4-cp314-cp314t-win32.whl", hash = "sha256:e846ae7835bf0703ae43f534ab79a867146dadd59dc9ca5c8b53d5c8f7c9ef02", size = 1955575, upload-time = "2026-05-06T13:38:51.116Z" },
+    { url = "https://files.pythonhosted.org/packages/40/1f/f1eb9eb350e795d1af8586289746f5c5677d16043040d63710e22abc43c9/pydantic_core-2.46.4-cp314-cp314t-win_amd64.whl", hash = "sha256:2108ba5c1c1eca18030634489dc544844144ee36357f2f9f780b93e7ddbb44b5", size = 2051624, upload-time = "2026-05-06T13:38:21.672Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/d2/42dd53d0a85c27606f316d3aa5d2869c4e8470a5ed6dec30e4a1abe19192/pydantic_core-2.46.4-cp314-cp314t-win_arm64.whl", hash = "sha256:4fcbe087dbc2068af7eda3aa87634eba216dbda64d1ae73c8684b621d33f6596", size = 2017325, upload-time = "2026-05-06T13:40:52.723Z" },
 ]
 
 [[package]]
@@ -1621,6 +1913,24 @@ wheels = [
 ]
 
 [[package]]
+name = "pypdf2"
+version = "3.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9f/bb/18dc3062d37db6c491392007dfd1a7f524bb95886eb956569ac38a23a784/PyPDF2-3.0.1.tar.gz", hash = "sha256:a74408f69ba6271f71b9352ef4ed03dc53a31aa404d29b5d31f53bfecfee1440", size = 227419, upload-time = "2022-12-31T10:36:13.13Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8e/5e/c86a5643653825d3c913719e788e41386bee415c2b87b4f955432f2de6b2/pypdf2-3.0.1-py3-none-any.whl", hash = "sha256:d16e4205cfee272fbdc0568b68d82be796540b1537508cef59388f839c191928", size = 232572, upload-time = "2022-12-31T10:36:10.327Z" },
+]
+
+[[package]]
+name = "pyreadline3"
+version = "3.5.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b6/6d/f94028646d7bbe6d9d873c47ee7c246f2d29129d253f0d96cb6fcab70733/pyreadline3-3.5.6.tar.gz", hash = "sha256:61e53218b99656091ddb077df9e71f25850e72e030b6183b39c9b7e6e4f4a9bf", size = 100368, upload-time = "2026-05-14T17:55:04.471Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f7/5e/35c856e186b74678c24927847ad9895a51f1bc02a0c6126477a6c6040064/pyreadline3-3.5.6-py3-none-any.whl", hash = "sha256:8449b734232e42a5dcd74048e39b60db2839a4c38cf3ae2bf7707d58b5389c0d", size = 85243, upload-time = "2026-05-14T17:55:03.262Z" },
+]
+
+[[package]]
 name = "pysocks"
 version = "1.7.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1691,6 +2001,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
+]
+
+[[package]]
+name = "python-magic"
+version = "0.4.27"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/da/db/0b3e28ac047452d079d375ec6798bf76a036a08182dbb39ed38116a49130/python-magic-0.4.27.tar.gz", hash = "sha256:c1ba14b08e4a5f5c31a302b7721239695b2f0f058d125bd5ce1ee36b9d9d3c3b", size = 14677, upload-time = "2022-06-07T20:16:59.508Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6c/73/9f872cb81fc5c3bb48f7227872c28975f998f3e7c2b1c16e95e6432bbb90/python_magic-0.4.27-py2.py3-none-any.whl", hash = "sha256:c212960ad306f700aa0d01e5d7a325d20548ff97eb9920dcd29513174f0294d3", size = 13840, upload-time = "2022-06-07T20:16:57.763Z" },
 ]
 
 [[package]]
@@ -2444,6 +2763,31 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "typing-inspect"
+version = "0.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mypy-extensions" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/dc/74/1789779d91f1961fa9438e9a8710cdae6bd138c80d7303996933d117264a/typing_inspect-0.9.0.tar.gz", hash = "sha256:b23fc42ff6f6ef6954e4852c1fb512cdd18dbea03134f91f856a95ccc9461f78", size = 13825, upload-time = "2023-05-24T20:25:47.612Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/65/f3/107a22063bf27bdccf2024833d3445f4eea42b2e598abfbd46f6a63b6cb0/typing_inspect-0.9.0-py3-none-any.whl", hash = "sha256:9ee6fc59062311ef8547596ab6b955e1b8aa46242d854bfc78f4f6b0eff35f9f", size = 8827, upload-time = "2023-05-24T20:25:45.287Z" },
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #39.
Part of epic #37.

## Summary
Phase 2 of the opencite pivot. Adds the library foundations: DOI source extractors for nm-datasets and legacy ds-datasets, plus a sync-friendly opencite backend. No CLI / pipeline changes yet; Phase 3 wires this behind a `--backend opencite` flag.

## What lands

### New subpackages
- `src/dataset_citations/sources/`
  - `models.py` — `DoiReference`, `CitingWork`, `FetchSuccess`/`FetchError` discriminated result.
  - `doi.py` — `normalize_doi`, `validate_identifier` (rejects newlines/control chars), `extract_identifiers` (DOI/PMID/arXiv from free text).
  - `nemar_metadata.py` — `NemarMetadataSource` + pure `parse_nemar_metadata`. Honors the relation-type allow-list from `.context/research.md` (`References`, `IsDerivedFrom`, `IsIdenticalTo`, `IsVersionOf`); skips `IsDescribedBy`, `IsSupplementedBy`, URL identifiers, and OpenNeuro `DatasetDOI` shapes.
  - `bids_metadata.py` — `BidsMetadataSource` + pure `parse_bids_description`. Infers relation types from source field (`DatasetDOI` -> `IsIdenticalTo`, `HowToAcknowledge` -> `IsDerivedFrom`, `ReferencesAndLinks` -> `References`). Drops OpenNeuro DatasetDOIs from lookup set.
- `src/dataset_citations/backends/opencite_backend.py` — `OpenCiteBackend` sync facade over opencite's async `CitationExplorer`. Batches reuse one session under a bounded semaphore (default 4). Errors classified into `FetchError` reasons (`rate_limit`, `not_found`, `auth`, `network`, `other`) — explicitly never silently cached as success.

### Dependency
- `opencite @ git+https://github.com/neuromechanist/opencite.git@v0.4.0` (PyPI lags at 0.2.3). Switch to a published version once opencite ships 0.5+ with the `[core]` extra (tracked: #43, neuromechanist/opencite#31).

### Tests (50 pass, 3 skipped)
- Real fixture files under `tests/test_data/sources/` (fetched via `gh api` from the actual nm/ds repos): `nm000103.metadata.json`, `nm000115.metadata.json`, `ds000117.description.json`, `ds002001.description.json`.
- `tests/test_sources_doi.py`, `tests/test_sources_nemar_metadata.py`, `tests/test_sources_bids_metadata.py` — fixture-driven, no network, no mocks.
- `tests/test_backends_opencite.py` — unit tests for error classification run unconditionally; live opencite lookups gated behind `RUN_INTEGRATION_TESTS=1`.

## Test plan
- [x] `uv sync --python 3.13 --all-extras` resolves (165 packages incl. opencite 0.4.0)
- [x] `uv run pytest tests/test_sources_* tests/test_backends_opencite.py` — 50 pass, 3 integration-skipped
- [x] `uv run ruff format --check src/ tests/` clean
- [x] `uv run ruff check src/ tests/` clean
- [ ] CI green on this PR

## Phase 1 review fixes baked in
- Errors return `FetchError(...)`, never silently absorbed as empty success (the cache-poisoning bug from the spike).
- No subprocess to gh / curl in library code — PyGithub everywhere (matches `quality/dataset_metadata.py`).
- DOI validator rejects newlines / control characters (CSV-safety guard).
- Pure `parse_*` helpers exposed so tests don't need network or mocks.

## Out of scope (Phase 3+)
- `dataset-citations-update --backend opencite` wiring — Phase 3 (#40).
- Citation JSON schema extension (`source_doi`, `source_relation`) — Phase 3.
- Dashboard aggregator relation-type slicing — Phase 3.
- Retiring scholarly + ScraperAPI — Phase 4 (#41).