### PR TITLE
feat(cli): wire update.py to catalog DOI + checkpoint resume

### DIFF
--- a/.github/workflows/update_citations.yml
+++ b/.github/workflows/update_citations.yml
@@ -128,10 +128,17 @@ jobs:
       - name: Discover relevant datasets
         id: discover
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Or a specific PAT if needed
+          # GITHUB_TOKEN is only used by the legacy --source github fallback;
+          # the default --source catalog path is unauthenticated against
+          # api.nemar.org/datasets.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          echo "Discovering relevant datasets..."
-          uv run dataset-citations-discover --output-file discovered_datasets.txt
+          echo "Discovering relevant datasets via api.nemar.org/datasets..."
+          # --source catalog: one paginated call to the NEMAR D1 catalog,
+          # no GitHub rate-limit pressure. Per #51.
+          uv run dataset-citations-discover \
+            --source catalog \
+            --output-file discovered_datasets.txt
           echo "dataset_list_file=discovered_datasets.txt" >> $GITHUB_OUTPUT
 
       - name: Update citation information

--- a/src/dataset_citations/cli/update.py
+++ b/src/dataset_citations/cli/update.py
@@ -17,16 +17,48 @@ import argparse
 import json
 import logging
 import os
+from pathlib import Path
 
 from dataset_citations.backends import OpenCiteBackend
 from dataset_citations.core.opencite_pipeline import (
     fetch_dataset_citations_via_opencite,
 )
+from dataset_citations.sources.models import FetchSuccess
+from dataset_citations.sources.nemar_catalog import get_or_fetch_catalog
 
 logging.basicConfig(
     level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
 )
 logger = logging.getLogger(__name__)
+
+
+def _load_catalog_doi_map(
+    cache_path: Path | None, max_age_seconds: int
+) -> dict[str, str]:
+    """Return a {dataset_id: catalog_doi} map for catalog-indexed datasets.
+
+    The catalog is fetched from `api.nemar.org/datasets` (or reused from the
+    shared cache populated by the discover step earlier in the same workflow
+    run). DOIs are normalized to lowercase to match the opencite anchor
+    convention. Empty / missing entries are omitted: a missing catalog DOI
+    is not an error; the pipeline simply doesn't seed an extra anchor for
+    that dataset.
+
+    On fetch failure we log and return an empty map rather than aborting:
+    the rest of the pipeline still produces citation JSON from the source-
+    derived anchors. The catalog DOI is purely additive.
+    """
+    result = get_or_fetch_catalog(
+        cache_path=cache_path, max_age_seconds=max_age_seconds
+    )
+    if not isinstance(result, FetchSuccess):
+        logger.warning(
+            "could not load catalog (%s): %s; proceeding without catalog DOIs",
+            result.reason,
+            result.detail,
+        )
+        return {}
+    return {row.dataset_id: row.doi.lower() for row in result.value if row.doi}
 
 
 def run_opencite_backend(args: argparse.Namespace) -> None:
@@ -57,11 +89,20 @@ def run_opencite_backend(args: argparse.Namespace) -> None:
     except ValueError:
         concurrency = 4
     backend = OpenCiteBackend(concurrency=concurrency)
+
+    # Load the catalog once so each dataset can be seeded with its own
+    # NEMAR-minted DOI as an additional opencite anchor. The catalog cache
+    # is shared with the discover step in the same workflow run, so this
+    # is typically a no-op disk read; the explicit fetch is a safety net
+    # for when update.py is invoked outside the workflow.
+    catalog_dois = _load_catalog_doi_map(args.catalog_cache, args.catalog_cache_max_age)
     logger.info(
-        "Running opencite backend for %d dataset(s) -> %s (concurrency=%d)",
+        "Running opencite backend for %d dataset(s) -> %s "
+        "(concurrency=%d, catalog rows known=%d)",
         len(dataset_ids),
         json_dir,
         concurrency,
+        len(catalog_dois),
     )
 
     # Statuses that indicate a genuine API failure rather than legitimately
@@ -81,7 +122,12 @@ def run_opencite_backend(args: argparse.Namespace) -> None:
     write_failures = 0
     api_failures = 0
     for dataset_id in dataset_ids:
-        payload = fetch_dataset_citations_via_opencite(dataset_id, backend=backend)
+        payload = fetch_dataset_citations_via_opencite(
+            dataset_id,
+            backend=backend,
+            catalog_doi=catalog_dois.get(dataset_id),
+            use_checkpoint=True,
+        )
         filepath = os.path.join(json_dir, f"{dataset_id}_citations.json")
         try:
             with open(filepath, "w", encoding="utf-8") as f:
@@ -138,6 +184,22 @@ def main():
         "--output-dir",
         default="citations",
         help="Directory to save output files (default: citations/).",
+    )
+    parser.add_argument(
+        "--catalog-cache",
+        type=Path,
+        default=Path.home() / ".cache" / "dataset_citations" / "catalog.json",
+        help=(
+            "Path to a cached api.nemar.org/datasets response. Shared with "
+            "dataset-citations-discover so the catalog is fetched once per "
+            "workflow run."
+        ),
+    )
+    parser.add_argument(
+        "--catalog-cache-max-age",
+        type=int,
+        default=3600,
+        help="Seconds before the catalog cache is considered stale (default: 3600).",
     )
 
     args = parser.parse_args()

--- a/src/dataset_citations/cli/update.py
+++ b/src/dataset_citations/cli/update.py
@@ -23,6 +23,7 @@ from dataset_citations.backends import OpenCiteBackend
 from dataset_citations.core.opencite_pipeline import (
     fetch_dataset_citations_via_opencite,
 )
+from dataset_citations.sources.doi import normalize_doi
 from dataset_citations.sources.models import FetchSuccess
 from dataset_citations.sources.nemar_catalog import get_or_fetch_catalog
 
@@ -39,10 +40,11 @@ def _load_catalog_doi_map(
 
     The catalog is fetched from `api.nemar.org/datasets` (or reused from the
     shared cache populated by the discover step earlier in the same workflow
-    run). DOIs are normalized to lowercase to match the opencite anchor
-    convention. Empty / missing entries are omitted: a missing catalog DOI
-    is not an error; the pipeline simply doesn't seed an extra anchor for
-    that dataset.
+    run). DOIs are run through `normalize_doi` (lowercased + prefix-stripped)
+    so the map values match what the pipeline's `_merge_anchors` produces
+    when deduping anchors. Empty / missing entries are omitted: a missing
+    catalog DOI is not an error; the pipeline simply doesn't seed an extra
+    anchor for that dataset.
 
     On fetch failure we log and return an empty map rather than aborting:
     the rest of the pipeline still produces citation JSON from the source-
@@ -58,7 +60,7 @@ def _load_catalog_doi_map(
             result.detail,
         )
         return {}
-    return {row.dataset_id: row.doi.lower() for row in result.value if row.doi}
+    return {row.dataset_id: normalize_doi(row.doi) for row in result.value if row.doi}
 
 
 def run_opencite_backend(args: argparse.Namespace) -> None:

--- a/tests/test_cli_update_backend.py
+++ b/tests/test_cli_update_backend.py
@@ -6,6 +6,7 @@ matching the project's "no Mock objects" rule.
 
 from __future__ import annotations
 
+import argparse
 import io
 import json
 import sys
@@ -15,6 +16,46 @@ from pathlib import Path
 from unittest import TestCase
 
 from dataset_citations.cli import update as cli_update
+
+
+def _make_args(
+    list_file: Path,
+    out_dir: str,
+    *,
+    catalog_doi_map: dict[str, str] | None = None,
+) -> argparse.Namespace:
+    """Build the argparse.Namespace `run_opencite_backend` expects.
+
+    Writes an empty catalog cache so `_load_catalog_doi_map` returns an
+    empty map without hitting the network. Pass `catalog_doi_map` to
+    inject a non-empty mapping for tests that exercise catalog-DOI
+    seeding.
+    """
+    cache_path = Path(out_dir) / "catalog.json"
+    if catalog_doi_map:
+        rows = [
+            {
+                "dataset_id": did,
+                "doi": doi,
+                "concept_doi": doi,
+                "source": "openneuro" if did.startswith(("ds", "on")) else "nemar",
+                "source_id": None,
+                "github_repo": f"nemarDatasets/{did}",
+                "modalities": "eeg",
+                "name": None,
+                "visibility": "public",
+            }
+            for did, doi in catalog_doi_map.items()
+        ]
+        cache_path.write_text(json.dumps(rows))
+    else:
+        cache_path.write_text("[]")
+    return argparse.Namespace(
+        dataset_list_file=str(list_file),
+        output_dir=out_dir,
+        catalog_cache=cache_path,
+        catalog_cache_max_age=3600,
+    )
 
 
 class CliParserTests(TestCase):
