### PR TITLE
fix(workflow): point deploy-dashboard.yml at citations/json_opencite

### DIFF
--- a/.github/workflows/deploy-dashboard.yml
+++ b/.github/workflows/deploy-dashboard.yml
@@ -30,17 +30,17 @@ jobs:
 
           echo "Generating theme analysis..."
           uv run python -m dataset_citations.analysis.generate_themes \
-            --citations-dir citations/json \
+            --citations-dir citations/json_opencite \
             --output-dir dashboard_data/themes || echo "Theme generation had issues"
 
           echo "Generating network analysis..."
           uv run python -m dataset_citations.analysis.generate_network \
-            --citations-dir citations/json \
+            --citations-dir citations/json_opencite \
             --output-dir dashboard_data/network || echo "Network analysis had issues"
 
           echo "Generating temporal analysis..."
           uv run python -m dataset_citations.analysis.generate_temporal \
-            --citations-dir citations/json \
+            --citations-dir citations/json_opencite \
             --output-dir dashboard_data/temporal || echo "Temporal analysis had issues"
 
           echo "Building dashboard..."
@@ -50,7 +50,7 @@ jobs:
           gen = DashboardGenerator(
               results_dir=Path('dashboard_data'),
               output_dir=Path('interactive_reports'),
-              citations_dir=Path('citations/json'),
+              citations_dir=Path('citations/json_opencite'),
           )
           output_path = gen.generate_dashboard(dashboard_type='nemar', lazy_load=True)
           print(f'Dashboard generated: {output_path}')


### PR DESCRIPTION
Closes #68. One-line-per-occurrence rename across four references in \`.github/workflows/deploy-dashboard.yml\`.

## Why
\`deploy-dashboard.yml\` was still referencing \`citations/json\` — the legacy scholarly tree, frozen at January 2026. The opencite pivot (PR #47, merged) moved the canonical output to \`citations/json_opencite/\`, and \`update_citations.yml\` already uses the right path. The manual deploy workflow was missed.

Result: triggering a manual deploy would have rebuilt the dashboard from stale Jan-2026 data. Caught while preparing to deploy the new opencite-backed dashboard.

## Files
- \`.github/workflows/deploy-dashboard.yml\` — four \`--citations-dir\` / \`citations_dir=Path(...)\` references updated to match \`update_citations.yml\`.

## Verification
- \`grep "citations/json" .github/workflows/deploy-dashboard.yml\` — no matches remaining for the legacy path.
- No code or test impact.

## Test plan
- [x] grep confirms no remaining legacy path references
- [ ] Reviewer confirms paths match \`update_citations.yml\` (lines 281 / 287 / 298 / 303 + 311 inline)