### PR TITLE
fix(metadata): route nm/on to nemarDatasets + add github timeout

### DIFF
--- a/src/dataset_citations/quality/dataset_metadata.py
+++ b/src/dataset_citations/quality/dataset_metadata.py
@@ -3,7 +3,16 @@
 Dataset metadata retrieval from GitHub API.
 
 This module retrieves dataset metadata (dataset_description.json and README files)
-from the OpenNeuro GitHub repository for confidence scoring.
+from the dataset's GitHub repository for confidence scoring.
+
+The org each dataset lives in depends on its prefix:
+  ds-* -> github.com/OpenNeuroDatasets/<id>  (legacy OpenNeuro tree)
+  nm-* -> github.com/nemarDatasets/<id>      (NEMAR-native datasets)
+  on-* -> github.com/nemarDatasets/<id>      (OpenNeuro datasets imported into NEMAR)
+
+Before this fix the org was hardcoded to OpenNeuroDatasets, which made
+nm-* / on-* lookups 404 and PyGithub's default infinite socket timeout
+turned a single bad lookup into a multi-hour CLOSE_WAIT stall.
 
 Copyright (c) 2025 Seyed Yahya Shirazi (neuromechanist)
 All rights reserved.
@@ -24,6 +33,21 @@ from github.GithubException import GithubException
 
 logger = logging.getLogger(__name__)
 
+# Bound every GitHub call so a dropped socket can't hang the pipeline.
+# PyGithub forwards this to urllib3; the default is no timeout.
+_GITHUB_TIMEOUT_SECONDS = 30
+
+
+def _org_for_dataset(dataset_id: str) -> str:
+    """Return the GitHub org that hosts the given dataset.
+
+    nm-* and on-* are NEMAR-managed (one in nemarDatasets per dataset);
+    everything else is treated as a legacy OpenNeuro repo.
+    """
+    if dataset_id.startswith("nm") or dataset_id.startswith("on"):
+        return "nemarDatasets"
+    return "OpenNeuroDatasets"
+
 
 class DatasetMetadataRetriever:
     """Retrieve dataset metadata from GitHub repositories."""
@@ -35,8 +59,12 @@ class DatasetMetadataRetriever:
         Args:
             github_token: GitHub token for API access. If None, uses public access.
         """
-        self.github = Github(github_token) if github_token else Github()
-        self.openneuro_repo = "OpenNeuroDatasets"
+        # `timeout` caps how long PyGithub will wait on a single HTTP call
+        # before raising; without it a CLOSE_WAIT socket can hang forever.
+        if github_token:
+            self.github = Github(github_token, timeout=_GITHUB_TIMEOUT_SECONDS)
+        else:
+            self.github = Github(timeout=_GITHUB_TIMEOUT_SECONDS)
 
     def get_dataset_metadata(self, dataset_id: str) -> Dict[str, Any]:
         """
@@ -56,13 +84,14 @@ class DatasetMetadataRetriever:
         """
         logger.info(f"Retrieving metadata for dataset: {dataset_id}")
 
+        org = _org_for_dataset(dataset_id)
         metadata = {
             "dataset_id": dataset_id,
             "date_retrieved": datetime.now(timezone.utc).isoformat(),
             "dataset_description": None,
             "readme_content": None,
             "github_info": {
-                "repository_url": f"https://github.com/{self.openneuro_repo}/{dataset_id}",
+                "repository_url": f"https://github.com/{org}/{dataset_id}",
                 "exists": False,
             },
             "retrieval_status": {
@@ -74,7 +103,7 @@ class DatasetMetadataRetriever:
 
         try:
             # Get the repository
-            repo = self.github.get_repo(f"{self.openneuro_repo}/{dataset_id}")
+            repo = self.github.get_repo(f"{org}/{dataset_id}")
             metadata["github_info"]["exists"] = True
             metadata["retrieval_status"]["repository"] = "success"
 

--- a/src/dataset_citations/quality/dataset_metadata.py
+++ b/src/dataset_citations/quality/dataset_metadata.py
@@ -25,6 +25,7 @@ Email: shirazi@ieee.org
 import json
 import logging
 import os
+import re
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 
@@ -37,14 +38,24 @@ logger = logging.getLogger(__name__)
 # PyGithub forwards this to urllib3; the default is no timeout.
 _GITHUB_TIMEOUT_SECONDS = 30
 
+# Match a NEMAR-managed dataset id: prefix (nm or on) followed by digits.
+# Tighter than `startswith("nm")` so future ids like `nmr-phantom` or
+# `online-study-x` don't silently route to nemarDatasets/.
+_NEMAR_PREFIX_RE = re.compile(r"^(nm|on)\d")
+
 
 def _org_for_dataset(dataset_id: str) -> str:
     """Return the GitHub org that hosts the given dataset.
 
