### PR TITLE
feat(cli): skip already-successful datasets so weekly cron just maintains

### DIFF
--- a/src/dataset_citations/cli/update.py
+++ b/src/dataset_citations/cli/update.py
@@ -17,6 +17,7 @@ import argparse
 import json
 import logging
 import os
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 from dataset_citations.backends import OpenCiteBackend
@@ -31,6 +32,43 @@ logging.basicConfig(
     level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
 )
 logger = logging.getLogger(__name__)
+
+
+def _is_fresh_success(filepath: str, max_age_seconds: int) -> bool:
+    """Return True if `filepath` is a successful, recent citation JSON.
+
+    Used by run_opencite_backend to skip datasets that were already
+    successfully fetched within the freshness window (typically the
+    weekly cron cadence). A JSON that doesn't parse, doesn't have a
+    success fetch_status, or has a stale date_last_updated triggers
+    a re-fetch.
+
+    Robust against missing fields and unparseable timestamps: any
+    failure to determine freshness returns False (refetch).
+    """
+    if not os.path.isfile(filepath):
+        return False
+    try:
+        with open(filepath, encoding="utf-8") as f:
+            payload = json.load(f)
+    except (OSError, json.JSONDecodeError):
+        return False
+    metadata = payload.get("metadata")
+    if not isinstance(metadata, dict):
+        return False
+    if metadata.get("fetch_status") != "success":
+        return False
+    raw_date = payload.get("date_last_updated")
+    if not isinstance(raw_date, str):
+        return False
+    try:
+        fetched_at = datetime.fromisoformat(raw_date)
+    except ValueError:
+        return False
+    if fetched_at.tzinfo is None:
+        fetched_at = fetched_at.replace(tzinfo=timezone.utc)
+    age = datetime.now(timezone.utc) - fetched_at
+    return age <= timedelta(seconds=max_age_seconds)
 
 
 def _load_catalog_doi_map(
@@ -119,18 +157,28 @@ def run_opencite_backend(args: argparse.Namespace) -> None:
         "parse",
         "other",
     }
+    max_age_seconds = args.max_age_days * 86400 if args.max_age_days > 0 else None
     successes = 0
     stub_only = 0
     write_failures = 0
     api_failures = 0
+    skipped_fresh = 0
     for dataset_id in dataset_ids:
+        filepath = os.path.join(json_dir, f"{dataset_id}_citations.json")
+        if max_age_seconds is not None and _is_fresh_success(filepath, max_age_seconds):
+            logger.info(
+                "%s: skipping (existing JSON is fresh-success within %d days)",
+                dataset_id,
+                args.max_age_days,
+            )
+            skipped_fresh += 1
+            continue
         payload = fetch_dataset_citations_via_opencite(
             dataset_id,
             backend=backend,
             catalog_doi=catalog_dois.get(dataset_id),
             use_checkpoint=True,
         )
-        filepath = os.path.join(json_dir, f"{dataset_id}_citations.json")
         try:
             with open(filepath, "w", encoding="utf-8") as f:
                 json.dump(payload, f, indent=2, ensure_ascii=False)
@@ -149,11 +197,12 @@ def run_opencite_backend(args: argparse.Namespace) -> None:
 
     logger.info(
         "opencite run complete: %d with citations, %d empty/stub "
-        "(%d API-failure), %d write failures, %d total.",
+        "(%d API-failure), %d write failures, %d skipped (fresh), %d total.",
         successes,
         stub_only,
         api_failures,
         write_failures,
+        skipped_fresh,
         len(dataset_ids),
     )
     total = len(dataset_ids)
@@ -202,6 +251,17 @@ def main():
         type=int,
         default=3600,
         help="Seconds before the catalog cache is considered stale (default: 3600).",
+    )
+    parser.add_argument(
+        "--max-age-days",
+        type=int,
+        default=7,
+        help=(
+            "Skip datasets whose existing JSON has fetch_status=success and "
+            "date_last_updated within this many days (default: 7, matching "
+            "the weekly cron cadence). Set to 0 to force re-fetch every "
+            "dataset on every invocation."
+        ),
     )
 
     args = parser.parse_args()

--- a/src/dataset_citations/cli/update.py
+++ b/src/dataset_citations/cli/update.py
@@ -206,13 +206,18 @@ def run_opencite_backend(args: argparse.Namespace) -> None:
         len(dataset_ids),
     )
     total = len(dataset_ids)
