### PR TITLE
docs: document nemar cross-repo contracts and fetch strategy

### DIFF
--- a/.context/architecture.md
+++ b/.context/architecture.md
@@ -1,68 +1,92 @@
 # System Architecture
 
-## Core Components
-
-### 1. Citation Fetching Pipeline
-- **Entry Point:** `dataset-citations-update` CLI command
-- **Core Module:** `src/dataset_citations/core/opencite_pipeline.py`, with DOI extractors in `src/dataset_citations/sources/` and the opencite adapter in `src/dataset_citations/backends/opencite_backend.py`
-- **Data Sources:** `.nemar/metadata.json` (nm datasets) and `dataset_description.json` (legacy ds datasets) provide DOI/PMID anchors; opencite then queries OpenAlex / Semantic Scholar / PubMed for papers citing each anchor.
-- **Output:** JSON files in `citations/json_opencite/` (schema v2) with citation details, source_doi/source_relation provenance, and discovery metadata.
-
-### 2. Confidence Scoring System
-- **Module:** `src/dataset_citations/quality/`
-- **Model:** Sentence-transformers with Qwen3-Embedding-0.6B
-- **Process:** Compares dataset metadata (from GitHub) with citation abstracts
-- **Threshold:** Confidence score ≥ 0.4 for inclusion in analysis
-
-### 3. Dashboard Generation
-- **Current:** Monolithic `create_interactive_reports.py` (3113 lines)
-- **Target:** Modular system with components:
-  - `dashboard/components/` - UI components
-  - `dashboard/data/` - Data aggregation
-  - `dashboard/templates/` - HTML templates
-  - `dashboard/core.py` - Orchestration
-
-### 4. Automation Workflow
-- **File:** `.github/workflows/update_citations.yml`
-- **Trigger:** Manual via workflow_dispatch
-- **Steps:**
-  1. Discover datasets
-  2. Fetch citations
-  3. Calculate confidence scores
-  4. Generate dashboards (BROKEN - needs fix)
-  5. Create PR with updates
-
-## Data Flow
+## Pipeline at a glance
 
 ```
-GitHub API (OpenNeuroDatasets, nemarDatasets)
-        ↓
-Dataset Discovery
-        ↓
-DOI extraction (.nemar/metadata.json | dataset_description.json)
-        ↓
-opencite (OpenAlex / Semantic Scholar / PubMed)
-        ↓
-Citation JSON files (citations/json_opencite/, schema v2)
-        ↓
-Confidence Scoring
-        ↓
-Dashboard Generation
-        ↓
-Interactive HTML Reports
+api.nemar.org/datasets  ─┐
+data.nemar.org/<id>/...  ─┤── Discovery + DOI extraction
+GitHub (ds-* fallback)   ─┘             │
+                                         ▼
+                  sources/nemar_metadata.py + bids_metadata.py
+                                         │  (DOI/PMID/arXiv with relation_type)
+                                         ▼
+                  backends/opencite_backend.py
+                       (OpenAlex / PubMed / S2*)
+                                         │
+                                         ▼
+                  core/opencite_pipeline.py
+                       (dedupe across anchors, schema v2)
+                                         │
+                                         ▼
+                  citations/json_opencite/*.json
+                                         │
+                                         ▼
+                  quality/  ── confidence scoring (sentence-transformers)
+                                         │
+                                         ▼
+                  analysis/  ── network / temporal / themes
+                                         │
+                                         ▼
+                  dashboard/  ── core.py → templates/nemar_simple.py
+                                         │
+                                         ▼
+                  dashboard.nemar.org/citations/  (Cloudflare Pages)
 ```
 
-## Key Directories
+\* S2 is a retirement candidate — see `.rules/cross_repo.md` and `.context/research.md`.
 
-- `citations/json_opencite/` - Citation data files (schema v2)
-- `datasets/` - Dataset metadata from GitHub
-- `interactive_reports/` - Generated dashboards
-- `embeddings/` - Semantic vectors for similarity
-- `tests/` - Test suite (needs expansion)
+## Core components
 
-## Current Problems
+### 1. Discovery + DOI extraction
+- **Primary source:** `https://api.nemar.org/datasets` (D1 catalog, no auth). Covers nm-* and on-* (NEMAR-imported OpenNeuro) IDs in one ~40KB response.
+- **Per-dataset metadata:** `https://data.nemar.org/<id>/metadata.json` for nm-* IDs.
+- **Legacy fallback:** GitHub REST against `OpenNeuroDatasets/` for ds-* IDs not yet in the D1 catalog (`cli/discover.py`).
+- **DOI parsers:**
+  - `src/dataset_citations/sources/nemar_metadata.py` — reads `.nemar/metadata.json` from each dataset repo's git tree; consumes `related_identifiers[]` with DataCite `relation_type` ∈ {`References`, `IsDerivedFrom`, `IsIdenticalTo`, `IsVersionOf`} and `identifier_type == "DOI"`.
+  - `src/dataset_citations/sources/bids_metadata.py` — reads `dataset_description.json` for legacy ds-* datasets.
 
