### PR TITLE
fix(ops): export GITHUB_TOKEN from gh auth in hallu cron script

### DIFF
--- a/scripts/hallu_cron_pipeline.sh
+++ b/scripts/hallu_cron_pipeline.sh
@@ -31,6 +31,17 @@ trap 'rc=$?; if [ $rc -ne 0 ]; then echo "FAILED rc=$rc at line $LINENO"; fi' EX
 echo "=== hallu-cron $TS start (host=$(hostname), pid=$$) ==="
 cd "$REPO_DIR"
 
+# Pull the GitHub token from gh CLI. cron jobs run with a minimal env;
+# without this, dataset-citations-retrieve-metadata falls back to the
+# unauthenticated public API (60 req/hr) and stalls after a handful of
+# repos. gh stores the token in ~/.config/gh/hosts.yml from a prior
+# `gh auth login`; we never have to write it to disk.
+export GITHUB_TOKEN="$(gh auth token 2>/dev/null)"
+if [ -z "${GITHUB_TOKEN:-}" ]; then
+  echo "ERROR: gh auth token returned empty; aborting" >&2
+  exit 2
+fi
+
 # Reset working tree to fresh main so each cron run starts from a known good state.
 git fetch --quiet origin main
 git checkout --quiet main


### PR DESCRIPTION
Trivial but critical fix for the hallu cron loop.

## Problem
Cron jobs run with a minimal environment (no shell rc loaded, no .env file sourced, no \`GITHUB_TOKEN\` inherited from interactive sessions). \`dataset-citations-retrieve-metadata\` then logs:
\`\`\`
WARNING - No GitHub token provided. Using public API access with rate limits.
\`\`\`
and quickly hits the 60-req/hr unauthenticated ceiling.

Discovered during the manual rerun on May 21: a setsid'd pipeline produced this warning even though \`gh auth\` was active.

## Fix
Source the token from \`gh auth token\` at script start. The token is already on disk in \`~/.config/gh/hosts.yml\` from a prior \`gh auth login\`, so we never have to handle it as a separate secret. Abort early with a clear message if \`gh\` isn't logged in.

Three lines added at the top of the script (after the lock acquisition).

## Test plan
- [x] gh auth token returns a token on hallu (verified)
- [x] Manual rerun (via the matching \`~/hallu_rerun.sh\` on hallu) now logs the dataset id and successfully fetches the repo on first attempt
- [ ] First 3am cron fire on Friday confirms the path end-to-end (in-flight; will verify next morning)