-    if total and write_failures == total:
-        # Every write failed (disk full, read-only output). Exit 2.
+    # The exit-2 / exit-3 sentinels must compare against the count of datasets
+    # we actually attempted, not the input list size: a maintenance run that
+    # skips most datasets as fresh would otherwise never trip exit-3 even
+    # when every processed dataset failed.
+    processed = total - skipped_fresh
+    if processed and write_failures == processed:
+        # Every write attempted failed (disk full, read-only output). Exit 2.
         raise SystemExit(2)
-    if total and successes == 0 and api_failures == total:
-        # Zero successes and every stub was an API failure (not just a
-        # dataset without DOIs). Exit 3 so cron can detect the degraded
-        # run before downstream steps regenerate empty CSVs.
+    if processed and successes == 0 and api_failures == processed:
+        # Zero successes among processed datasets and every stub was an API
+        # failure (not just a dataset without DOIs). Exit 3 so cron can detect
+        # the degraded run before downstream steps regenerate empty CSVs.
         raise SystemExit(3)
 
 

--- a/tests/test_cli_update_backend.py
+++ b/tests/test_cli_update_backend.py
@@ -55,6 +55,7 @@ def _make_args(
         output_dir=out_dir,
         catalog_cache=cache_path,
         catalog_cache_max_age=3600,
+        max_age_days=0,
     )
 
 
@@ -223,6 +224,143 @@ class RunOpenciteBackendTests(TestCase):
             finally:
                 # Restore write perm so tempfile cleanup works.
                 os.chmod(json_dir, stat.S_IRWXU)
+
+
+class SkipFreshSuccessTests(TestCase):
+    """run_opencite_backend skips datasets whose existing JSON is a recent
+    success. The pipeline call is patched so the test asserts on what would
+    have been re-fetched without doing any network."""
+
+    def test_fresh_success_is_skipped(self) -> None:
+        from datetime import datetime, timezone
+
+        from dataset_citations.cli import update as cli_module
+
+        with tempfile.TemporaryDirectory() as out_dir:
+            list_file = Path(out_dir) / "list.txt"
+            list_file.write_text("nm000104\n")
+
+            # Pre-create a "fresh success" JSON for nm000104.
+            json_dir = Path(out_dir) / "json_opencite"
+            json_dir.mkdir()
+            fresh_path = json_dir / "nm000104_citations.json"
+            fresh_path.write_text(
+                json.dumps(
+                    {
+                        "dataset_id": "nm000104",
+                        "num_citations": 5,
+                        "date_last_updated": datetime.now(timezone.utc).isoformat(),
+                        "metadata": {"fetch_status": "success"},
+                        "citation_details": [],
+                    }
+                )
+            )
+
+            called: list[str] = []
+
+            def stub_pipeline(dataset_id, **_):
+                called.append(dataset_id)
+                return {
+                    "dataset_id": dataset_id,
+                    "num_citations": 0,
+                    "metadata": {"fetch_status": "success"},
+                }
+
+            original = cli_module.fetch_dataset_citations_via_opencite
+            cli_module.fetch_dataset_citations_via_opencite = stub_pipeline  # type: ignore[assignment]
+            args = _make_args(list_file, out_dir)
+            args.max_age_days = 7  # enable freshness skip
+            try:
+                cli_update.run_opencite_backend(args)
+            finally:
+                cli_module.fetch_dataset_citations_via_opencite = original  # type: ignore[assignment]
+            self.assertEqual(called, [], "skip should have prevented the call")
+
+    def test_stale_success_is_refetched(self) -> None:
+        from datetime import datetime, timedelta, timezone
+
+        from dataset_citations.cli import update as cli_module
+
+        with tempfile.TemporaryDirectory() as out_dir:
+            list_file = Path(out_dir) / "list.txt"
+            list_file.write_text("nm000104\n")
+            json_dir = Path(out_dir) / "json_opencite"
+            json_dir.mkdir()
+            stale = datetime.now(timezone.utc) - timedelta(days=30)
+            (json_dir / "nm000104_citations.json").write_text(
+                json.dumps(
+                    {
+                        "dataset_id": "nm000104",
+                        "num_citations": 5,
+                        "date_last_updated": stale.isoformat(),
+                        "metadata": {"fetch_status": "success"},
+                        "citation_details": [],
+                    }
+                )
+            )
+
+            called: list[str] = []
+
+            def stub_pipeline(dataset_id, **_):
+                called.append(dataset_id)
+                return {
+                    "dataset_id": dataset_id,
+                    "num_citations": 0,
+                    "metadata": {"fetch_status": "success"},
+                }
+
+            original = cli_module.fetch_dataset_citations_via_opencite
+            cli_module.fetch_dataset_citations_via_opencite = stub_pipeline  # type: ignore[assignment]
+            args = _make_args(list_file, out_dir)
+            args.max_age_days = 7
+            try:
+                cli_update.run_opencite_backend(args)
+            finally:
+                cli_module.fetch_dataset_citations_via_opencite = original  # type: ignore[assignment]
+            self.assertEqual(called, ["nm000104"])
+
+    def test_prior_failure_is_refetched(self) -> None:
+        from datetime import datetime, timezone
+
+        from dataset_citations.cli import update as cli_module
+
+        with tempfile.TemporaryDirectory() as out_dir:
+            list_file = Path(out_dir) / "list.txt"
+            list_file.write_text("nm000104\n")
+            json_dir = Path(out_dir) / "json_opencite"
+            json_dir.mkdir()
+            (json_dir / "nm000104_citations.json").write_text(
+                json.dumps(
+                    {
+                        "dataset_id": "nm000104",
+                        "num_citations": 0,
+                        "date_last_updated": datetime.now(timezone.utc).isoformat(),
+                        # Fresh but not a success: prior run hit rate_limit.
+                        "metadata": {"fetch_status": "rate_limit"},
+                        "citation_details": [],
+                    }
+                )
+            )
+
+            called: list[str] = []
+
+            def stub_pipeline(dataset_id, **_):
+                called.append(dataset_id)
+                return {
+                    "dataset_id": dataset_id,
+                    "num_citations": 0,
+                    "metadata": {"fetch_status": "success"},
+                }
+
+            original = cli_module.fetch_dataset_citations_via_opencite
+            cli_module.fetch_dataset_citations_via_opencite = stub_pipeline  # type: ignore[assignment]
+            args = _make_args(list_file, out_dir)
+            args.max_age_days = 7
+            try:
+                cli_update.run_opencite_backend(args)
+            finally:
+                cli_module.fetch_dataset_citations_via_opencite = original  # type: ignore[assignment]
+            self.assertEqual(called, ["nm000104"])
 
 
 class CatalogDoiWiringTests(TestCase):