@@ -74,15 +115,10 @@ class RunOpenciteBackendTests(TestCase):
     """Direct tests for run_opencite_backend's write/dispatch behavior."""
 
     def test_unsupported_prefix_still_writes_stub(self) -> None:
-        import argparse
-
         with tempfile.TemporaryDirectory() as out_dir:
             list_file = Path(out_dir) / "list.txt"
             list_file.write_text("xx123\n")
-            args = argparse.Namespace(
-                dataset_list_file=str(list_file),
-                output_dir=out_dir,
-            )
+            args = _make_args(list_file, out_dir)
             cli_update.run_opencite_backend(args)
             stub = Path(out_dir) / "json_opencite" / "xx123_citations.json"
             self.assertTrue(stub.exists())
@@ -99,8 +135,6 @@ class RunOpenciteBackendTests(TestCase):
         proceed silently and downstream steps would regenerate empty CSVs.
         Substitute the pipeline call with a recording function via setattr.
         """
-        import argparse
-
         from dataset_citations.cli import update as cli_module
 
         with tempfile.TemporaryDirectory() as out_dir:
@@ -122,10 +156,7 @@ class RunOpenciteBackendTests(TestCase):
 
             original = cli_module.fetch_dataset_citations_via_opencite
             cli_module.fetch_dataset_citations_via_opencite = stub_pipeline  # type: ignore[assignment]
-            args = argparse.Namespace(
-                dataset_list_file=str(list_file),
-                output_dir=out_dir,
-            )
+            args = _make_args(list_file, out_dir)
             try:
                 with self.assertRaises(SystemExit) as ctx:
                     cli_update.run_opencite_backend(args)
@@ -137,8 +168,6 @@ class RunOpenciteBackendTests(TestCase):
         """A run where every dataset legitimately has no DOI references
         should NOT exit non-zero; that's a normal outcome (e.g., new nm
         datasets without metadata.json yet)."""
-        import argparse
-
         from dataset_citations.cli import update as cli_module
 
         with tempfile.TemporaryDirectory() as out_dir:
@@ -160,10 +189,7 @@ class RunOpenciteBackendTests(TestCase):
 
             original = cli_module.fetch_dataset_citations_via_opencite
             cli_module.fetch_dataset_citations_via_opencite = stub_pipeline  # type: ignore[assignment]
-            args = argparse.Namespace(
-                dataset_list_file=str(list_file),
-                output_dir=out_dir,
-            )
+            args = _make_args(list_file, out_dir)
             try:
                 # Should return normally, no SystemExit.
                 cli_update.run_opencite_backend(args)
@@ -177,7 +203,6 @@ class RunOpenciteBackendTests(TestCase):
         read-only after run_opencite_backend creates it. We re-enter the
         function with the directory already in place but non-writable.
         """
-        import argparse
         import os
         import stat
 
@@ -190,10 +215,7 @@ class RunOpenciteBackendTests(TestCase):
             json_dir = Path(out_dir) / "json_opencite"
             json_dir.mkdir()
             os.chmod(json_dir, stat.S_IRUSR | stat.S_IXUSR)
-            args = argparse.Namespace(
-                dataset_list_file=str(list_file),
-                output_dir=out_dir,
-            )
+            args = _make_args(list_file, out_dir)
             try:
                 with self.assertRaises(SystemExit) as ctx:
                     cli_update.run_opencite_backend(args)
@@ -201,3 +223,52 @@ class RunOpenciteBackendTests(TestCase):
             finally:
                 # Restore write perm so tempfile cleanup works.
                 os.chmod(json_dir, stat.S_IRWXU)