-    nm-* and on-* are NEMAR-managed (one in nemarDatasets per dataset);
-    everything else is treated as a legacy OpenNeuro repo.
+    Routing:
+      nm<digits...>  -> nemarDatasets   (NEMAR-native)
+      on<digits...>  -> nemarDatasets   (OpenNeuro imported into NEMAR)
+      everything else -> OpenNeuroDatasets (legacy)
+
+    Case-insensitive on the prefix; the project's canonical ids are
+    lowercase but a stray uppercase input shouldn't silently misroute.
     """
-    if dataset_id.startswith("nm") or dataset_id.startswith("on"):
+    if _NEMAR_PREFIX_RE.match(dataset_id.lower()):
         return "nemarDatasets"
     return "OpenNeuroDatasets"
 

--- a/tests/test_dataset_metadata_routing.py
+++ b/tests/test_dataset_metadata_routing.py
@@ -1,0 +1,39 @@
+"""Tests for the GitHub-org routing in quality.dataset_metadata.
+
+The retrieve-metadata pipeline was hardcoded to OpenNeuroDatasets/. nm-*
+and on-* datasets live in nemarDatasets/; sending them to the wrong org
+yielded 404s on every call and, combined with PyGithub's missing
+timeout, multi-hour CLOSE_WAIT stalls in the cron pipeline.
+
+Pure helper test, no network.
+"""
+
+from __future__ import annotations
+
+from unittest import TestCase
+
+from dataset_citations.quality.dataset_metadata import _org_for_dataset
+
+
+class OrgForDatasetTests(TestCase):
+    def test_ds_prefix_routes_to_openneurodatasets(self) -> None:
+        # Legacy OpenNeuro tree.
+        for did in ("ds000117", "ds002885", "ds007788"):
+            self.assertEqual(_org_for_dataset(did), "OpenNeuroDatasets", did)
+
+    def test_nm_prefix_routes_to_nemardatasets(self) -> None:
+        # NEMAR-native datasets are in nemarDatasets, not OpenNeuroDatasets.
+        for did in ("nm000103", "nm000115", "nm000999"):
+            self.assertEqual(_org_for_dataset(did), "nemarDatasets", did)
+
+    def test_on_prefix_routes_to_nemardatasets(self) -> None:
+        # OpenNeuro datasets imported into NEMAR keep the on-* id and the
+        # repo lives under nemarDatasets/, not OpenNeuroDatasets/.
+        for did in ("on005261", "on007315"):
+            self.assertEqual(_org_for_dataset(did), "nemarDatasets", did)
+
+    def test_unrecognized_prefix_falls_through_to_openneuro(self) -> None:
+        # Defensive default. xx-* datasets aren't a real prefix today, but
+        # keep the legacy behaviour for unknown prefixes so this helper
+        # doesn't silently route to a wrong NEMAR repo.
+        self.assertEqual(_org_for_dataset("xx12345"), "OpenNeuroDatasets")

--- a/tests/test_dataset_metadata_routing.py
+++ b/tests/test_dataset_metadata_routing.py
@@ -37,3 +37,22 @@ class OrgForDatasetTests(TestCase):
         # keep the legacy behaviour for unknown prefixes so this helper
         # doesn't silently route to a wrong NEMAR repo.
         self.assertEqual(_org_for_dataset("xx12345"), "OpenNeuroDatasets")
+
+    def test_partial_word_match_does_not_misroute(self) -> None:
+        # Tighter than startswith("nm"): the prefix must be followed by a
+        # digit. Future ids like 'online-study-x' or 'nmr-phantom' must
+        # NOT silently route to nemarDatasets/.
+        for did in ("online-study-x", "nmr-phantom", "nm-no-digits"):
+            self.assertEqual(
+                _org_for_dataset(did),
+                "OpenNeuroDatasets",
+                f"{did!r} should not route to nemarDatasets",
+            )
+
+    def test_uppercase_prefix_normalized(self) -> None:
+        # Case-insensitive on the prefix. NEMAR's canonical ids are
+        # lowercase, but the helper should not silently misroute if a
+        # stray uppercase id ever flows through.
+        self.assertEqual(_org_for_dataset("NM000103"), "nemarDatasets")
+        self.assertEqual(_org_for_dataset("ON005261"), "nemarDatasets")
+        self.assertEqual(_org_for_dataset("DS000117"), "OpenNeuroDatasets")


### PR DESCRIPTION
Critical bug fix surfaced by the May 21 hallu pipeline run: a single misrouted dataset (nm-* or on-* sent to OpenNeuroDatasets/) combined with PyGithub's default \"wait forever\" socket timeout produced a multi-hour CLOSE_WAIT stall. 7+ hours wallclock, 3 datasets written.

## What
- New \`_org_for_dataset()\` helper routes by prefix:
  - \`ds-*\` -> \`OpenNeuroDatasets/\` (legacy)
  - \`nm-*\` -> \`nemarDatasets/\` (NEMAR-native)
  - \`on-*\` -> \`nemarDatasets/\` (OpenNeuro imported into NEMAR)
- \`Github(timeout=30)\` wired so no single HTTP call can hang forever. PyGithub forwards this to urllib3; default is no timeout.
- 4 unit tests for the routing helper (\`tests/test_dataset_metadata_routing.py\`).

## Why
The hallu cron pipeline (#72) needs retrieve-metadata to work correctly for the 118 nm-*/on-* datasets, otherwise confidence scoring has no metadata to compare against and the dashboard shows 0 high-confidence citations + 0 bridge papers.

Before this fix:
- For nm/on datasets the code did \`OpenNeuroDatasets/nm000103\` -> 404
- PyGithub retried on the 404 path which hit a CLOSE_WAIT socket
- No timeout -> indefinite hang

After this fix:
- Routing matches the actual GitHub layout
- 30s socket timeout means worst-case 30s per stuck request, not 7+ hours

## Tests
- \`tests/test_dataset_metadata_routing.py\` — 4 cases covering each prefix branch + an \"unknown prefix\" defensive fallback.
- Full suite: 169 passed, 21 skipped (pre-existing integration gates).

## Verification
- \`uv run ruff format\` + \`ruff check\` clean.
- \`uv run pytest\` 173 passed (up from 169).
- \`ty\` has one pre-existing diagnostic on unmodified \`MutableMapping.update\` call (line 111); not introduced by this PR.

## Follow-up
- Once merged: I'll restart the hallu pipeline (which will now process nm/on correctly) and continue toward the 3am cron loop validation.