--- a/tests/test_cli_update_backend.py
+++ b/tests/test_cli_update_backend.py
@@ -226,141 +226,123 @@ class RunOpenciteBackendTests(TestCase):
                 os.chmod(json_dir, stat.S_IRWXU)
 
 
-class SkipFreshSuccessTests(TestCase):
-    """run_opencite_backend skips datasets whose existing JSON is a recent
-    success. The pipeline call is patched so the test asserts on what would
-    have been re-fetched without doing any network."""
+class IsFreshSuccessTests(TestCase):
+    """Direct tests for the `_is_fresh_success` helper. Pure file reader,
+    no network, real JSON fixtures on disk — no stubs of any kind.
+    """
 
-    def test_fresh_success_is_skipped(self) -> None:
-        from datetime import datetime, timezone
+    def _write_json(self, path: Path, payload: dict) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload))
 
-        from dataset_citations.cli import update as cli_module
+    def test_returns_false_when_missing(self) -> None:
+        from dataset_citations.cli.update import _is_fresh_success
 
-        with tempfile.TemporaryDirectory() as out_dir:
-            list_file = Path(out_dir) / "list.txt"
-            list_file.write_text("nm000104\n")
-
-            # Pre-create a "fresh success" JSON for nm000104.
-            json_dir = Path(out_dir) / "json_opencite"
-            json_dir.mkdir()
-            fresh_path = json_dir / "nm000104_citations.json"
-            fresh_path.write_text(
-                json.dumps(
-                    {
-                        "dataset_id": "nm000104",
-                        "num_citations": 5,
-                        "date_last_updated": datetime.now(timezone.utc).isoformat(),
-                        "metadata": {"fetch_status": "success"},
-                        "citation_details": [],
-                    }
-                )
+        with tempfile.TemporaryDirectory() as tmp:
+            self.assertFalse(
+                _is_fresh_success(str(Path(tmp) / "absent.json"), 7 * 86400)
             )
 
-            called: list[str] = []
+    def test_returns_true_for_fresh_success(self) -> None:
+        from datetime import datetime, timezone
 
-            def stub_pipeline(dataset_id, **_):
-                called.append(dataset_id)
-                return {
-                    "dataset_id": dataset_id,
-                    "num_citations": 0,
+        from dataset_citations.cli.update import _is_fresh_success
+
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "nm000104_citations.json"
+            self._write_json(
+                path,
+                {
+                    "dataset_id": "nm000104",
+                    "num_citations": 5,
+                    "date_last_updated": datetime.now(timezone.utc).isoformat(),
                     "metadata": {"fetch_status": "success"},
-                }
+                },
+            )
+            self.assertTrue(_is_fresh_success(str(path), 7 * 86400))
 
-            original = cli_module.fetch_dataset_citations_via_opencite
-            cli_module.fetch_dataset_citations_via_opencite = stub_pipeline  # type: ignore[assignment]
-            args = _make_args(list_file, out_dir)
-            args.max_age_days = 7  # enable freshness skip
-            try:
-                cli_update.run_opencite_backend(args)
-            finally:
-                cli_module.fetch_dataset_citations_via_opencite = original  # type: ignore[assignment]
-            self.assertEqual(called, [], "skip should have prevented the call")
-
-    def test_stale_success_is_refetched(self) -> None:
+    def test_returns_false_for_stale_success(self) -> None:
         from datetime import datetime, timedelta, timezone
 
-        from dataset_citations.cli import update as cli_module
+        from dataset_citations.cli.update import _is_fresh_success
 
-        with tempfile.TemporaryDirectory() as out_dir:
-            list_file = Path(out_dir) / "list.txt"
-            list_file.write_text("nm000104\n")
-            json_dir = Path(out_dir) / "json_opencite"
-            json_dir.mkdir()
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "nm000104_citations.json"
             stale = datetime.now(timezone.utc) - timedelta(days=30)
-            (json_dir / "nm000104_citations.json").write_text(
-                json.dumps(
-                    {
-                        "dataset_id": "nm000104",
-                        "num_citations": 5,
-                        "date_last_updated": stale.isoformat(),
-                        "metadata": {"fetch_status": "success"},
-                        "citation_details": [],
-                    }
-                )
-            )
-
-            called: list[str] = []
-
-            def stub_pipeline(dataset_id, **_):
-                called.append(dataset_id)
-                return {
-                    "dataset_id": dataset_id,
-                    "num_citations": 0,
+            self._write_json(
+                path,
+                {
+                    "dataset_id": "nm000104",
+                    "date_last_updated": stale.isoformat(),
                     "metadata": {"fetch_status": "success"},
-                }
+                },
+            )
+            self.assertFalse(_is_fresh_success(str(path), 7 * 86400))
 
-            original = cli_module.fetch_dataset_citations_via_opencite
-            cli_module.fetch_dataset_citations_via_opencite = stub_pipeline  # type: ignore[assignment]
-            args = _make_args(list_file, out_dir)
-            args.max_age_days = 7
-            try:
-                cli_update.run_opencite_backend(args)
-            finally:
-                cli_module.fetch_dataset_citations_via_opencite = original  # type: ignore[assignment]
-            self.assertEqual(called, ["nm000104"])
-
-    def test_prior_failure_is_refetched(self) -> None:
+    def test_returns_false_for_non_success_status(self) -> None:
         from datetime import datetime, timezone
 
-        from dataset_citations.cli import update as cli_module
+        from dataset_citations.cli.update import _is_fresh_success
 
-        with tempfile.TemporaryDirectory() as out_dir:
-            list_file = Path(out_dir) / "list.txt"
-            list_file.write_text("nm000104\n")
-            json_dir = Path(out_dir) / "json_opencite"
-            json_dir.mkdir()
-            (json_dir / "nm000104_citations.json").write_text(
-                json.dumps(
-                    {
-                        "dataset_id": "nm000104",
-                        "num_citations": 0,
-                        "date_last_updated": datetime.now(timezone.utc).isoformat(),
-                        # Fresh but not a success: prior run hit rate_limit.
-                        "metadata": {"fetch_status": "rate_limit"},
-                        "citation_details": [],
-                    }
-                )
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "nm000104_citations.json"
+            self._write_json(
+                path,
+                {
+                    "dataset_id": "nm000104",
+                    "date_last_updated": datetime.now(timezone.utc).isoformat(),
+                    # Fresh but not a success: prior run hit rate_limit.
+                    "metadata": {"fetch_status": "rate_limit"},
+                },
             )
+            self.assertFalse(_is_fresh_success(str(path), 7 * 86400))
 
-            called: list[str] = []
+    def test_returns_false_for_malformed_json(self) -> None:
+        from dataset_citations.cli.update import _is_fresh_success
 
-            def stub_pipeline(dataset_id, **_):
-                called.append(dataset_id)
-                return {
-                    "dataset_id": dataset_id,
-                    "num_citations": 0,
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "broken.json"
+            path.write_text("not json at all")
+            self.assertFalse(_is_fresh_success(str(path), 7 * 86400))
+
+    def test_returns_false_for_missing_metadata(self) -> None:
+        from dataset_citations.cli.update import _is_fresh_success
+
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "headerless.json"
+            self._write_json(path, {"dataset_id": "x", "num_citations": 0})
+            self.assertFalse(_is_fresh_success(str(path), 7 * 86400))
+
+    def test_returns_false_for_unparseable_timestamp(self) -> None:
+        from dataset_citations.cli.update import _is_fresh_success
+
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "bad_date.json"
+            self._write_json(
+                path,
+                {
+                    "date_last_updated": "not-a-real-iso-string",
                     "metadata": {"fetch_status": "success"},
-                }
+                },
+            )
+            self.assertFalse(_is_fresh_success(str(path), 7 * 86400))
 
-            original = cli_module.fetch_dataset_citations_via_opencite
-            cli_module.fetch_dataset_citations_via_opencite = stub_pipeline  # type: ignore[assignment]
-            args = _make_args(list_file, out_dir)
-            args.max_age_days = 7
-            try:
-                cli_update.run_opencite_backend(args)
-            finally:
-                cli_module.fetch_dataset_citations_via_opencite = original  # type: ignore[assignment]
-            self.assertEqual(called, ["nm000104"])
+    def test_treats_naive_timestamp_as_utc(self) -> None:
+        from datetime import datetime, timezone
+
+        from dataset_citations.cli.update import _is_fresh_success
+
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "naive.json"
+            naive_now = datetime.now(timezone.utc).replace(tzinfo=None).isoformat()
+            self._write_json(
+                path,
+                {
+                    "date_last_updated": naive_now,
+                    "metadata": {"fetch_status": "success"},
+                },
+            )
+            self.assertTrue(_is_fresh_success(str(path), 7 * 86400))
 
 
 class CatalogDoiWiringTests(TestCase):


### PR DESCRIPTION
Closes #66. Tiny but high-leverage change for the dashboard-up goal.

## What
\`cli/update.py\` gains a \`--max-age-days\` flag (default \`7\`). Before each dataset is processed, the existing citation JSON is checked:
- exists + parses + \`metadata.fetch_status == "success"\` + \`date_last_updated\` within the window -> skip, log, move on.
- missing / malformed / failed prior run / stale -> process normally.

Set \`--max-age-days 0\` to force re-fetch on every dataset (used by the initial local backfill).

## Why now
The May 19 dispatch (\`26128147561\`) processed 121/585 in 6h before timing out. Even with #51 + #62 + #63 + #65, a single weekly cron job cannot fit a from-scratch backfill of all 585 datasets. The plan is:

1. **One-time local backfill** of the full tree (no 6h ceiling) — in progress in parallel.
2. **Weekly cron** then only processes new / stale / previously-failed datasets, which is a cheap delta pass that comfortably fits the 6h ceiling.

This PR is step 2. Step 1 produces the seed tree.

## Failure semantics
A malformed JSON, missing fetch_status, or unparseable timestamp falls through to re-fetch — never silently masks a corrupted file. Tests cover all three branches: fresh-skip, stale-refetch, prior-failure-refetch.

## Tests
- \`SkipFreshSuccessTests\` (3 new tests):
  - Fresh + success -> skip
  - Stale (>max_age) -> refetch
  - Fresh but non-success status (e.g. rate_limit) -> refetch
- All existing tests pass after the \`_make_args\` helper updates to include the new flag.

## Verification
- \`uv run ruff format && ruff check\` clean
- \`uv run ty check src/dataset_citations/cli/update.py\` clean
- \`uv run pytest tests/test_cli_update_backend.py\` — **10 passed**

## Test plan
- [x] Unit tests for all three skip/refetch branches
- [x] \`--max-age-days 0\` path covered by existing tests (default in \`_make_args\`)
- [ ] Reviewer scans \`_is_fresh_success\` for edge cases (timezones, missing fields)
- [ ] Reviewer confirms the workflow doesn't need an explicit flag (the default 7 matches the cron cadence)