+
+
+class CatalogDoiWiringTests(TestCase):
+    """run_opencite_backend forwards catalog_doi + use_checkpoint=True to
+    the pipeline. Substitutes the pipeline call to record arguments."""
+
+    def test_catalog_doi_and_checkpoint_forwarded(self) -> None:
+        from dataset_citations.cli import update as cli_module
+
+        with tempfile.TemporaryDirectory() as out_dir:
+            list_file = Path(out_dir) / "list.txt"
+            list_file.write_text("nm000104\nnm000999\n")
+
+            captured: list[dict] = []
+
+            def stub_pipeline(dataset_id, **kwargs):
+                captured.append({"dataset_id": dataset_id, **kwargs})
+                return {
+                    "dataset_id": dataset_id,
+                    "num_citations": 0,
+                    "date_last_updated": "2026-01-01T00:00:00",
+                    "metadata": {
+                        "schema_version": "2.0",
+                        "discovery_backend": "opencite",
+                        "fetch_status": "no_doi_references",
+                    },
+                    "citation_details": [],
+                }
+
+            original = cli_module.fetch_dataset_citations_via_opencite
+            cli_module.fetch_dataset_citations_via_opencite = stub_pipeline  # type: ignore[assignment]
+            args = _make_args(
+                list_file,
+                out_dir,
+                catalog_doi_map={"nm000104": "10.82901/nemar.nm000104"},
+            )
+            try:
+                cli_update.run_opencite_backend(args)
+            finally:
+                cli_module.fetch_dataset_citations_via_opencite = original  # type: ignore[assignment]
+
+            self.assertEqual(len(captured), 2)
+            # nm000104 was in the catalog -> catalog_doi forwarded.
+            self.assertEqual(captured[0]["catalog_doi"], "10.82901/nemar.nm000104")
+            # nm000999 was NOT in the catalog -> catalog_doi=None.
+            self.assertIsNone(captured[1]["catalog_doi"])
+            # Both calls opt in to checkpoint resume.
+            self.assertTrue(captured[0]["use_checkpoint"])
+            self.assertTrue(captured[1]["use_checkpoint"])


### PR DESCRIPTION
Closes #64. Folds in the workflow-level \`--source catalog\` change so the discover step's intent is obvious in the file. Targets the dashboard-running goal.

## What it does
The pipeline already supported catalog-DOI seeding and per-anchor checkpoint resume after PR #58; this PR wires the production CLI (\`cli/update.py\`) and the cron workflow to actually use them.

1. **Catalog DOI seeding.** \`run_opencite_backend\` loads the catalog once (sharing the disk cache with \`dataset-citations-discover\`) and forwards each dataset's NEMAR-minted DOI to the pipeline as an extra \`References\` anchor.
2. **Checkpoint resume.** Every per-dataset call now sets \`use_checkpoint=True\`, so a run cancelled at the 6h Actions ceiling can resume from the unfetched anchors instead of refetching from scratch.
3. **Workflow explicit-source.** Discover step now passes \`--source catalog\` explicitly. The default since #51 was catalog; making it explicit prevents quiet drift.

## Why now
This is the last wiring step between the new infrastructure (catalog + data.nemar.org + checkpoint + S2 prefix filter + max_retries=1) and a successful cron-driven dashboard rebuild. With this PR merged, a fresh \`workflow_dispatch\` should:
- Discover via \`api.nemar.org/datasets\` (no GitHub pagination)
- Fetch DOI anchors via \`data.nemar.org/<id>/metadata.json\` (no GitHub git-tree reads)
- Skip S2 for known-404 DOI families (\`10.82901/nemar.*\`, \`10.5281/zenodo.*\`, \`10.13026/*\`)
- Retry once instead of three times on transient 429s
- Persist per-anchor progress so the next run picks up where this one left off
- Seed each dataset's own DOI as an extra anchor for cited-by lookups

## Failure handling
A catalog-fetch failure is logged and treated as \"no catalog DOIs to seed\" rather than a fatal. The source-derived anchors still flow through, so a transient \`api.nemar.org\` blip degrades gracefully instead of zeroing a run.

## Tests
- New \`CatalogDoiWiringTests\` substitutes the pipeline call (no-mock setattr pattern already used elsewhere in this file) and verifies:
  - \`catalog_doi\` from a known map is forwarded for matching dataset_ids
  - \`catalog_doi=None\` for dataset_ids absent from the catalog
  - \`use_checkpoint=True\` is forwarded for every call
- Existing 6 tests still pass after the Namespace helper refactor (\`_make_args\`) which writes an empty catalog cache to avoid network calls.

## Verification
- \`uv run ruff format\` + \`ruff check\` — clean
- \`uv run ty check src/dataset_citations/cli/update.py\` — clean
- \`uv run pytest\` — **161 passed, 21 skipped** (all skips are pre-existing integration/slow gates)

## Test plan
- [x] Unit tests for catalog-DOI forwarding + checkpoint opt-in
- [x] Existing CLI tests still pass with the new args
- [x] Full suite passes
- [ ] Reviewer scans \`_load_catalog_doi_map\` failure semantics
- [ ] Reviewer confirms the workflow \`--source catalog\` change matches intent
- [ ] Reviewer signs off so we can fire \`workflow_dispatch\` for the dashboard rebuild