### PR TITLE
Phase 3: DOI-anchored citation pipeline (feature-flagged)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,7 +119,8 @@ uv run dataset-citations-score-confidence --citations-dir citations/json --datas
 6. **Dashboard** — Interactive HTML + D3 deployed to Cloudflare Pages
 
 ## Key Data Formats
-- **Citation JSON** (`citations/json/`) — web-ready, includes confidence scores
+- **Citation JSON** (`citations/json/`) — legacy scholarly path, web-ready, includes confidence scores
+- **Citation JSON v2** (`citations/json_opencite/`) — Phase 3 opencite path. Same shape plus `metadata.schema_version="2.0"`, `metadata.discovery_backend="opencite"`, per-citation `source_doi` + `source_relation` (one of `References`, `IsDerivedFrom`, `IsIdenticalTo`, `IsVersionOf`)
 - **Dataset metadata** (`datasets/`) — GitHub-sourced descriptions
 - **Embeddings** (`embeddings/`) — semantic vectors + registry
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,7 +120,7 @@ uv run dataset-citations-score-confidence --citations-dir citations/json --datas
 
 ## Key Data Formats
 - **Citation JSON** (`citations/json/`) — legacy scholarly path, web-ready, includes confidence scores
-- **Citation JSON v2** (`citations/json_opencite/`) — Phase 3 opencite path. Same shape plus `metadata.schema_version="2.0"`, `metadata.discovery_backend="opencite"`, per-citation `source_doi` + `source_relation` (one of `References`, `IsDerivedFrom`, `IsIdenticalTo`, `IsVersionOf`)
+- **Citation JSON v2** (`citations/json_opencite/`), Phase 3 opencite path. Same shape plus `metadata.schema_version="2.0"`, `metadata.discovery_backend="opencite"`, per-citation `source_doi` + `source_relation` (one of `References`, `IsDerivedFrom`, `IsIdenticalTo`, `IsVersionOf`)
 - **Dataset metadata** (`datasets/`) — GitHub-sourced descriptions
 - **Embeddings** (`embeddings/`) — semantic vectors + registry
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ All notable changes to this project. The format loosely follows
 ## [Unreleased]
 
 ### Added
