### PR TITLE
fix: throttle opencite concurrency in CI to avoid Semantic Scholar 429s

### DIFF
--- a/.github/workflows/update_citations.yml
+++ b/.github/workflows/update_citations.yml
@@ -143,6 +143,12 @@ jobs:
           SEMANTIC_SCHOLAR_API_KEY: ${{ secrets.SEMANTIC_SCHOLAR_API_KEY }}
           OPENALEX_API_KEY: ${{ secrets.OPENALEX_API_KEY }}
           PUBMED_API_KEY: ${{ secrets.PUBMED_API_KEY }}
+          # Serialize anchor fan-out within each dataset; Semantic Scholar's
+          # free tier rate-limits to ~1 req/sec even with a key, and many
+          # ds-datasets share canonical anchor papers (e.g. PMID:25977808
+          # for the HBN family). Concurrency=4 (the in-code default) bursts
+          # the same seed lookup multiple times and 429s. Tracked in #49.
+          OPENCITE_CONCURRENCY: "1"
         run: |
           uv run dataset-citations-update \
             --dataset-list-file ${{ steps.discover.outputs.dataset_list_file }} \

--- a/src/dataset_citations/cli/update.py
+++ b/src/dataset_citations/cli/update.py
@@ -18,6 +18,7 @@ import json
 import logging
 import os
 
+from dataset_citations.backends import OpenCiteBackend
 from dataset_citations.core.opencite_pipeline import (
     fetch_dataset_citations_via_opencite,
 )
@@ -46,10 +47,21 @@ def run_opencite_backend(args: argparse.Namespace) -> None:
     with open(args.dataset_list_file, encoding="utf-8") as f:
         dataset_ids = [line.strip() for line in f if line.strip()]
 
+    # OPENCITE_CONCURRENCY caps the anchor fan-out inside one dataset. The CI
+    # workflow sets it to 1 to avoid Semantic Scholar 429s when canonical
+    # anchor papers are shared across datasets (issue #49). Construct ONE
+    # backend instance and pass it to every per-dataset call so the
+    # CitationExplorer session and rate-limit headers are reused.
+    try:
+        concurrency = max(1, int(os.environ.get("OPENCITE_CONCURRENCY", "4")))
+    except ValueError:
+        concurrency = 4
+    backend = OpenCiteBackend(concurrency=concurrency)
     logger.info(
-        "Running opencite backend for %d dataset(s) -> %s",
+        "Running opencite backend for %d dataset(s) -> %s (concurrency=%d)",
         len(dataset_ids),
         json_dir,
+        concurrency,
     )
 
     # Statuses that indicate a genuine API failure rather than legitimately
@@ -69,7 +81,7 @@ def run_opencite_backend(args: argparse.Namespace) -> None:
     write_failures = 0
     api_failures = 0
     for dataset_id in dataset_ids:
-        payload = fetch_dataset_citations_via_opencite(dataset_id)
+        payload = fetch_dataset_citations_via_opencite(dataset_id, backend=backend)
         filepath = os.path.join(json_dir, f"{dataset_id}_citations.json")
         try:
             with open(filepath, "w", encoding="utf-8") as f:


### PR DESCRIPTION
Closes #49.

## Diagnosis

The weekly cron's first opencite run (workflow #26029165830, cancelled) hit Semantic Scholar 429s within the first second of the Update step:

```
11:05:06.442  GET .../paper/PMID:25977808  -> 200 OK
11:05:07.290  GET .../paper/PMID:25977808  -> 429 (waiting 5s, attempt 1/3)
```

API keys ARE injected and attached as request headers (verified at `opencite/src/opencite/clients/semantic_scholar.py:73-74`). The 429 is a self-induced burst: `OpenCiteBackend.concurrency = 4` fans out 4 anchors simultaneously, and many ds-datasets share canonical anchor papers (PMID:25977808 is the Wakeman & Henson 2015 paper that anchors the HBN family). Semantic Scholar's free tier rate-limits to ~1 req/sec sustained even with an API key (the key adds reliability, not throughput).

## Fix

- `run_opencite_backend` reads `OPENCITE_CONCURRENCY` from the env (default 4) and constructs ONE `OpenCiteBackend` instance reused across every dataset call.
- Weekly cron workflow sets `OPENCITE_CONCURRENCY: "1"` so anchor lookups within a dataset are sequential.
- Local users can override by exporting a different value.

## Verification
- [x] `uv run ruff format/check` clean
- [x] `uv run pytest tests/test_cli_update_backend.py` -- 6 tests pass
- [ ] CI on this PR green
- [ ] Re-trigger workflow after merge and confirm no 429 / 5s-backoff lines in the Update log