-1. **Automation Broken:** Dashboard generation not integrated in workflow
-2. **Manual Process:** Dashboards created manually outside pipeline
-3. **Monolithic Code:** Dashboard module too large to maintain
-4. **No Test Data:** Need controlled test dataset for CI/CD
+### 2. Citation fetching
+- **Module:** `src/dataset_citations/backends/opencite_backend.py` (sync facade over opencite).
+- **Backends:** OpenAlex (primary), PubMed, Semantic Scholar (retirement candidate).
+- **Throttling:** `OPENCITE_MAX_CONCURRENCY` (CI sets to 1, see PR #50).
+- **Orchestrator:** `src/dataset_citations/core/opencite_pipeline.py` deduplicates across DOI anchors and writes schema-v2 JSON.
+
+### 3. Confidence scoring
+- **Module:** `src/dataset_citations/quality/`.
+- **Model:** sentence-transformers Qwen3-Embedding-0.6B (CPU-only in CI).
+- **Process:** Cosine similarity between dataset metadata (`datasets/<id>.json`) and citation abstracts.
+- **Threshold:** ≥ 0.4 surfaces in the dashboard's high-confidence view.
+
+### 4. Dashboard generation
+- **Entry point CLI:** `dataset-citations-create-reports` → `src/dataset_citations/cli/create_interactive_reports_modular.py`.
+- **Generator:** `src/dataset_citations/dashboard/core.py` (modularized; the legacy 3113-line `create_interactive_reports.py` is no longer the active entry point).
+- **Template:** `src/dataset_citations/dashboard/templates/nemar_simple.py` — overview / network / themes tabs.
+- **Components:** `src/dataset_citations/dashboard/components/` (modals, charts, etc.).
+- **Per-dataset uses/related panel:** **not yet implemented.** The modal at `dashboard/components/modals.py:105-140` currently splits citations only by confidence, not by `source_relation`. Adding a "uses vs related" view is a small, isolated change once `citations/json_opencite/` actually contains data.
+
+### 5. Automation workflow
+- **File:** `.github/workflows/update_citations.yml`.
+- **Triggers:** weekly cron (Sunday 06:00 UTC) + `workflow_dispatch`.
+- **Steps:** Discover → Update citations (opencite) → Score → Generate dashboard → Deploy to Cloudflare Pages → Open PR.
+- **Status as of May 18, 2026:** Workflow is correctly wired to opencite (post PR #47 / #50), but the most recent run (`26030534541`) was cancelled at the 6h GitHub Actions ceiling during the fetch step. Downstream steps (scoring, dashboard, deploy) never ran. The public dashboard therefore still shows January 2026 scholarly-format JSON.
+
+## Cross-repo data flow
+See `.rules/cross_repo.md` for the contract details. The short version:
+
+- `nemar-cli` (`api.nemar.org` + `data.nemar.org` + `.nemar/metadata.json` LLM enrichment) is **upstream of us** for dataset listing and DOI provenance.
+- `website` (`nemar.org`, Astro 6 SSR) does **not consume citation data today**; the dashboard remains the canonical surface at `dashboard.nemar.org/citations/`.
+
+## Key directories
+- `citations/json_opencite/` — current schema-v2 citation data (currently empty; see workflow status above).
+- `citations/json/` — legacy scholarly-format data from up to January 2026, read-only history.
+- `datasets/` — per-dataset metadata snapshots used for confidence scoring.
+- `embeddings/` — semantic vectors + registry.
+- `interactive_reports/` — generated dashboard artifacts (gitignored target; produced fresh each workflow run).
+- `tests/` — real-data tests (no mocks).
+
+## Open structural problems
+1. **Backfill timeout.** Full opencite fetch at `OPENCITE_MAX_CONCURRENCY=1` does not finish inside a 6h GitHub Actions job. Needs sharding (chunked discovery into multiple jobs) or a one-time local run that commits the seeded `citations/json_opencite/` tree.
+2. **S2 retirement.** Semantic Scholar throttling broke the last full run; need to verify OpenAlex coverage on a sample before flipping S2 off in opencite config.
+3. **GitHub rate-limit on discovery.** Migrate `cli/discover.py` to consume `api.nemar.org/datasets` as the primary catalog; keep GitHub only for legacy ds-* IDs.
+4. **Per-dataset uses/related view missing in dashboard.** Schema v2 already carries `source_relation`; renderer needs to group by it.
+5. **Citation endpoint on api.nemar.org.** Out of scope here, but a future integration with `nemar.org` per-dataset pages would require adding `GET /datasets/:id/citations.json` to `nemar-cli/backend/`.

--- a/.context/current_issues.md
+++ b/.context/current_issues.md
@@ -1,34 +1,52 @@
-# Current Open Issues (Priority Order)
+# Current Open Issues (priority order)
 
-## Issue #10: Revisit automation
-**Status:** OPEN
-**Priority:** CRITICAL - DO FIRST
-**Problem:** The pipeline was automated before but broke after adding JSON format and dashboard generation. Dashboard is currently generated manually.
-**Solution:** Add dashboard generation to workflow after confidence scoring. This MUST be fixed before we can test anything.
+_Last refreshed: 2026-05-18. Authoritative state comes from `gh issue list --state open`; the entries below add context that doesn't fit in an issue title._
 
-## Issue #12: Breakdown the dashboard-making function
-**Status:** OPEN
-**Priority:** HIGH - DO SECOND
-**Problem:** The dashboard-making function `src/dataset_citations/cli/create_interactive_reports.py` is too big (3113 lines), handling all dashboard aspects in one file.
-**Solution:** After automation works, modularize into separate components. Test each module as extracted.
+## CRITICAL: Backfill the opencite citation tree
+**Status:** OPEN (no single issue; tracked across #43, #48 and operational state).
+**Problem:** `citations/json_opencite/` is empty. The May 18 `workflow_dispatch` run (`26030534541`) was cancelled at the 6h GitHub Actions limit during the fetch step. The public dashboard at `dashboard.nemar.org/citations/` therefore still serves January 2026 scholarly-format data.
+**Solution path:**
+1. Shard discovery + fetch so each job finishes inside the 6h limit, OR run locally once with checkpointing and commit the seeded JSON tree.
+2. Address #48 (dataset citation vs methodology-paper citation) before the backfill; otherwise we re-fetch.
+3. Pin opencite version per #43.
 
-## Issue #11: Create a simple test and add CodeCov
-**Status:** OPEN
-**Priority:** MEDIUM - DO THIRD
-**Problem:** No comprehensive test infrastructure. Need tests with real data.
-**Solution:** After fixing automation and modularizing, create comprehensive test suite with controlled datasets. Target 75%+ coverage.
+## #48: Distinguish "cites the dataset" vs "cites the methodology paper"
+**Opened:** 2026-05-18. **Priority:** HIGH — blocks meaningful backfill.
+A citation that came from an `IsDerivedFrom` anchor (methodology paper, mirror DOI) should not be counted as "this paper uses the dataset". Schema v2 stores `source_relation` per citation; downstream rendering and scoring need to honor it.
 
-## Issue #5: Explore more robust Graph network visualizations
-**Status:** OPEN
-**Priority:** Low
-**Problem:** Current network visualizations could be improved with better libraries.
-**Solution:** Investigate D3.js, Sigma.js, or vis.js as alternatives to Cytoscape.
+## #43: Pin opencite version for Phase 2
+**Opened:** 2026-05-18. **Priority:** HIGH — blocks deterministic backfill.
+Settle on a release tag or commit SHA before running a full reindex, so future runs are reproducible.
 
-## Recently Closed Issues (Keep in Mind)
-- Issue #14: Dashboard modal data (CLOSED - but ensure new code maintains 20+ items)
-- Issue #9: Scrollable modal leaderboard (CLOSED)
-- Issue #8: Data modality pie chart (CLOSED)
-- Issue #6: Bar plot HTML rendering (CLOSED)
-- Issue #4: Add hyperlinks to datasets/citations (CLOSED)
-- Issue #3: Cumulative growth timeline (CLOSED)
-- Issue #1: Dashboard performance (CLOSED - reduced from 18MB to 106KB)
+## CRITICAL: Decide Semantic Scholar (S2) retirement
+**Status:** OPEN (no issue yet — open one).
+S2 throttling under opencite contributed to the May 18 timeout. Before retiring it, verify that OpenAlex covers the citations S2 currently surfaces uniquely (sample ~20 datasets). Document the diff in `.context/research.md`; retire via opencite config rather than a code fork. See `.rules/cross_repo.md` § Fetch Strategy.
+
+## CRITICAL: Migrate discovery to api.nemar.org
+**Status:** OPEN (no issue yet — open one; relates to #29 / #30).
+`cli/discover.py` paginates GitHub for both `nemarDatasets/` and `OpenNeuroDatasets/` and now hits rate limits on full reindex. `api.nemar.org/datasets` returns the full catalog (~40KB, no auth) including DOI, modalities, source. Switch the primary discovery path; keep GitHub only as ds-* fallback. See `.rules/cross_repo.md`.
+
+## HIGH: Render per-dataset uses/related panel in dashboard
+**Status:** OPEN (no issue yet — open one).
+`dashboard/components/modals.py:105-140` splits citations only by confidence. Schema v2 already carries `source_relation` ∈ {`References`, `IsDerivedFrom`, `IsIdenticalTo`, `IsVersionOf`}. Add a per-dataset panel grouped by relation type once the backfill lands. Small, isolated change.
+
+## #30: Expand citation search methodology beyond dataset IDs
+**Opened:** 2026-01-15. **Priority:** MEDIUM.
+Captured in part by the opencite pivot (anchors expanded to PMID, arXiv, related DOIs). Revisit after backfill to confirm coverage gains.
+
+## #29: Research alternative citation APIs (OpenAlex, S2, PubMed)
+**Opened:** 2026-01-15. **Priority:** MEDIUM.
+Largely answered by the opencite pivot (PR #47). Remaining work: document the OpenAlex-vs-S2 coverage comparison required to retire S2.
+
+## #27: Style suggestions for next dashboard iteration
+**Opened:** 2025-11-24. **Priority:** LOW.
+Visual polish; revisit after the uses/related panel ships.
+
+## #5: Explore richer graph network visualization libraries
+**Opened:** 2025-08-26. **Priority:** LOW.
+D3.js / Sigma.js / vis.js as alternatives to Cytoscape. Not blocking.
+
+## Historical references
+- **#10 (closed earlier):** "Revisit automation" — the workflow is now correctly wired to opencite (PR #47 + #50) but the timeout from the actual run is the live blocker. Don't conflate with the original code-integration problem.
+- **#12 (closed earlier):** "Break down the dashboard-making function" — modularization shipped; `create_interactive_reports.py` is no longer the active entry point.
+- **#11 (closed earlier):** "Simple test + CodeCov" — covered by the current `tests/` directory and `test.yml` workflow.

--- a/.rules/cross_repo.md
+++ b/.rules/cross_repo.md
@@ -18,7 +18,8 @@ Each NEMAR-managed dataset repo (`github.com/nemarDatasets/<id>/`) carries `.nem
 **DOI-bearing fields we consume:**
 - `related_identifiers[]` — array of `{ identifier, identifier_type, relation_type }`.
   - `identifier_type` accepted: `"DOI"` only (PMID / arXiv / URL / handle are skipped by the parser today; widen here if you start needing them).
-  - `relation_type` accepted: `References`, `IsDerivedFrom`, `IsIdenticalTo`, `IsVersionOf` — these are the DataCite kernel-4.6 values we surface in citation JSON as `source_relation`.
+  - `relation_type` accepted: `References`, `IsDerivedFrom`, `IsIdenticalTo`, `IsVersionOf`. These are the four DataCite kernel-4.6 values we surface in citation JSON as `source_relation`. The producer (`nemar-cli`) emits a wider set — `IsDescribedBy` and `IsSupplementedBy` also appear in real payloads but are deliberately filtered out by the parser today because they point at human-navigation targets (the GitHub repo, the NEMAR landing page) rather than citation-worthy works. Note: `IsDescribedBy` entries are sometimes DOI-typed and may carry arXiv preprints; widening the parser to include them is a known gap, not an oversight to leave silent.
+- The specific relation-type mix varies per dataset. Reference dataset `nm000104` carries `IsVersionOf`, `IsIdenticalTo`, and `IsDescribedBy` in its live payload; other datasets (e.g. `nm000103`) carry `References` and `IsDerivedFrom`. Don't assume all four accepted types are present on any single dataset.
 - OpenNeuro dataset DOIs are deduplicated; do not double-count when a dataset is mirrored under multiple IDs.
 
 **When producer and consumer drift:** treat as a contract break. Open issues in both repos; do not silently widen the parser to accept fields the producer doesn't yet emit.
@@ -28,8 +29,8 @@ Public, no token required for any of these. Routes are mounted by `nemar-cli/bac
 
 | URL | Returns | Use for |
 |---|---|---|
-| `GET https://api.nemar.org/datasets` | Full catalog as `{datasets: [...]}` (~40KB, nm-* and on-* IDs) with `dataset_id`, `doi`, `concept_doi`, `source`, `source_id`, `modalities`, `participants`, `tasks`, `github_repo` | **Primary discovery source.** Replaces GitHub-API pagination of `OpenNeuroDatasets/` + `nemarDatasets/`. |
-| `GET https://api.nemar.org/datasets/:id` | Single dataset metadata + version list | Per-dataset enrichment without cloning the repo. |
+| `GET https://api.nemar.org/datasets` | Full catalog as `{datasets: [...], count, total_count, limit, offset}` (~40KB at default limit, nm-* and on-* IDs). Per-row fields: `dataset_id`, `doi`, `concept_doi`, `source`, `source_id`, `modalities`, `participants`, `tasks`, `github_repo` | **Primary discovery source.** Replaces GitHub-API pagination of `OpenNeuroDatasets/` + `nemarDatasets/`. Use `offset` + `limit` to paginate. |
+| `GET https://api.nemar.org/datasets/:id` | Single dataset wrapped as `{"dataset": {...}}` (note the wrap; not the bare row shape returned by the list endpoint), including the version list. | Per-dataset enrichment without cloning the repo. |
 | `GET https://api.nemar.org/datasets/resolve/:sourceId` | nm-ID for a given OpenNeuro `ds*` ID | Mapping legacy ds-* to NEMAR-managed nm-*. |
 | `GET https://data.nemar.org/<id>/metadata.json` | Per-dataset neuroschema doc — includes `related_identifiers[]` with `{identifier, identifier_type, relation_type}` (DataCite values: `References`, `IsDerivedFrom`, `IsIdenticalTo`, `IsVersionOf`, `IsDescribedBy`, ...) | Per-dataset metadata + citation anchors for nm-* / on-* IDs. Legacy ds-* returns 404 here, fall back to GitHub. |
 | `GET https://data.nemar.org/<id>/<version>/manifest.json` | File-level BIDS manifest with presigned S3 URLs | Generally not needed for citations; reference for context. |
@@ -42,7 +43,7 @@ Path: `citations/json_opencite/<id>_citations.json`. Schema v2 (see `AGENTS.md` 
 Downstream consumers of this artifact should treat:
 - `metadata.schema_version` as the version gate. Bump it on any breaking shape change.
 - `metadata.discovery_backend == "opencite"` as confirmation of provenance. Legacy `"scholarly"` files (under `citations/json/`) are read-only history.
-- `citation_details[].source_doi` + `source_relation` as required fields — they tell the website which DOI anchor surfaced the citation and what kind of link it is (`References` = "uses this dataset"; `IsDerivedFrom` / `IsIdenticalTo` / `IsVersionOf` = "related work via the dataset's own DOI graph").
+- `citation_details[].source_doi` + `source_relation` as required fields; they tell the website which DOI anchor surfaced the citation and what kind of link it is (`References` = "uses this dataset"; `IsDerivedFrom` / `IsIdenticalTo` / `IsVersionOf` = "related work via the dataset's own DOI graph").
 
 ## Deploy targets
 - `dashboard.nemar.org/citations/` — Cloudflare Pages project `nemar-dashboard`. Canonical citation surface. Deployed from `.github/workflows/update_citations.yml` (and `deploy-dashboard.yml` for manual rebuilds).

--- a/.rules/cross_repo.md
+++ b/.rules/cross_repo.md
@@ -1,0 +1,85 @@
+# Cross-Repo Contracts (NEMAR triangle)
+
+This repo (`dataset_citations`) ships citation data and a dashboard. Two sibling repos jointly own the surrounding system; they live under `github.com/nemarOrg/` (locally: `/Users/yahya/Documents/git/nemar/`).
+
+| Repo | Surface | Role |
+|---|---|---|
+| `nemar-cli` | `api.nemar.org`, `data.nemar.org`, `.nemar/metadata.json` | Catalog + manifest + LLM enrichment |
+| `website` | `nemar.org` | Astro 6 SSR frontend |
+| `dataset_citations` (here) | `dashboard.nemar.org/citations/`, `citations/json_opencite/` | Citation discovery, scoring, dashboard |
+
+## The `.nemar/metadata.json` contract
+Each NEMAR-managed dataset repo (`github.com/nemarDatasets/<id>/`) carries `.nemar/metadata.json` at the root. This file is the authoritative DOI source for citation work.
+
+- **Schema:** `NemarMetadataV2` — defined in `nemar-cli/shared/datacite-constants.ts:160-185`.
+- **Producer:** `nemar-cli/backend/src/services/enrich-dataset.ts` (LLM enrichment job, committed via PR to the dataset repo).
+- **Consumer:** `src/dataset_citations/sources/nemar_metadata.py:83-125` (`parse_nemar_metadata()`).
+
+**DOI-bearing fields we consume:**
+- `related_identifiers[]` — array of `{ identifier, identifier_type, relation_type }`.
+  - `identifier_type` accepted: `"DOI"` only (PMID / arXiv / URL / handle are skipped by the parser today; widen here if you start needing them).
+  - `relation_type` accepted: `References`, `IsDerivedFrom`, `IsIdenticalTo`, `IsVersionOf` — these are the DataCite kernel-4.6 values we surface in citation JSON as `source_relation`.
+- OpenNeuro dataset DOIs are deduplicated; do not double-count when a dataset is mirrored under multiple IDs.
+
+**When producer and consumer drift:** treat as a contract break. Open issues in both repos; do not silently widen the parser to accept fields the producer doesn't yet emit.
+
+## api.nemar.org endpoints we depend on
+Public, no token required for any of these. Routes are mounted by `nemar-cli/backend/src/index.ts`; see `routes/datasets.ts` and `routes/data.ts` for handlers.
+
+| URL | Returns | Use for |
+|---|---|---|
+| `GET https://api.nemar.org/datasets` | Full catalog as `{datasets: [...]}` (~40KB, nm-* and on-* IDs) with `dataset_id`, `doi`, `concept_doi`, `source`, `source_id`, `modalities`, `participants`, `tasks`, `github_repo` | **Primary discovery source.** Replaces GitHub-API pagination of `OpenNeuroDatasets/` + `nemarDatasets/`. |
+| `GET https://api.nemar.org/datasets/:id` | Single dataset metadata + version list | Per-dataset enrichment without cloning the repo. |
+| `GET https://api.nemar.org/datasets/resolve/:sourceId` | nm-ID for a given OpenNeuro `ds*` ID | Mapping legacy ds-* to NEMAR-managed nm-*. |
+| `GET https://data.nemar.org/<id>/metadata.json` | Per-dataset neuroschema doc — includes `related_identifiers[]` with `{identifier, identifier_type, relation_type}` (DataCite values: `References`, `IsDerivedFrom`, `IsIdenticalTo`, `IsVersionOf`, `IsDescribedBy`, ...) | Per-dataset metadata + citation anchors for nm-* / on-* IDs. Legacy ds-* returns 404 here, fall back to GitHub. |
+| `GET https://data.nemar.org/<id>/<version>/manifest.json` | File-level BIDS manifest with presigned S3 URLs | Generally not needed for citations; reference for context. |
+
+There is **no citations endpoint** on the backend today. We do not publish citation JSON back into the D1 catalog. If/when we do, the natural shape is `GET /datasets/:id/citations.json` returning the schema-v2 payload — coordinate with `nemar-cli/backend/src/routes/`.
+
+## Citation JSON contract (we produce)
+Path: `citations/json_opencite/<id>_citations.json`. Schema v2 (see `AGENTS.md` § Key Data Formats).
+
+Downstream consumers of this artifact should treat:
+- `metadata.schema_version` as the version gate. Bump it on any breaking shape change.
+- `metadata.discovery_backend == "opencite"` as confirmation of provenance. Legacy `"scholarly"` files (under `citations/json/`) are read-only history.
+- `citation_details[].source_doi` + `source_relation` as required fields — they tell the website which DOI anchor surfaced the citation and what kind of link it is (`References` = "uses this dataset"; `IsDerivedFrom` / `IsIdenticalTo` / `IsVersionOf` = "related work via the dataset's own DOI graph").
+
+## Deploy targets
+- `dashboard.nemar.org/citations/` — Cloudflare Pages project `nemar-dashboard`. Canonical citation surface. Deployed from `.github/workflows/update_citations.yml` (and `deploy-dashboard.yml` for manual rebuilds).
+- `nemar.org` — Cloudflare Pages project owned by `nemar/website`. Does not embed citation data today.
+- `api.nemar.org` / `data.nemar.org` — Cloudflare Worker owned by `nemar/nemar-cli/backend/`.
+
+## Fetch strategy & rate-limit posture
+Two of our upstreams have throttled us in production: GitHub (on full-catalog discovery) and Semantic Scholar (on `cited_by` lookups). Default to the NEMAR backend; treat third-party APIs as scarce.
+
+### Dataset / DOI discovery — order of preference
+1. **`api.nemar.org/datasets`** — primary. One request gets the full catalog with DOIs.
+2. **`data.nemar.org/<id>/metadata.json`** — secondary, when you need richer per-dataset metadata than the catalog row.
+3. **Local checkout** at `/Users/yahya/Documents/git/nemar/<repo>/` — development / offline.
+4. **GitHub REST** — fallback only, for legacy `ds-*` IDs not yet ingested into the D1 catalog. Use a token; respect `X-RateLimit-Remaining`.
+
+### Citation backends inside opencite — order of preference
+1. **OpenAlex** — free, no key required. Set `OPENALEX_API_KEY` to enter the politeness pool. Most reliable for `cited_by(DOI)`. Treat as primary.
+2. **PubMed** (NCBI E-utilities) — free, 3 req/s without API key, 10 with. Use for PMID anchors and biomedical-only coverage.
+3. **Semantic Scholar (S2)** — **retirement candidate.** Throttles aggressively without an enterprise key; frequent 429s broke our last full backfill. Before flipping it off:
+   - Verify OpenAlex coverage on a sample of ~20 datasets that S2 currently surfaces unique citations for.
+   - Log the diff in `.context/research.md`.
+   - Retire via opencite config (env var or backend selection), not a code fork.
+
+### Guardrails (already partly in code; keep enforced)
+- `OPENCITE_MAX_CONCURRENCY` — env var, CI sets to 1 (PR #50). Don't raise in CI without sharding.
+- Per-anchor checkpointing — persist partial progress; resume rather than refetch on retry.
+- Sharded backfill — split discovery+fetch into chunks small enough to finish inside a single GitHub Actions job (≤6h). Full catalog at concurrency=1 does **not** fit.
+- Batch git operations — don't commit per dataset; one commit per shard, one PR per run.
+- Cache the catalog response locally during a CI run; don't refetch `api.nemar.org/datasets` between steps.
+
+## Where the website is *today* vs. where this might go
+Today: `website/src/lib/data-api.ts` SSR-fetches from `data.nemar.org` and `api.nemar.org` per request; nothing pulls from `dataset_citations`. The dashboard is a standalone link.
+
+If/when citations are surfaced inside `nemar.org` per-dataset pages, the integration path is:
+1. Publish `citations/json_opencite/<id>.json` to a known CDN URL (likely behind `data.nemar.org/<id>/citations.json` via the worker, or directly to a Pages route).
+2. Add `getCitations(id)` to `website/src/lib/data-api.ts` mirroring `getMetadata()` / `getManifest()`.
+3. Render a per-dataset panel that splits citations by `source_relation` (uses vs related).
+4. Schema gate via `metadata.schema_version`.
+
+The reverse direction — the website **producing** anything we consume — is not currently in scope.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,9 +1,24 @@
 # NEMAR Citations Instructions
 
 ## Project Context
-**Purpose:** Automated Brain Imaging Data Structure (BIDS) dataset citation tracking system for the NEMAR.org project. Discovers and tracks citations for 300+ neuroscience datasets from OpenNeuro and NEMAR, scores them with AI confidence, and renders an interactive dashboard hosted at `dashboard.nemar.org/citations/`.
+**Purpose:** Automated Brain Imaging Data Structure (BIDS) dataset citation tracking system for the NEMAR.org project. Discovers and tracks citations for ~594 neuroscience datasets (the live `api.nemar.org/datasets` total as of 2026-05-18) from OpenNeuro and NEMAR, scores them with AI confidence, and renders an interactive dashboard hosted at `dashboard.nemar.org/citations/`.
 **Tech Stack:** Python 3.13+, UV, Ruff, Ty, pytest, sentence-transformers, opencite (OpenAlex / Semantic Scholar / PubMed aggregator), PyGithub, Cloudflare Pages.
 **Architecture:** CLI-first package (`dataset_citations.*`) with discovery → DOI extraction → opencite lookup → scoring → analysis → dashboard pipeline. Automated via GitHub Actions.
+
+## Related Repositories
+Three sibling repos jointly produce the public NEMAR surface. They live under `/Users/yahya/Documents/git/nemar/` locally and under `github.com/nemarOrg/` remotely.
+
+| Repo | Path (local) | Role |
+|---|---|---|
+| `nemar-cli` | `../nemar/nemar-cli/` | Bun CLI for BIDS dataset upload/version/DOI. Cloudflare Worker backend serves `api.nemar.org` (D1 catalog) + `data.nemar.org` (S3-backed BIDS view). LLM enrichment writes `.nemar/metadata.json` into each dataset repo. |
+| `website` | `../nemar/website/` | Astro 6 SSR frontend for `nemar.org`, deployed to Cloudflare Pages. SSR reads dataset metadata at request time from `api.nemar.org` and `data.nemar.org`. No build-time data bundling. |
+| `dataset_citations` (this repo) | `../dataset_citations/` | Citation discovery, scoring, analysis, and dashboard. Reads `.nemar/metadata.json` for DOIs; publishes `citations/json_opencite/` and the dashboard at `dashboard.nemar.org/citations/`. |
+
+**Cross-repo contracts** (details: `.rules/cross_repo.md`):
+- `.nemar/metadata.json` schema (`NemarMetadataV2`) — producer: `nemar-cli/backend/src/services/enrich-dataset.ts`; consumer: `src/dataset_citations/sources/nemar_metadata.py`. Authoritative DOI source via `related_identifiers[]` with DataCite relation types.
+- `https://api.nemar.org/datasets` — public, no auth, returns full catalog (nm-* and on-* IDs). Preferred over GitHub API for discovery.
+- `https://data.nemar.org/<id>/metadata.json` — per-dataset neuroschema. Live for `nm-*` IDs; legacy `ds-*` still requires GitHub-based discovery.
+- Citation publishing back to the website is **not wired yet** — there is no `/datasets/:id/citations` endpoint and the website does not embed citation JSON. The canonical surface stays at `dashboard.nemar.org/citations/`. Adding a citations endpoint would be a `nemar-cli` backend change.
 
 ## Architecture Map
 ```
@@ -112,13 +127,33 @@ uv run dataset-citations-score-confidence --citations-dir citations/json_opencit
 ```
 
 ## Data Flow
-1. **Discovery**: Find BIDS datasets via GitHub API (`cli/discover.py`).
-2. **DOI extraction**: `sources/nemar_metadata.py` reads `.nemar/metadata.json` for nm-datasets; `sources/bids_metadata.py` reads `dataset_description.json` for legacy ds-datasets. Returns DOI/PMID/arXiv anchors with relation types (`References`, `IsDerivedFrom`, `IsIdenticalTo`, `IsVersionOf`).
-3. **Citation fetching**: `backends/opencite_backend.py` (sync facade over opencite) queries OpenAlex / Semantic Scholar / PubMed for papers citing each anchor.
+1. **Discovery**: Prefer `https://api.nemar.org/datasets` (D1 catalog, no auth, ~40KB for the full list of 594 datasets) for both nm-* and on-* (NEMAR-imported OpenNeuro) IDs. One request gives every dataset's `dataset_id`, `doi`, `concept_doi`, `source`, `source_id`, `github_repo`, and modality/task/author metadata. Legacy ds-* IDs not yet in the catalog still come from GitHub via `cli/discover.py`.
+2. **DOI extraction**: For nm-* / on-* — fetch `https://data.nemar.org/<id>/metadata.json` (the same neuroschema doc the worker generates from `.nemar/metadata.json` + D1 enrichment) and parse `related_identifiers[]` via `sources/nemar_metadata.py`. Confirmed shape: `{ identifier, identifier_type, relation_type }` with DataCite relation values. For legacy ds-* — fall back to `dataset_description.json` via `sources/bids_metadata.py`. The dataset's **own** DOI (from the catalog `doi` field) is also a citation anchor with `relation_type = References`. Relation types we consume: `References`, `IsDerivedFrom`, `IsIdenticalTo`, `IsVersionOf`.
+3. **Citation fetching**: `backends/opencite_backend.py` (sync facade over opencite) queries OpenAlex / Semantic Scholar / PubMed for papers citing each anchor. Concurrency throttled by `OPENCITE_MAX_CONCURRENCY` (CI sets to 1, see PR #50).
 4. **Processing**: `core/opencite_pipeline.py` deduplicates across anchors and produces schema-v2 citation JSON.
 5. **Quality scoring**: sentence-transformer similarity between dataset metadata and citation abstract.
 6. **Analysis**: network, temporal, and theme analyses with embeddings.
-7. **Dashboard**: interactive HTML + D3 deployed to Cloudflare Pages.
+7. **Dashboard**: interactive HTML + D3 deployed to Cloudflare Pages at `dashboard.nemar.org/citations/`.
+
+## Fetch Strategy & Rate Limits
+Both upstream sources we depend on have throttled us in production. Treat external APIs as scarce; cache, retry, and prefer the NEMAR backend.
+
+**Order of preference for dataset / DOI discovery:**
+1. `api.nemar.org/datasets` (D1, public, generous limits — primary).
+2. `data.nemar.org/<id>/metadata.json` (S3-backed, nm-* IDs only today — secondary).
+3. GitHub API on `nemarDatasets/` and `OpenNeuroDatasets/` (`GITHUB_TOKEN`, 5000/hr, hits ceiling on full reindex — fallback only).
+4. Local checkout under `~/Documents/git/nemar/` for development (offline).
+
+**Order of preference for citation backends inside opencite:**
+1. **OpenAlex** — free, no key required but `OPENALEX_API_KEY` raises politeness pool. Most reliable for `cited_by` queries against DOIs. Treat as primary.
+2. **PubMed** — free, NLM E-utilities limit (3 req/sec without API key, 10 with). Use for PMID anchors.
+3. **Semantic Scholar (S2)** — currently in opencite but **retirement candidate**: heavy throttling without enterprise key, frequent 429s on `paper/cited_by`. Document the decision in `.context/research.md` before flipping the switch; remove via opencite config rather than a code fork.
+
+**Guardrails to keep in code (not aspirational — already partially in place):**
+- Respect `OPENCITE_MAX_CONCURRENCY` and `OPENCITE_RATE_LIMIT_*` env vars in the backend facade.
+- Persist partial progress per anchor; resume on next invocation rather than refetch.
+- Shard discovery and fetch into chunks that fit GitHub Actions' 6h job limit (the May-18 full-catalog run was cancelled at 6h with concurrency=1).
+- Avoid push-on-every-dataset; batch commits to the auto-update branch.
 
 ## Key Data Formats
 - **Citation JSON** (`citations/json_opencite/`), the canonical output. Schema v2: top-level `dataset_id`, `num_citations`, `date_last_updated`, `citation_details[]`, `metadata.{schema_version="2.0", discovery_backend="opencite", fetch_status, anchor_count, anchor_errors, ...}`; per-citation `source_doi` + `source_relation` (one of `References`, `IsDerivedFrom`, `IsIdenticalTo`, `IsVersionOf`).
@@ -137,6 +172,9 @@ uv run dataset-citations-score-confidence --citations-dir citations/json_opencit
 - `.rules/ci_cd.md` — GitHub Actions setup
 - `.rules/git.md` — Branch + commit conventions
 
+### Cross-Repo
+- `.rules/cross_repo.md` — Contracts with `nemar-cli` and `website`; fetch strategy; rate-limit posture
+
 ### MCP Tools
 - `.rules/serena_mcp.md` — Code intelligence with Serena MCP
 
@@ -154,7 +192,8 @@ uv run dataset-citations-score-confidence --citations-dir citations/json_opencit
 - `.github/workflows/test.yml` — Lint (ruff format/check, ty), pytest 3.13, integration tests
 - `.github/workflows/update_citations.yml`: weekly cron (Sunday 06:00 UTC) plus `workflow_dispatch`. Fetches citations via opencite, regenerates the dashboard, deploys to Cloudflare Pages, opens PR.
 - `.github/workflows/deploy-dashboard.yml` — Manual rebuild + deploy
-- Required secrets: `GITHUB_TOKEN`, `CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ACCOUNT_ID`. Optional: `SEMANTIC_SCHOLAR_API_KEY`, `OPENALEX_API_KEY` for opencite rate-limit relief.
+- Required secrets: `GITHUB_TOKEN`, `CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ACCOUNT_ID`. Optional: `OPENALEX_API_KEY` (politeness pool), `SEMANTIC_SCHOLAR_API_KEY` (only while S2 is still wired in opencite — see retirement note in Fetch Strategy).
+- Known blocker (May 2026): the full opencite backfill has not yet produced data; `citations/json_opencite/` is empty and the public dashboard still shows January 2026 scholarly-format JSON. Last `workflow_dispatch` run (`26030534541`) was cancelled at the 6h GitHub Actions ceiling during the fetch step. Resolve before relying on cron output.
 
 ## Project-Specific Guidelines
 - **Domain:** NEMAR / OpenNeuro / BIDS / Hierarchical Event Descriptors (HED)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,4 +16,23 @@ The shared project instructions live in `AGENTS.md`; this file imports them for 
 ### Plan mode
 Use `/plan` before non-trivial implementations; align on the approach before changing files.
 
+### Cross-repo work (NEMAR triangle)
+This repo is one of three sibling repos that jointly produce the public NEMAR surface. The contracts are in `.rules/cross_repo.md`; here is the Claude-specific procedural guidance.
+
+- **Sibling repos exist locally**, but **not at `../`** relative to this repo. They are at:
+  - `/Users/yahya/Documents/git/nemar/website/` (Astro 6 SSR for `nemar.org`)
+  - `/Users/yahya/Documents/git/nemar/nemar-cli/` (Bun CLI + Cloudflare Worker backend for `api.nemar.org` and `data.nemar.org`)
+- When the user says "the website" or "nemar-cli", they mean those paths. Don't assume sibling layout.
+- **Before claiming a route or schema exists, verify it.** The live API is the ground truth, not stale docs:
+  - `curl -s "https://api.nemar.org/datasets?limit=2"` — confirms catalog availability and shape.
+  - `curl -s "https://data.nemar.org/<id>/metadata.json"` — works for `nm-*` IDs, returns 404 for legacy `ds-*`.
+- **Don't edit sibling repos from this session unless explicitly asked.** Cross-repo changes (e.g., adding a citations endpoint to `nemar-cli/backend/`) need their own branch + PR in the target repo and should be raised as an issue here first.
+- **When reading sibling code**, prefer `Explore` agent over `grep` for breadth — the relevant files span TypeScript + Python and naming conventions differ. Already-validated entry points: `nemar-cli/backend/src/routes/data.ts`, `nemar-cli/backend/src/routes/datasets.ts`, `nemar-cli/shared/datacite-constants.ts`, `website/src/lib/data-api.ts`.
+
+### Rate-limit posture (Claude-facing)
+GitHub and Semantic Scholar both throttled us during the May 2026 backfill. Operational rules in `.rules/cross_repo.md` § Fetch Strategy. Claude-specific:
+- **Don't kick the cron** during interactive sessions to "see what happens" — the workflow uses real opencite calls and costs us our rate-limit budget. Trigger only when you have a fix to verify.
+- **Prefer reading `api.nemar.org/datasets` once and caching** the JSON to disk for the session over repeated requests.
+- **For background investigations**, use `Explore` / `general-purpose` agents with explicit tool budgets rather than open-ended scraping.
+
 Keep cross-agent project rules in `AGENTS.md` so Codex, Copilot, Cursor, and other AGENTS.md-aware tools stay aligned. Append only Claude-specific plugin / skill / command / MCP guidance below.


### PR DESCRIPTION
Documentation-only PR that captures how this repo now relates to the sibling repos under `github.com/nemarOrg/`:

- `nemar-cli` — serves `api.nemar.org` (D1 catalog) and `data.nemar.org` (per-dataset neuroschema). LLM enrichment writes `.nemar/metadata.json` into each dataset repo.
- `website` — Astro 6 SSR for `nemar.org`. Does not embed citation data today; the canonical citation surface remains `dashboard.nemar.org/citations/`.

## Changes
- **AGENTS.md**: new Related Repositories section, Data Flow now prefers `api.nemar.org/datasets` over GitHub pagination, new Fetch Strategy & Rate Limits section documenting OpenAlex-first / S2-retirement-candidate stance and CI guardrails.
- **.rules/cross_repo.md** (new): NemarMetadataV2 contract (producer + consumer, file:line), live api.nemar.org / data.nemar.org endpoint table with confirmed shapes, citation JSON contract, deploy targets, ordered backend preferences.
- **.context/architecture.md**: rewritten around the current opencite-only pipeline and the operational backfill-timeout blocker.
- **.context/current_issues.md**: refreshed against `gh issue list --state open`; flags backfill timeout, S2 retirement, and discovery migration as CRITICAL.
- **CLAUDE.md**: Claude-only additions (sibling repo paths are not `../`, verify live API via curl, no-edit-sibling-repos-from-this-session rule).

## Why now
The May 18 backfill run (`26030534541`) was cancelled at the 6h GitHub Actions limit. Three follow-up issues (#51, #52, #53) are queued to fix the underlying fetch strategy. This PR pins down the contract documentation those issues depend on, so reviewers and future contributors have a shared map.

## Verification
All live URLs in the new docs were probed before being written:
- `curl https://api.nemar.org/datasets?limit=2` → 200, expected schema (594 datasets total).
- `curl https://data.nemar.org/nm000104/metadata.json` → 200, includes `related_identifiers[]` with DataCite relation types.
- `curl https://data.nemar.org/ds002718/metadata.json` → 404 (documented as ds-* fallback case).

## Test plan
- [ ] Reviewer scans AGENTS.md / .rules/cross_repo.md for technical accuracy
- [ ] No CI implications (docs-only)

Refs #51 #52 #53