+- `dataset-citations-update --backend opencite` runs the new DOI-anchored
+  pipeline alongside the legacy scholarly path. Output lands at
+  `<output-dir>/json_opencite/<id>_citations.json` (side-by-side; the
+  legacy `citations/json/` tree is untouched).
+- `src/dataset_citations/core/opencite_pipeline.py` orchestrates source
+  extraction (nm or ds prefix), opencite lookup, dedup across anchors,
+  and emits the schema-v2 citation JSON.
+- `core.citation_utils.add_discovery_provenance` augments a citation JSON
+  with `metadata.schema_version` (`"2.0"`), `metadata.discovery_backend`,
+  and per-citation `discovery_backend` markers. Opencite-path citations
+  additionally carry `source_doi` and `source_relation`.
+- `dashboard.data.aggregator.DataAggregator.summary_by_backend()` returns
+  `{dataset_id: {"scholarly": N, "opencite": M}}` for side-by-side parity
+  reporting before scholarly is retired.
 - `src/dataset_citations/sources/` subpackage with `NemarMetadataSource` and
   `BidsMetadataSource` for DOI-anchored citation discovery. Reads
   `.nemar/metadata.json` from `nemarDatasets` (DataCite-style
@@ -19,9 +33,6 @@ All notable changes to this project. The format loosely follows
   empty results from rate limits / network failures.
 - `opencite` declared as a git-ref dependency pinned to `v0.4.0` (PyPI lags;
   switch tracked in #43 + neuromechanist/opencite#31).
-
-Not yet wired to any CLI; Phase 3 of epic #37 will add the
-`dataset-citations-update --backend opencite` path.
 
 ### Changed
 - `pyproject.toml`: added `opencite` to `dependencies` and regenerated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,12 @@ All notable changes to this project. The format loosely follows
 ## [Unreleased]
 
 ### Added
-- `dataset-citations-update --backend opencite` runs the new DOI-anchored
-  pipeline alongside the legacy scholarly path. Output lands at
-  `<output-dir>/json_opencite/<id>_citations.json` (side-by-side; the
-  legacy `citations/json/` tree is untouched).
+- `dataset-citations-update --backend opencite` selects the new DOI-anchored
+  pipeline instead of the legacy scholarly path; the two backends are
+  mutually exclusive per invocation. Output lands at
+  `<output-dir>/json_opencite/<id>_citations.json`, so the legacy
+  `citations/json/` tree is untouched and both outputs can coexist on disk
+  for side-by-side parity comparison before Phase 4 retires scholarly.
 - `src/dataset_citations/core/opencite_pipeline.py` orchestrates source
   extraction (nm or ds prefix), opencite lookup, dedup across anchors,
   and emits the schema-v2 citation JSON.

--- a/src/dataset_citations/cli/update.py
+++ b/src/dataset_citations/cli/update.py
@@ -27,6 +27,9 @@ from dataset_citations.core import (
 from dataset_citations.core import (
     getCitations as gc,
 )
+from dataset_citations.core.opencite_pipeline import (
+    fetch_dataset_citations_via_opencite,
+)
 
 # Configure basic logging for the script
 logging.basicConfig(
@@ -404,6 +407,54 @@ def save_updated_dataset_summary(
         return None
 
 
+def run_opencite_backend(args: argparse.Namespace) -> None:
+    """Run the Phase 3 opencite pipeline against each dataset in the input list.
+
+    Writes results to `<output-dir>/json_opencite/<id>_citations.json` so the
+    legacy scholarly tree (`<output-dir>/json/`) is untouched. This is the
+    side-by-side mode the Phase 3 design calls for; Phase 4 retires the
+    scholarly path once parity is verified in production.
+    """
+    import json
+
+    json_dir = os.path.join(args.output_dir, "json_opencite")
+    os.makedirs(json_dir, exist_ok=True)
+
+    with open(args.dataset_list_file, encoding="utf-8") as f:
+        dataset_ids = [line.strip() for line in f if line.strip()]
+
+    logger.info(
+        "Running opencite backend for %d dataset(s) -> %s",
+        len(dataset_ids),
+        json_dir,
+    )
+
+    successes = 0
+    stub_only = 0
+    for dataset_id in dataset_ids:
+        payload = fetch_dataset_citations_via_opencite(dataset_id)
+        filepath = os.path.join(json_dir, f"{dataset_id}_citations.json")
+        try:
+            with open(filepath, "w", encoding="utf-8") as f:
+                json.dump(payload, f, indent=2, ensure_ascii=False)
+        except OSError as e:
+            logger.error("Failed to write %s: %s", filepath, e)
+            continue
+        if payload["num_citations"] > 0:
+            successes += 1
+        else:
+            stub_only += 1
+            status = payload.get("metadata", {}).get("fetch_status", "empty")
+            logger.info("%s: 0 citations (status=%s)", dataset_id, status)
+
+    logger.info(
+        "opencite run complete: %d with citations, %d empty/stub, %d total.",
+        successes,
+        stub_only,
+        len(dataset_ids),
+    )
+
+
 def main():
     parser = argparse.ArgumentParser(
         description="Update dataset citation numbers and lists."
@@ -447,6 +498,18 @@ def main():
         default="both",
         help="Output format for detailed citation data (default: both).",
     )
+    parser.add_argument(
+        "--backend",
+        choices=["scholarly", "opencite"],
+        default="scholarly",
+        help=(
+            "Citation discovery backend (default: scholarly). With 'opencite', "
+            "lookups are anchored on DOIs surfaced by .nemar/metadata.json or "
+            "dataset_description.json; output is written to "
+            "<output-dir>/json_opencite/<id>_citations.json (side-by-side with "
+            "the legacy citations/json/ tree)."
+        ),
+    )
     parser.set_defaults(update_num_cites=True, update_cite_list=True)
 
     args = parser.parse_args()
@@ -455,6 +518,10 @@ def main():
     if not os.path.exists(args.output_dir):
         os.makedirs(args.output_dir)
         logger.info(f"Created output directory: {args.output_dir}")
+
+    if args.backend == "opencite":
+        run_opencite_backend(args)
+        return
 
     # Initialize proxy after parsing args, as it might be needed by gc functions
     # gc.get_working_proxy() is called, its internal logging will be used.

--- a/src/dataset_citations/cli/update.py
+++ b/src/dataset_citations/cli/update.py
@@ -431,6 +431,7 @@ def run_opencite_backend(args: argparse.Namespace) -> None:
 
     successes = 0
     stub_only = 0
+    write_failures = 0
     for dataset_id in dataset_ids:
         payload = fetch_dataset_citations_via_opencite(dataset_id)
         filepath = os.path.join(json_dir, f"{dataset_id}_citations.json")
@@ -439,6 +440,7 @@ def run_opencite_backend(args: argparse.Namespace) -> None:
                 json.dump(payload, f, indent=2, ensure_ascii=False)
         except OSError as e:
             logger.error("Failed to write %s: %s", filepath, e)
+            write_failures += 1
             continue
         if payload["num_citations"] > 0:
             successes += 1
@@ -448,11 +450,17 @@ def run_opencite_backend(args: argparse.Namespace) -> None:
             logger.info("%s: 0 citations (status=%s)", dataset_id, status)
 
     logger.info(
-        "opencite run complete: %d with citations, %d empty/stub, %d total.",
+        "opencite run complete: %d with citations, %d empty/stub, "
+        "%d write failures, %d total.",
         successes,
         stub_only,
+        write_failures,
         len(dataset_ids),
     )
+    if write_failures and write_failures == len(dataset_ids):
+        # Every single write failed; surface as non-zero exit so automation
+        # (cron, CI) can detect the wholesale failure.
+        raise SystemExit(2)
 
 
 def main():
@@ -507,7 +515,9 @@ def main():
             "lookups are anchored on DOIs surfaced by .nemar/metadata.json or "
             "dataset_description.json; output is written to "
             "<output-dir>/json_opencite/<id>_citations.json (side-by-side with "
-            "the legacy citations/json/ tree)."
+            "the legacy citations/json/ tree). In opencite mode, "
+            "--previous-citations-file, --workers, --output-format, and the "
+            "--no-update-* flags are ignored."
         ),
     )
     parser.set_defaults(update_num_cites=True, update_cite_list=True)

--- a/src/dataset_citations/core/citation_utils.py
+++ b/src/dataset_citations/core/citation_utils.py
@@ -17,11 +17,14 @@ import json
 import logging
 import os
 from datetime import datetime, timezone
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Literal, Optional
 
 import pandas as pd
 
 logger = logging.getLogger(__name__)
+
+DiscoveryBackend = Literal["scholarly", "opencite"]
+SCHEMA_VERSION_V2 = "2.0"
 
 
 def create_citation_json_structure(
@@ -120,6 +123,33 @@ def create_citation_json_structure(
     }
 
     return json_structure
+
+
+def add_discovery_provenance(
+    citation_json: Dict[str, Any],
+    *,
+    discovery_backend: DiscoveryBackend,
+    schema_version: str = SCHEMA_VERSION_V2,
+) -> Dict[str, Any]:
+    """Attach Phase 3 discovery-provenance fields to an existing citation JSON.
+
+    Mutates and returns the input dict. Fills in:
+      - top-level `metadata.schema_version` (default `2.0`)
+      - top-level `metadata.discovery_backend` (`scholarly` or `opencite`)
+      - per-citation `discovery_backend` (only if missing)
+
+    Per-citation `source_doi` and `source_relation` are NOT set here, because
+    they only make sense for the opencite path where the orchestrator knows
+    which DOI/relation each citing work was discovered through. Scholarly
+    citations leave both fields absent so consumers can distinguish them via
+    `.get("source_doi")`.
+    """
+    metadata = citation_json.setdefault("metadata", {})
+    metadata["schema_version"] = schema_version
+    metadata["discovery_backend"] = discovery_backend
+    for entry in citation_json.get("citation_details", []) or []:
+        entry.setdefault("discovery_backend", discovery_backend)
+    return citation_json
 
 
 def _safe_get_value(row: pd.Series, key: str, default: str = "n/a") -> str:

--- a/src/dataset_citations/core/citation_utils.py
+++ b/src/dataset_citations/core/citation_utils.py
@@ -131,18 +131,26 @@ def add_discovery_provenance(
     discovery_backend: DiscoveryBackend,
     schema_version: str = SCHEMA_VERSION_V2,
 ) -> Dict[str, Any]:
-    """Attach Phase 3 discovery-provenance fields to an existing citation JSON.
+    """Stamp a citation JSON with Phase 3 discovery-provenance markers.
 
-    Mutates and returns the input dict. Fills in:
-      - top-level `metadata.schema_version` (default `2.0`)
-      - top-level `metadata.discovery_backend` (`scholarly` or `opencite`)
-      - per-citation `discovery_backend` (only if missing)
+    Mutates and returns the input dict. Always overwrites the top-level
+    `metadata.schema_version` and `metadata.discovery_backend` keys: callers
+    are explicitly declaring the schema/backend identity of this output, so
+    any prior values were either stale or wrong. Per-citation
+    `discovery_backend` is set only when missing (`entry.setdefault`) so the
+    orchestrator can pre-populate the field with finer-grained labels in the
+    future without this helper clobbering them.
 
-    Per-citation `source_doi` and `source_relation` are NOT set here, because
-    they only make sense for the opencite path where the orchestrator knows
-    which DOI/relation each citing work was discovered through. Scholarly
-    citations leave both fields absent so consumers can distinguish them via
-    `.get("source_doi")`.
+    Per-citation `source_doi` and `source_relation` are NOT set here. The
+    opencite orchestrator writes them per-citation while building the JSON
+    because it alone knows which anchor surfaced each citing work. The
+    helper is only responsible for the top-level provenance markers and the
+    per-citation `discovery_backend` label.
+
+    The legacy scholarly path does not yet call this helper, so historical
+    scholarly JSONs lack the markers (treat them as schema v1 by absence).
+    Phase 4 retires the scholarly path; wiring it through here is not
+    needed in the interim.
     """
     metadata = citation_json.setdefault("metadata", {})
     metadata["schema_version"] = schema_version

--- a/src/dataset_citations/core/opencite_pipeline.py
+++ b/src/dataset_citations/core/opencite_pipeline.py
@@ -51,6 +51,14 @@ def fetch_dataset_citations_via_opencite(
       3. Ask `OpenCiteBackend.get_citing_works_batch` for citing works.
       4. Aggregate works across anchors, dedupe by (normalized DOI || title).
       5. Build the JSON dict with discovery provenance fields.
+
+    Always returns a dict; never raises for expected fetch failures.
+    `metadata.fetch_status` distinguishes outcomes:
+      - "success": every anchor returned a successful result.
+      - "partial": at least one anchor returned a FetchError but others
+        produced citing works; see `metadata.anchor_errors` for details.
+      - Any other value (e.g. "rate_limit", "not_found", "no_doi_references",
+        "unsupported_prefix:...") indicates a stub payload with zero citations.
     """
     when = fetch_date or datetime.now(timezone.utc)
     backend = backend or OpenCiteBackend()
@@ -105,6 +113,7 @@ def fetch_dataset_citations_via_opencite(
             "processing_version": "1.0",
             "schema_version": SCHEMA_VERSION_V2,
             "discovery_backend": "opencite",
+            "fetch_status": "success" if not per_anchor_errors else "partial",
             "anchor_count": len(refs),
             "anchor_errors": per_anchor_errors,
         },

--- a/src/dataset_citations/core/opencite_pipeline.py
+++ b/src/dataset_citations/core/opencite_pipeline.py
@@ -1,0 +1,197 @@
+"""Phase 3 orchestrator: fetch dataset citations via the opencite backend.
+
+Picks a source extractor by dataset-ID prefix (`nm*` -> nemar metadata,
+`ds*` -> OpenNeuro BIDS description), resolves DOI/PMID/arXiv references,
+asks the opencite backend for citing works, deduplicates them across source
+anchors, and returns a citation JSON dict in the schema-v2 shape that
+`citation_utils.add_discovery_provenance` produces.
+
+This module deliberately mirrors the legacy `core/citation_utils.save_citation_json`
+output shape so the dashboard aggregator and reporting tools keep working
+when reading from `citations/json_opencite/`.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from typing import Any
+
+from dataset_citations.backends import OpenCiteBackend
+from dataset_citations.core.citation_utils import (
+    SCHEMA_VERSION_V2,
+    add_discovery_provenance,
+)
+from dataset_citations.sources import (
+    BidsMetadataSource,
+    CitingWork,
+    DoiReference,
+    FetchSuccess,
+    NemarMetadataSource,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def fetch_dataset_citations_via_opencite(
+    dataset_id: str,
+    *,
+    backend: OpenCiteBackend | None = None,
+    nemar_source: NemarMetadataSource | None = None,
+    bids_source: BidsMetadataSource | None = None,
+    github_token: str | None = None,
+    fetch_date: datetime | None = None,
+) -> dict[str, Any]:
+    """Return a schema-v2 citation JSON dict for one dataset.
+
+    Steps:
+      1. Pick the source by dataset prefix (`nm` -> nemar, `ds` -> bids).
+      2. Fetch DOI/PMID anchors. On error, return a stub with the FetchError
+         reason in `metadata.fetch_status` and empty `citation_details`.
+      3. Ask `OpenCiteBackend.get_citing_works_batch` for citing works.
+      4. Aggregate works across anchors, dedupe by (normalized DOI || title).
+      5. Build the JSON dict with discovery provenance fields.
+    """
+    when = fetch_date or datetime.now(timezone.utc)
+    backend = backend or OpenCiteBackend()
+
+    if dataset_id.startswith("nm"):
+        source: Any = nemar_source or NemarMetadataSource(github_token=github_token)
+    elif dataset_id.startswith("ds"):
+        source = bids_source or BidsMetadataSource(github_token=github_token)
+    else:
+        return _stub_payload(
+            dataset_id, when, fetch_status=f"unsupported_prefix:{dataset_id[:2]}"
+        )
+
+    refs_result = source.get_doi_references(dataset_id)
+    if not isinstance(refs_result, FetchSuccess):
+        logger.warning(
+            "source lookup for %s failed: %s (%s)",
+            dataset_id,
+            refs_result.reason,
+            refs_result.detail,
+        )
+        return _stub_payload(dataset_id, when, fetch_status=refs_result.reason)
+
+    refs: list[DoiReference] = refs_result.value
+    if not refs:
+        return _stub_payload(dataset_id, when, fetch_status="no_doi_references")
+
+    batch = backend.get_citing_works_batch(refs)
+    citing_works, per_anchor_errors = _flatten_batch(batch)
+
+    if not citing_works and per_anchor_errors:
+        # Every anchor failed; surface the dominant failure reason.
+        reason = _dominant_error_reason(per_anchor_errors)
+        return _stub_payload(
+            dataset_id,
+            when,
+            fetch_status=reason,
+            anchor_count=len(refs),
+            anchor_errors=per_anchor_errors,
+        )
+
+    citation_details = [_citing_work_to_dict(w) for w in citing_works]
+    total_cumulative_citations = sum((w.citation_count or 0) for w in citing_works)
+
+    payload: dict[str, Any] = {
+        "dataset_id": dataset_id,
+        "num_citations": len(citation_details),
+        "date_last_updated": when.isoformat(),
+        "metadata": {
+            "total_cumulative_citations": int(total_cumulative_citations),
+            "fetch_date": when.isoformat(),
+            "processing_version": "1.0",
+            "schema_version": SCHEMA_VERSION_V2,
+            "discovery_backend": "opencite",
+            "anchor_count": len(refs),
+            "anchor_errors": per_anchor_errors,
+        },
+        "citation_details": citation_details,
+    }
+    return add_discovery_provenance(payload, discovery_backend="opencite")
+
+
+def _flatten_batch(
+    batch: dict[str, Any],
+) -> tuple[list[CitingWork], dict[str, str]]:
+    """Dedupe citing works across anchors; return (works, per-anchor error map)."""
+    seen: set[tuple[str, str]] = set()
+    works: list[CitingWork] = []
+    errors: dict[str, str] = {}
+    for anchor_id, result in batch.items():
+        if not isinstance(result, FetchSuccess):
+            errors[anchor_id] = result.reason
+            continue
+        for work in result.value:
+            key = (
+                (work.doi or "").lower(),
+                _normalize_title(work.title),
+            )
+            if key in seen:
+                continue
+            seen.add(key)
+            works.append(work)
+    return works, errors
+
+
+def _normalize_title(title: str) -> str:
+    return " ".join(title.lower().split())
+
+
+def _citing_work_to_dict(work: CitingWork) -> dict[str, Any]:
+    return {
+        "title": work.title,
+        "author": ", ".join(a.name for a in work.authors) if work.authors else "n/a",
+        "venue": work.venue or "n/a",
+        "year": work.year or 0,
+        "url": _doi_to_url(work.doi),
+        "cited_by": work.citation_count or 0,
+        "abstract": work.abstract,
+        "doi": work.doi,
+        "pmid": work.pmid,
+        "openalex_id": work.openalex_id,
+        "source_doi": work.source_doi,
+        "source_relation": work.source_relation,
+        "discovery_backend": "opencite",
+    }
+
+
+def _doi_to_url(doi: str | None) -> str:
+    return f"https://doi.org/{doi}" if doi else "n/a"
+
+
+def _dominant_error_reason(errors: dict[str, str]) -> str:
+    """Return the most common reason in the per-anchor error map."""
+    counts: dict[str, int] = {}
+    for reason in errors.values():
+        counts[reason] = counts.get(reason, 0) + 1
+    return max(counts, key=lambda r: counts[r]) if counts else "unknown"
+
+
+def _stub_payload(
+    dataset_id: str,
+    when: datetime,
+    *,
+    fetch_status: str,
+    anchor_count: int = 0,
+    anchor_errors: dict[str, str] | None = None,
+) -> dict[str, Any]:
+    payload = {
+        "dataset_id": dataset_id,
+        "num_citations": 0,
+        "date_last_updated": when.isoformat(),
+        "metadata": {
+            "total_cumulative_citations": 0,
+            "fetch_date": when.isoformat(),
+            "processing_version": "1.0",
+            "schema_version": SCHEMA_VERSION_V2,
+            "discovery_backend": "opencite",
+            "fetch_status": fetch_status,
+            "anchor_count": anchor_count,
+            "anchor_errors": anchor_errors or {},
+        },
+        "citation_details": [],
+    }
+    return add_discovery_provenance(payload, discovery_backend="opencite")

--- a/src/dataset_citations/dashboard/data/aggregator.py
+++ b/src/dataset_citations/dashboard/data/aggregator.py
@@ -46,7 +46,16 @@ class DataAggregator:
         self.logger = logging.getLogger(__name__)
 
     def _resolve_opencite_dir(self, explicit: Optional[Path]) -> Optional[Path]:
-        """Pick the opencite citations dir: explicit > sibling > None."""
+        """Pick the opencite citations dir: explicit > sibling > None.
+
+        Auto-detection assumes `citations_dir` points at the `json/`
+        subdirectory of the citations tree (e.g., `citations/json`) and
+        looks for `<parent>/json_opencite`. The CLI writes to
+        `<output-dir>/json_opencite/`, which matches this layout. Callers
+        that pass `citations_dir=citations/` directly will miss
+        auto-detection; pass `citations_opencite_dir=...` explicitly in
+        that case.
+        """
         if explicit is not None:
             p = Path(explicit)
             return p if p.exists() else None

--- a/src/dataset_citations/dashboard/data/aggregator.py
+++ b/src/dataset_citations/dashboard/data/aggregator.py
@@ -78,13 +78,25 @@ class DataAggregator:
                 out[entry[0]]["opencite"] = entry[1]
         return out
 
-    @staticmethod
-    def _counts_from_dir(directory: Path):
-        """Yield (dataset_id, num_citations) from each *_citations.json."""
+    def _counts_from_dir(self, directory: Path):
+        """Yield (dataset_id, num_citations) from each *_citations.json.
+
+        Unreadable or malformed files are logged at warning level and skipped.
+        Phase 1 review flagged silent skip as a cache-poisoning anti-pattern
+        for parity reporting: a corrupted scholarly file silently dropping to
+        0 could trick a parity-gate decision. The warning log makes the
+        occurrence visible.
+        """
         for path in sorted(directory.glob("*_citations.json")):
             try:
                 payload = json.loads(path.read_text())
-            except (OSError, json.JSONDecodeError):
+            except OSError as e:
+                self.logger.warning("summary_by_backend: cannot read %s: %s", path, e)
+                continue
+            except json.JSONDecodeError as e:
+                self.logger.warning(
+                    "summary_by_backend: malformed JSON in %s: %s", path, e
+                )
                 continue
             dataset_id = payload.get(
                 "dataset_id", path.name.removesuffix("_citations.json")

--- a/src/dataset_citations/dashboard/data/aggregator.py
+++ b/src/dataset_citations/dashboard/data/aggregator.py
@@ -18,6 +18,7 @@ class DataAggregator:
         results_dir: Path,
         citations_dir: Optional[Path] = None,
         datasets_dir: Optional[Path] = None,
+        citations_opencite_dir: Optional[Path] = None,
     ):
         """
         Initialize data aggregator.
@@ -26,6 +27,10 @@ class DataAggregator:
             results_dir: Directory containing analysis results
             citations_dir: Optional directory containing citation JSON files
             datasets_dir: Optional directory containing dataset metadata
+            citations_opencite_dir: Optional directory containing opencite-
+                produced citation JSON files (Phase 3 side-by-side output).
+                If None, the aggregator auto-detects `citations/json_opencite`
+                next to `citations_dir`.
         """
         self.results_dir = Path(results_dir)
         # Check if dashboard_data exists as primary location
@@ -37,7 +42,54 @@ class DataAggregator:
 
         self.citations_dir = Path(citations_dir) if citations_dir else None
         self.datasets_dir = Path(datasets_dir) if datasets_dir else None
+        self.citations_opencite_dir = self._resolve_opencite_dir(citations_opencite_dir)
         self.logger = logging.getLogger(__name__)
+
+    def _resolve_opencite_dir(self, explicit: Optional[Path]) -> Optional[Path]:
+        """Pick the opencite citations dir: explicit > sibling > None."""
+        if explicit is not None:
+            p = Path(explicit)
+            return p if p.exists() else None
+        if self.citations_dir is not None:
+            sibling = self.citations_dir.parent / "json_opencite"
+            if sibling.exists():
+                return sibling
+        return None
+
+    def summary_by_backend(self) -> Dict[str, Dict[str, int]]:
+        """Return per-dataset citation counts split by discovery backend.
+
+        Shape: `{dataset_id: {"scholarly": N, "opencite": M}}`. Used by Phase 3
+        side-by-side reporting to confirm opencite parity before scholarly
+        is retired in Phase 4. Datasets that appear in only one directory
+        get a 0 for the missing backend.
+        """
+        out: Dict[str, Dict[str, int]] = {}
+        if self.citations_dir is not None and self.citations_dir.exists():
+            for entry in self._counts_from_dir(self.citations_dir):
+                out.setdefault(entry[0], {"scholarly": 0, "opencite": 0})
+                out[entry[0]]["scholarly"] = entry[1]
+        if (
+            self.citations_opencite_dir is not None
+            and self.citations_opencite_dir.exists()
+        ):
+            for entry in self._counts_from_dir(self.citations_opencite_dir):
+                out.setdefault(entry[0], {"scholarly": 0, "opencite": 0})
+                out[entry[0]]["opencite"] = entry[1]
+        return out
+
+    @staticmethod
+    def _counts_from_dir(directory: Path):
+        """Yield (dataset_id, num_citations) from each *_citations.json."""
+        for path in sorted(directory.glob("*_citations.json")):
+            try:
+                payload = json.loads(path.read_text())
+            except (OSError, json.JSONDecodeError):
+                continue
+            dataset_id = payload.get(
+                "dataset_id", path.name.removesuffix("_citations.json")
+            )
+            yield dataset_id, int(payload.get("num_citations") or 0)
 
     def aggregate_all_data(self) -> Dict[str, Any]:
         """

--- a/tests/test_citation_utils_provenance.py
+++ b/tests/test_citation_utils_provenance.py
@@ -1,0 +1,75 @@
+"""Direct tests for citation_utils.add_discovery_provenance.
+
+Until Phase 3 the helper was only exercised transitively via the opencite
+pipeline tests. These tests pin its behavior so future refactors do not
+silently change the schema-v2 contract.
+"""
+
+from __future__ import annotations
+
+from unittest import TestCase
+
+from dataset_citations.core.citation_utils import (
+    SCHEMA_VERSION_V2,
+    add_discovery_provenance,
+)
+
+
+class AddDiscoveryProvenanceTests(TestCase):
+    def test_creates_metadata_when_missing(self) -> None:
+        result = add_discovery_provenance({}, discovery_backend="opencite")
+        self.assertEqual(result["metadata"]["schema_version"], SCHEMA_VERSION_V2)
+        self.assertEqual(result["metadata"]["discovery_backend"], "opencite")
+
+    def test_overwrites_existing_top_level_markers(self) -> None:
+        """Helper is a 'stamp this output' operation; it overwrites by design.
+
+        The docstring says so explicitly; this test pins that behavior so a
+        future refactor to setdefault would fail loudly.
+        """
+        payload = {
+            "metadata": {
+                "schema_version": "1.0",
+                "discovery_backend": "scholarly",
+            }
+        }
+        out = add_discovery_provenance(payload, discovery_backend="opencite")
+        self.assertEqual(out["metadata"]["schema_version"], "2.0")
+        self.assertEqual(out["metadata"]["discovery_backend"], "opencite")
+
+    def test_preserves_unrelated_metadata_keys(self) -> None:
+        payload = {
+            "metadata": {"fetch_date": "2026-01-01", "total_cumulative_citations": 99}
+        }
+        out = add_discovery_provenance(payload, discovery_backend="opencite")
+        self.assertEqual(out["metadata"]["fetch_date"], "2026-01-01")
+        self.assertEqual(out["metadata"]["total_cumulative_citations"], 99)
+
+    def test_per_citation_backend_only_set_when_missing(self) -> None:
+        """setdefault on per-citation discovery_backend so callers can
+        pre-populate with finer-grained labels and not have them clobbered."""
+        payload = {
+            "citation_details": [
+                {"title": "A", "discovery_backend": "scholarly"},
+                {"title": "B"},
+            ]
+        }
+        out = add_discovery_provenance(payload, discovery_backend="opencite")
+        self.assertEqual(out["citation_details"][0]["discovery_backend"], "scholarly")
+        self.assertEqual(out["citation_details"][1]["discovery_backend"], "opencite")
+
+    def test_tolerates_none_citation_details(self) -> None:
+        payload = {"citation_details": None}
+        out = add_discovery_provenance(payload, discovery_backend="opencite")
+        self.assertEqual(out["metadata"]["schema_version"], "2.0")
+
+    def test_custom_schema_version(self) -> None:
+        out = add_discovery_provenance(
+            {}, discovery_backend="opencite", schema_version="2.1-preview"
+        )
+        self.assertEqual(out["metadata"]["schema_version"], "2.1-preview")
+
+    def test_returns_same_dict_for_chaining(self) -> None:
+        payload: dict = {}
+        out = add_discovery_provenance(payload, discovery_backend="opencite")
+        self.assertIs(out, payload)

--- a/tests/test_cli_update_backend.py
+++ b/tests/test_cli_update_backend.py
@@ -1,54 +1,87 @@
-"""Argparse smoke tests for `dataset-citations-update --backend opencite`.
+"""Tests for `dataset-citations-update --backend opencite`.
 
-No I/O. Just exercises the CLI's argument parser and the dispatch shape.
+Uses monkeypatch (stdlib setattr) to substitute one real function for another,
+matching the project's "no Mock objects" rule.
 """
 
 from __future__ import annotations
 
 import io
 import json
-from contextlib import redirect_stderr
+import sys
+import tempfile
+from contextlib import redirect_stdout
 from pathlib import Path
 from unittest import TestCase
 
-from dataset_citations.cli.update import main, run_opencite_backend
+from dataset_citations.cli import update as cli_update
 
 
-class CliBackendFlagTests(TestCase):
-    def test_help_text_includes_backend_flag(self) -> None:
+class CliBackendParserTests(TestCase):
+    def test_real_help_text_lists_backend_flag(self) -> None:
+        """Capture the real CLI's --help output (no fresh parser substitute)."""
         buf = io.StringIO()
-        with self.assertRaises(SystemExit), redirect_stderr(buf):
-            import sys
+        old_argv = sys.argv
+        sys.argv = ["dataset-citations-update", "--help"]
+        try:
+            with self.assertRaises(SystemExit), redirect_stdout(buf):
+                cli_update.main()
+        finally:
+            sys.argv = old_argv
+        help_text = buf.getvalue()
+        self.assertIn("--backend", help_text)
+        self.assertIn("scholarly", help_text)
+        self.assertIn("opencite", help_text)
 
-            old = sys.argv
-            sys.argv = ["dataset-citations-update", "--help"]
+    def test_backend_dispatch_invokes_run_opencite(self) -> None:
+        """When --backend opencite is set, main() must call run_opencite_backend.
+
+        Substitute run_opencite_backend with a recording function; this is
+        setattr, not unittest.mock, so it stays within the no-mocks rule.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            list_file = Path(tmp) / "list.txt"
+            list_file.write_text("ds999999\n")
+            prev_csv = Path(tmp) / "prev.csv"
+            prev_csv.write_text("dataset_id,number_of_citations\n")
+
+            captured: dict[str, object] = {}
+
+            def recording_run_opencite(args):
+                captured["called"] = True
+                captured["backend"] = args.backend
+                captured["output_dir"] = args.output_dir
+
+            original = cli_update.run_opencite_backend
+            cli_update.run_opencite_backend = recording_run_opencite  # type: ignore[assignment]
+            old_argv = sys.argv
+            sys.argv = [
+                "dataset-citations-update",
+                "--dataset-list-file",
+                str(list_file),
+                "--previous-citations-file",
+                str(prev_csv),
+                "--output-dir",
+                tmp,
+                "--backend",
+                "opencite",
+            ]
             try:
-                main()
+                cli_update.main()
             finally:
-                sys.argv = old
-        # SystemExit on --help; output went to stdout (captured by pytest), so
-        # re-import the parser to inspect.
-        import argparse
+                cli_update.run_opencite_backend = original  # type: ignore[assignment]
+                sys.argv = old_argv
 
-        from dataset_citations.cli import update as upd
-
-        # Reach into main()'s parser by reconstructing a parse_args call.
-        # Easier: just check the formatted action list via a direct ArgParse.
-        parser = argparse.ArgumentParser()
-        parser.add_argument("--backend", choices=["scholarly", "opencite"])
-        ns = parser.parse_args(["--backend", "opencite"])
-        self.assertEqual(ns.backend, "opencite")
-        # Sanity that the symbol we imported is wired up.
-        self.assertTrue(callable(upd.run_opencite_backend))
+            self.assertTrue(captured.get("called"))
+            self.assertEqual(captured.get("backend"), "opencite")
+            self.assertEqual(captured.get("output_dir"), tmp)
 
 
-class RunOpenciteBackendIntegration(TestCase):
-    """Verify the side-by-side dispatch writes to json_opencite/ and never
-    touches the legacy json/ tree."""
+class RunOpenciteBackendTests(TestCase):
+    """Direct tests for run_opencite_backend's write/dispatch behavior."""
 
     def test_unsupported_prefix_still_writes_stub(self) -> None:
         import argparse
-        import tempfile
 
         with tempfile.TemporaryDirectory() as out_dir:
             list_file = Path(out_dir) / "list.txt"
@@ -57,11 +90,42 @@ class RunOpenciteBackendIntegration(TestCase):
                 dataset_list_file=str(list_file),
                 output_dir=out_dir,
             )
-            run_opencite_backend(args)
+            cli_update.run_opencite_backend(args)
             stub = Path(out_dir) / "json_opencite" / "xx123_citations.json"
             self.assertTrue(stub.exists())
             payload = json.loads(stub.read_text())
             self.assertEqual(payload["num_citations"], 0)
             self.assertIn("unsupported_prefix", payload["metadata"]["fetch_status"])
-            # Legacy tree was NOT created.
             self.assertFalse((Path(out_dir) / "json").exists())
+
+    def test_total_write_failure_raises_systemexit(self) -> None:
+        """When every write fails, surface non-zero exit.
+
+        Force-fail writes by making the json_opencite output directory
+        read-only after run_opencite_backend creates it. We re-enter the
+        function with the directory already in place but non-writable.
+        """
+        import argparse
+        import os
+        import stat
+
+        with tempfile.TemporaryDirectory() as out_dir:
+            list_file = Path(out_dir) / "list.txt"
+            list_file.write_text("xx123\nxx456\n")
+            # Pre-create the json_opencite directory and make it read-only;
+            # makedirs(exist_ok=True) tolerates an existing dir, then each
+            # file write inside fails with PermissionError (OSError subclass).
+            json_dir = Path(out_dir) / "json_opencite"
+            json_dir.mkdir()
+            os.chmod(json_dir, stat.S_IRUSR | stat.S_IXUSR)
+            args = argparse.Namespace(
+                dataset_list_file=str(list_file),
+                output_dir=out_dir,
+            )
+            try:
+                with self.assertRaises(SystemExit) as ctx:
+                    cli_update.run_opencite_backend(args)
+                self.assertEqual(ctx.exception.code, 2)
+            finally:
+                # Restore write perm so tempfile cleanup works.
+                os.chmod(json_dir, stat.S_IRWXU)

--- a/tests/test_cli_update_backend.py
+++ b/tests/test_cli_update_backend.py
@@ -1,0 +1,67 @@
+"""Argparse smoke tests for `dataset-citations-update --backend opencite`.
+
+No I/O. Just exercises the CLI's argument parser and the dispatch shape.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+from contextlib import redirect_stderr
+from pathlib import Path
+from unittest import TestCase
+
+from dataset_citations.cli.update import main, run_opencite_backend
+
+
+class CliBackendFlagTests(TestCase):
+    def test_help_text_includes_backend_flag(self) -> None:
+        buf = io.StringIO()
+        with self.assertRaises(SystemExit), redirect_stderr(buf):
+            import sys
+
+            old = sys.argv
+            sys.argv = ["dataset-citations-update", "--help"]
+            try:
+                main()
+            finally:
+                sys.argv = old
+        # SystemExit on --help; output went to stdout (captured by pytest), so
+        # re-import the parser to inspect.
+        import argparse
+
+        from dataset_citations.cli import update as upd
+
+        # Reach into main()'s parser by reconstructing a parse_args call.
+        # Easier: just check the formatted action list via a direct ArgParse.
+        parser = argparse.ArgumentParser()
+        parser.add_argument("--backend", choices=["scholarly", "opencite"])
+        ns = parser.parse_args(["--backend", "opencite"])
+        self.assertEqual(ns.backend, "opencite")
+        # Sanity that the symbol we imported is wired up.
+        self.assertTrue(callable(upd.run_opencite_backend))
+
+
+class RunOpenciteBackendIntegration(TestCase):
+    """Verify the side-by-side dispatch writes to json_opencite/ and never
+    touches the legacy json/ tree."""
+
+    def test_unsupported_prefix_still_writes_stub(self) -> None:
+        import argparse
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as out_dir:
+            list_file = Path(out_dir) / "list.txt"
+            list_file.write_text("xx123\n")
+            args = argparse.Namespace(
+                dataset_list_file=str(list_file),
+                output_dir=out_dir,
+            )
+            run_opencite_backend(args)
+            stub = Path(out_dir) / "json_opencite" / "xx123_citations.json"
+            self.assertTrue(stub.exists())
+            payload = json.loads(stub.read_text())
+            self.assertEqual(payload["num_citations"], 0)
+            self.assertIn("unsupported_prefix", payload["metadata"]["fetch_status"])
+            # Legacy tree was NOT created.
+            self.assertFalse((Path(out_dir) / "json").exists())

--- a/tests/test_core_opencite_pipeline.py
+++ b/tests/test_core_opencite_pipeline.py
@@ -1,0 +1,225 @@
+"""Tests for src/dataset_citations/core/opencite_pipeline.py.
+
+The opencite backend is replaced in unit tests by a subclass that returns
+hardcoded `FetchSuccess` / `FetchError` results. This is real code (no
+unittest.mock), keeps the no-mocks rule, and lets us exercise the dedup,
+error-propagation, and schema-shape branches without hitting the network.
+
+Integration tests run live opencite lookups and are gated behind
+RUN_INTEGRATION_TESTS=1.
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime, timezone
+from unittest import TestCase, skipUnless
+
+from dataset_citations.backends.opencite_backend import OpenCiteBackend
+from dataset_citations.core.opencite_pipeline import (
+    fetch_dataset_citations_via_opencite,
+)
+from dataset_citations.sources.models import (
+    Author,
+    CitingWork,
+    DoiReference,
+    FetchError,
+    FetchSuccess,
+)
+
+
+def _make_work(
+    title: str,
+    *,
+    doi: str | None,
+    source_doi: str,
+    source_relation: str = "References",
+    citation_count: int = 10,
+) -> CitingWork:
+    return CitingWork(
+        title=title,
+        doi=doi,
+        pmid=None,
+        openalex_id=None,
+        year=2020,
+        authors=(Author(name="A. Researcher"),),
+        venue="Journal of Tests",
+        abstract=None,
+        citation_count=citation_count,
+        source_doi=source_doi,
+        source_relation=source_relation,  # type: ignore[arg-type]
+    )
+
+
+class _StubBackend(OpenCiteBackend):
+    """Real OpenCiteBackend subclass; overrides the batch method to return
+    a hand-built map. Not a mock; this is the project's no-mocks pattern."""
+
+    def __init__(self, batch_outcome: dict[str, FetchSuccess | FetchError]):
+        # Skip parent init so we don't try to read OPENCITE config.
+        self._batch_outcome = batch_outcome
+        self._config = None  # type: ignore[assignment]
+        self._max_results_per_doi = 100
+        self._concurrency = 1
+
+    def get_citing_works_batch(self, refs):  # type: ignore[override]
+        return {r.identifier: self._batch_outcome[r.identifier] for r in refs}
+
+
+class _StubSource:
+    """Real source-shaped object returning a fixed FetchResult."""
+
+    def __init__(self, outcome):
+        self._outcome = outcome
+
+    def get_doi_references(self, dataset_id):  # noqa: ARG002
+        return self._outcome
+
+
+WHEN = datetime(2026, 5, 18, tzinfo=timezone.utc)
+
+
+class FetchViaOpenCiteTests(TestCase):
+    def test_unsupported_prefix_returns_stub(self) -> None:
+        out = fetch_dataset_citations_via_opencite(
+            "xx123", fetch_date=WHEN, backend=_StubBackend({})
+        )
+        self.assertEqual(out["num_citations"], 0)
+        self.assertIn("unsupported_prefix", out["metadata"]["fetch_status"])
+
+    def test_source_error_propagated(self) -> None:
+        bids = _StubSource(FetchError("not_found", "missing"))
+        out = fetch_dataset_citations_via_opencite(
+            "ds000999",
+            backend=_StubBackend({}),
+            bids_source=bids,
+            fetch_date=WHEN,
+        )
+        self.assertEqual(out["metadata"]["fetch_status"], "not_found")
+        self.assertEqual(out["citation_details"], [])
+
+    def test_no_references_returns_no_doi_status(self) -> None:
+        bids = _StubSource(FetchSuccess([]))
+        out = fetch_dataset_citations_via_opencite(
+            "ds000999",
+            backend=_StubBackend({}),
+            bids_source=bids,
+            fetch_date=WHEN,
+        )
+        self.assertEqual(out["metadata"]["fetch_status"], "no_doi_references")
+
+    def test_happy_path_produces_schema_v2(self) -> None:
+        ref = DoiReference(
+            identifier="10.1038/sdata.2015.1",
+            identifier_type="doi",
+            relation_type="References",
+            source="openneuro_description",
+            source_field="ReferencesAndLinks",
+        )
+        bids = _StubSource(FetchSuccess([ref]))
+        backend = _StubBackend(
+            {
+                ref.identifier: FetchSuccess(
+                    [
+                        _make_work(
+                            "Method paper",
+                            doi="10.1234/method",
+                            source_doi=ref.identifier,
+                        )
+                    ]
+                )
+            }
+        )
+        out = fetch_dataset_citations_via_opencite(
+            "ds000117",
+            backend=backend,
+            bids_source=bids,
+            fetch_date=WHEN,
+        )
+        self.assertEqual(out["dataset_id"], "ds000117")
+        self.assertEqual(out["num_citations"], 1)
+        self.assertEqual(out["metadata"]["schema_version"], "2.0")
+        self.assertEqual(out["metadata"]["discovery_backend"], "opencite")
+        self.assertEqual(out["metadata"]["anchor_count"], 1)
+        entry = out["citation_details"][0]
+        self.assertEqual(entry["title"], "Method paper")
+        self.assertEqual(entry["source_doi"], "10.1038/sdata.2015.1")
+        self.assertEqual(entry["source_relation"], "References")
+        self.assertEqual(entry["discovery_backend"], "opencite")
+
+    def test_dedup_across_anchors(self) -> None:
+        ref_a = DoiReference(
+            identifier="10.1234/A",
+            identifier_type="doi",
+            relation_type="References",
+            source="nemar_metadata",
+        )
+        ref_b = DoiReference(
+            identifier="10.1234/B",
+            identifier_type="doi",
+            relation_type="IsDerivedFrom",
+            source="nemar_metadata",
+        )
+        shared_work = _make_work(
+            "Same paper cites both", doi="10.5555/cited", source_doi=ref_a.identifier
+        )
+        unique_to_b = _make_work(
+            "Only cites B", doi="10.5555/only-b", source_doi=ref_b.identifier
+        )
+        nemar = _StubSource(FetchSuccess([ref_a, ref_b]))
+        backend = _StubBackend(
+            {
+                ref_a.identifier: FetchSuccess([shared_work]),
+                ref_b.identifier: FetchSuccess([shared_work, unique_to_b]),
+            }
+        )
+        out = fetch_dataset_citations_via_opencite(
+            "nm000103",
+            backend=backend,
+            nemar_source=nemar,
+            fetch_date=WHEN,
+        )
+        self.assertEqual(out["num_citations"], 2)
+        titles = {c["title"] for c in out["citation_details"]}
+        self.assertEqual(titles, {"Same paper cites both", "Only cites B"})
+
+    def test_all_anchors_rate_limited_surfaces_dominant_reason(self) -> None:
+        ref = DoiReference(
+            identifier="10.1234/A",
+            identifier_type="doi",
+            relation_type="References",
+            source="nemar_metadata",
+        )
+        nemar = _StubSource(FetchSuccess([ref]))
+        backend = _StubBackend(
+            {ref.identifier: FetchError("rate_limit", "429 too many")}
+        )
+        out = fetch_dataset_citations_via_opencite(
+            "nm000103",
+            backend=backend,
+            nemar_source=nemar,
+            fetch_date=WHEN,
+        )
+        self.assertEqual(out["metadata"]["fetch_status"], "rate_limit")
+        self.assertEqual(
+            out["metadata"]["anchor_errors"], {ref.identifier: "rate_limit"}
+        )
+        self.assertEqual(out["citation_details"], [])
+
+
+@skipUnless(
+    os.getenv("RUN_INTEGRATION_TESTS"),
+    "live opencite lookup; set RUN_INTEGRATION_TESTS=1 to enable",
+)
+class FetchViaOpenCiteIntegration(TestCase):
+    def test_ds000117_live(self) -> None:
+        out = fetch_dataset_citations_via_opencite("ds000117")
+        # Either we get real citations or a transient FetchError; both are
+        # acceptable for the integration test as long as the schema is right.
+        self.assertEqual(out["dataset_id"], "ds000117")
+        self.assertEqual(out["metadata"]["schema_version"], "2.0")
+        self.assertEqual(out["metadata"]["discovery_backend"], "opencite")
+        if out["num_citations"] > 0:
+            entry = out["citation_details"][0]
+            self.assertTrue(entry.get("title"))
+            self.assertEqual(entry.get("discovery_backend"), "opencite")

--- a/tests/test_core_opencite_pipeline.py
+++ b/tests/test_core_opencite_pipeline.py
@@ -141,6 +141,9 @@ class FetchViaOpenCiteTests(TestCase):
         self.assertEqual(out["metadata"]["schema_version"], "2.0")
         self.assertEqual(out["metadata"]["discovery_backend"], "opencite")
         self.assertEqual(out["metadata"]["anchor_count"], 1)
+        # Phase 3 review: happy path must be distinguishable from "stub empty".
+        self.assertEqual(out["metadata"]["fetch_status"], "success")
+        self.assertEqual(out["metadata"]["anchor_errors"], {})
         entry = out["citation_details"][0]
         self.assertEqual(entry["title"], "Method paper")
         self.assertEqual(entry["source_doi"], "10.1038/sdata.2015.1")
@@ -205,6 +208,101 @@ class FetchViaOpenCiteTests(TestCase):
             out["metadata"]["anchor_errors"], {ref.identifier: "rate_limit"}
         )
         self.assertEqual(out["citation_details"], [])
+
+    def test_partial_failure_keeps_anchor_errors(self) -> None:
+        """When some anchors succeed and others fail, the successes survive
+        and the failing-anchor errors are recorded for downstream debugging."""
+        ref_ok = DoiReference(
+            identifier="10.1234/OK",
+            identifier_type="doi",
+            relation_type="References",
+            source="nemar_metadata",
+        )
+        ref_bad = DoiReference(
+            identifier="10.1234/BAD",
+            identifier_type="doi",
+            relation_type="IsDerivedFrom",
+            source="nemar_metadata",
+        )
+        nemar = _StubSource(FetchSuccess([ref_ok, ref_bad]))
+        backend = _StubBackend(
+            {
+                ref_ok.identifier: FetchSuccess(
+                    [
+                        _make_work(
+                            "good paper", doi="10.5/good", source_doi=ref_ok.identifier
+                        )
+                    ]
+                ),
+                ref_bad.identifier: FetchError("rate_limit", "429"),
+            }
+        )
+        out = fetch_dataset_citations_via_opencite(
+            "nm000103",
+            backend=backend,
+            nemar_source=nemar,
+            fetch_date=WHEN,
+        )
+        self.assertEqual(out["num_citations"], 1)
+        self.assertEqual(out["metadata"]["fetch_status"], "partial")
+        self.assertEqual(
+            out["metadata"]["anchor_errors"], {ref_bad.identifier: "rate_limit"}
+        )
+
+    def test_dominant_error_reason_tiebreak(self) -> None:
+        """When all anchors fail with mixed reasons, _dominant_error_reason
+        picks the most frequent. The tie-break path was previously untested."""
+        refs = [
+            DoiReference(
+                identifier=f"10.1234/{label}",
+                identifier_type="doi",
+                relation_type="References",
+                source="nemar_metadata",
+            )
+            for label in ("A", "B", "C")
+        ]
+        nemar = _StubSource(FetchSuccess(refs))
+        backend = _StubBackend(
+            {
+                refs[0].identifier: FetchError("rate_limit", "429"),
+                refs[1].identifier: FetchError("rate_limit", "429"),
+                refs[2].identifier: FetchError("not_found", "404"),
+            }
+        )
+        out = fetch_dataset_citations_via_opencite(
+            "nm000103",
+            backend=backend,
+            nemar_source=nemar,
+            fetch_date=WHEN,
+        )
+        # Two rate_limit vs one not_found; dominant should win.
+        self.assertEqual(out["metadata"]["fetch_status"], "rate_limit")
+
+    def test_nm_prefix_constructs_default_source_when_missing(self) -> None:
+        """fetch_dataset_citations_via_opencite("nm...") with no nemar_source
+        must construct a NemarMetadataSource. We substitute the class via
+        setattr so the test stays offline."""
+        import dataset_citations.core.opencite_pipeline as pipeline_module
+
+        recorded: list[str] = []
+
+        class RecordingNemarSource:
+            def __init__(self, github_token=None):  # noqa: ARG002
+                recorded.append("constructed")
+
+            def get_doi_references(self, dataset_id):  # noqa: ARG002
+                return FetchSuccess([])
+
+        original = pipeline_module.NemarMetadataSource
+        pipeline_module.NemarMetadataSource = RecordingNemarSource  # type: ignore[assignment,misc]
+        try:
+            out = fetch_dataset_citations_via_opencite(
+                "nm000103", backend=_StubBackend({}), fetch_date=WHEN
+            )
+        finally:
+            pipeline_module.NemarMetadataSource = original  # type: ignore[assignment]
+        self.assertEqual(recorded, ["constructed"])
+        self.assertEqual(out["metadata"]["fetch_status"], "no_doi_references")
 
 
 @skipUnless(

--- a/tests/test_core_opencite_pipeline.py
+++ b/tests/test_core_opencite_pipeline.py
@@ -52,8 +52,8 @@ def _make_work(
 
 
 class _StubBackend(OpenCiteBackend):
-    """Real OpenCiteBackend subclass; overrides the batch method to return
-    a hand-built map. Not a mock; this is the project's no-mocks pattern."""
+    """OpenCiteBackend test double that returns a preset batch result without
+    touching the network."""
 
     def __init__(self, batch_outcome: dict[str, FetchSuccess | FetchError]):
         # Skip parent init so we don't try to read OPENCITE config.

--- a/tests/test_dashboard_aggregator.py
+++ b/tests/test_dashboard_aggregator.py
@@ -260,3 +260,107 @@ class TestSummaryByBackend(TestCase):
         )
         summary = agg.summary_by_backend()
         self.assertEqual(summary["ds000117"]["opencite"], 42)
+
+    def test_explicit_opencite_dir_nonexistent_falls_back_to_none(self):
+        """Phase 3 review: branch when explicit path doesn't exist."""
+        agg = DataAggregator(
+            results_dir=self.results_dir,
+            citations_dir=self.citations_dir,
+            citations_opencite_dir=Path("/nonexistent/path/does-not-exist"),
+        )
+        self.assertIsNone(agg.citations_opencite_dir)
+        # summary still works from citations_dir alone:
+        self._write(self.citations_dir, "ds000117", 7)
+        self.assertEqual(
+            agg.summary_by_backend()["ds000117"], {"scholarly": 7, "opencite": 0}
+        )
+
+    def test_malformed_opencite_json_is_logged_and_skipped(self):
+        """Phase 3 review: silent skip was a cache-poisoning anti-pattern.
+        Verify that a corrupted JSON is skipped AND emits a warning log."""
+        import logging
+
+        # One valid file, one corrupted.
+        self._write(self.opencite_dir, "good", 5)
+        (self.opencite_dir / "corrupt_citations.json").write_text("{not valid json")
+        agg = DataAggregator(
+            results_dir=self.results_dir,
+            citations_dir=self.citations_dir,
+            citations_opencite_dir=self.opencite_dir,
+        )
+        with self.assertLogs(
+            "dataset_citations.dashboard.data.aggregator", level=logging.WARNING
+        ) as cm:
+            summary = agg.summary_by_backend()
+        # Good file present, corrupted skipped:
+        self.assertEqual(summary["good"], {"scholarly": 0, "opencite": 5})
+        self.assertNotIn("corrupt", summary)
+        # Warning emitted with the path:
+        self.assertTrue(
+            any("corrupt_citations.json" in msg for msg in cm.output),
+            f"expected warning log mentioning corrupt file, got: {cm.output}",
+        )
+
+
+class TestOpenCiteJsonReadback(TestCase):
+    """Phase 3 review: regression test that opencite-shape JSONs can be read
+    by the existing aggregator paths without crashing.
+
+    A schema drift that broke `_calculate_summary_stats` would otherwise ship
+    undetected until the dashboard run."""
+
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+        self.results_dir = Path(self.temp_dir) / "results"
+        self.results_dir.mkdir(parents=True)
+        self.citations_dir = Path(self.temp_dir) / "citations" / "json_opencite"
+        self.citations_dir.mkdir(parents=True)
+
+    def tearDown(self):
+        shutil.rmtree(self.temp_dir)
+
+    def test_opencite_schema_readable_by_summary_stats(self):
+        from dataset_citations.core.citation_utils import (
+            SCHEMA_VERSION_V2,
+            add_discovery_provenance,
+        )
+
+        payload = {
+            "dataset_id": "ds000117",
+            "num_citations": 1,
+            "date_last_updated": "2026-01-01T00:00:00",
+            "metadata": {
+                "total_cumulative_citations": 10,
+                "fetch_date": "2026-01-01T00:00:00",
+                "processing_version": "1.0",
+                "schema_version": SCHEMA_VERSION_V2,
+                "discovery_backend": "opencite",
+                "fetch_status": "success",
+                "anchor_count": 1,
+                "anchor_errors": {},
+            },
+            "citation_details": [
+                {
+                    "title": "Citing Paper",
+                    "author": "X. Y",
+                    "venue": "Journal of Tests",
+                    "year": 2023,
+                    "url": "https://doi.org/10.5/cite",
+                    "cited_by": 4,
+                    "doi": "10.5/cite",
+                    "source_doi": "10.1038/sdata.2015.1",
+                    "source_relation": "References",
+                    "discovery_backend": "opencite",
+                }
+            ],
+        }
+        add_discovery_provenance(payload, discovery_backend="opencite")
+        (self.citations_dir / "ds000117_citations.json").write_text(json.dumps(payload))
+        # Point the aggregator at the opencite tree as the citations_dir and
+        # verify _calculate_summary_stats walks it without crashing.
+        agg = DataAggregator(
+            results_dir=self.results_dir, citations_dir=self.citations_dir
+        )
+        stats = agg._calculate_summary_stats()
+        self.assertEqual(stats["total_datasets"], 1)
+        self.assertEqual(stats["total_citations"], 1)

--- a/tests/test_dashboard_aggregator.py
+++ b/tests/test_dashboard_aggregator.py
@@ -192,3 +192,71 @@ class TestDataAggregator(TestCase):
         data = aggregator.aggregate_all_data()
         self.assertIsNotNone(data)
         self.assertEqual(data["summary_stats"]["total_datasets"], 0)
+
+
+class TestSummaryByBackend(TestCase):
+    """Phase 3: aggregator surfaces per-dataset counts for scholarly vs opencite."""
+
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+        self.results_dir = Path(self.temp_dir) / "results"
+        self.results_dir.mkdir(parents=True)
+        self.citations_dir = Path(self.temp_dir) / "citations" / "json"
+        self.citations_dir.mkdir(parents=True)
+        self.opencite_dir = Path(self.temp_dir) / "citations" / "json_opencite"
+        self.opencite_dir.mkdir(parents=True)
+
+    def tearDown(self):
+        shutil.rmtree(self.temp_dir)
+
+    def _write(self, directory: Path, dataset_id: str, num: int):
+        (directory / f"{dataset_id}_citations.json").write_text(
+            json.dumps({"dataset_id": dataset_id, "num_citations": num})
+        )
+
+    def test_auto_detects_sibling_opencite_dir(self):
+        self._write(self.citations_dir, "ds000117", 75)
+        self._write(self.opencite_dir, "ds000117", 100)
+        agg = DataAggregator(
+            results_dir=self.results_dir, citations_dir=self.citations_dir
+        )
+        # Auto-detection picked up the sibling directory.
+        self.assertEqual(agg.citations_opencite_dir, self.opencite_dir)
+        summary = agg.summary_by_backend()
+        self.assertEqual(summary, {"ds000117": {"scholarly": 75, "opencite": 100}})
+
+    def test_dataset_only_in_opencite(self):
+        # ds-only-in-opencite is what we expect for nm-datasets that the
+        # legacy scholarly path never produced output for.
+        self._write(self.opencite_dir, "nm000103", 174)
+        agg = DataAggregator(
+            results_dir=self.results_dir,
+            citations_dir=self.citations_dir,
+            citations_opencite_dir=self.opencite_dir,
+        )
+        summary = agg.summary_by_backend()
+        self.assertEqual(summary["nm000103"], {"scholarly": 0, "opencite": 174})
+
+    def test_dataset_only_in_scholarly(self):
+        self._write(self.citations_dir, "ds002001", 5)
+        agg = DataAggregator(
+            results_dir=self.results_dir,
+            citations_dir=self.citations_dir,
+            citations_opencite_dir=self.opencite_dir,
+        )
+        summary = agg.summary_by_backend()
+        self.assertEqual(summary["ds002001"], {"scholarly": 5, "opencite": 0})
+
+    def test_explicit_opencite_dir_overrides_autodetect(self):
+        # Explicit param wins even when a sibling exists.
+        alt = Path(self.temp_dir) / "alt_opencite"
+        alt.mkdir()
+        self._write(alt, "ds000117", 42)
+        self._write(self.opencite_dir, "ds000117", 999)
+        agg = DataAggregator(
+            results_dir=self.results_dir,
+            citations_dir=self.citations_dir,
+            citations_opencite_dir=alt,
+        )
+        summary = agg.summary_by_backend()
+        self.assertEqual(summary["ds000117"]["opencite"], 42)


### PR DESCRIPTION
Closes #40.
Part of epic #37.

## Summary
Wires the Phase 2 building blocks (sources/, backends/) into a working pipeline behind a feature flag. The legacy scholarly path stays the default; opencite output is side-by-side in `citations/json_opencite/` so we can verify parity before Phase 4 retires scholarly.

## What's in the PR

### New modules
- \`src/dataset_citations/core/opencite_pipeline.py\` — \`fetch_dataset_citations_via_opencite(dataset_id)\` orchestrator. Source-prefix dispatch (nm vs ds), dedup across anchors by (DOI, normalized_title), schema-v2 output. Surfaces \`FetchError\` reasons in \`metadata.fetch_status\` so 'rate limited' is distinguishable from 'no citations'.
- \`core.citation_utils.add_discovery_provenance(...)\` helper marks citation JSONs with \`schema_version\`, \`discovery_backend\`, and per-citation \`discovery_backend\`. Opencite-path citations additionally carry \`source_doi\` and \`source_relation\` (one of References / IsDerivedFrom / IsIdenticalTo / IsVersionOf).

### CLI
- \`dataset-citations-update --backend opencite\` runs the new path end-to-end. Output: \`<output-dir>/json_opencite/<id>_citations.json\`. Default remains \`--backend scholarly\` (no behavior change for current automation).

### Dashboard aggregator
- \`DataAggregator(citations_opencite_dir=...)\` (auto-detects sibling \`citations/json_opencite/\` if not specified).
- \`DataAggregator.summary_by_backend()\` returns \`{dataset_id: {scholarly: N, opencite: M}}\` for side-by-side parity reporting. UI changes to render this are out of scope (separate follow-up).

### Tests (20 new, 50+11+9 still pass from earlier phases)
- \`test_core_opencite_pipeline.py\` — unit tests use a real \`OpenCiteBackend\` subclass returning hand-built FetchResult maps. Not Mock objects; satisfies the no-mocks rule.
- \`test_cli_update_backend.py\` — verifies the side-by-side dispatch writes to json_opencite/ without touching the legacy json/ tree.
- \`test_dashboard_aggregator.py\` extended with \`TestSummaryByBackend\` (auto-detect, dataset-only-in-opencite, dataset-only-in-scholarly, explicit-override-wins).
- Integration test for live opencite gated behind \`RUN_INTEGRATION_TESTS=1\`.

## Test plan
- [x] \`uv run pytest\` — all unit tests pass locally
- [x] \`uv run ruff format --check src/ tests/\` clean
- [x] \`uv run ruff check src/ tests/\` clean
- [x] CLI \`--help\` shows the new \`--backend\` flag
- [ ] CI green on this PR

## Out of scope (Phase 4 / follow-ups)
- Retiring scholarly + ScraperAPI — Phase 4 (#41).
- Dashboard UI changes to render side-by-side counts — follow-up after parity verification.
- Confidence scoring on opencite output — sentence-transformer pipeline reuse is a follow-up.
- Backfilling all 300+ datasets — separate ops issue once parity is validated.