### PR TITLE
Phase 1: anchor adjudication probe + LLM client

### DIFF
--- a/.context/research.md
+++ b/.context/research.md
@@ -200,3 +200,47 @@ These prefixes account for 11 of the 17 DOIs with zero S2 contribution in this s
 ## What this PR does
 
 This PR ships only the probe script + the captured data + this report. The behavioral changes listed above are deliberately deferred to focused follow-up PRs so the data and the decision are reviewable independently of the code change. Issue #53 is closeable as "Phase A complete; Phase B = follow-up issues."
+
+---
+
+# 2026-05-22 — Epic #76 Phase 1 acceptance-gate probe
+
+Status: PASS. Phase 1 (#85) ready for merge.
+
+## Setup
+
+- Model: `gemma4:31b` served by Ollama on hallu's RTX 4090.
+- Network path: `ssh -fN -L 21434:localhost:11434 hallu`; `OLLAMA_BASE_URL=http://localhost:21434`. (Do NOT forward to port 11434 if a local `ollama serve` is also running — see the docstring in `scripts/probe_anchor_judgment.py` for why.)
+- Probe: `scripts/probe_anchor_judgment.py` with the 5-class taxonomy + 3 in-prompt few-shot examples from `dataset_citations.quality.llm_client.build_anchor_prompt`.
+
+## Results (10 anchors classified, 1 skip from a malformed-DOI extraction in `bids_metadata.py`)
+
+| Dataset | Anchor DOI | Relation | Classification | Notes |
+|---|---|---|---|---|
+| ds005505 | 10.1101/2024.10.03.615261 | IsDerivedFrom | data_paper | HBN preprint, correct |
+| ds005505 | 10.1101/2024.10.03.615261 | References | data_paper | same anchor, different relation |
+| ds005505 | 10.1038/sdata.2017.181 | References | **umbrella** | HBN initiative paper, NOT this dataset's data paper — exactly the inflation case epic #76 exists to fix |
+| ds005505 | 10.1038/sdata.2017.40 | References | **umbrella** | HBN imaging-resource paper, same pattern |
+| ds000246 | 10.3389/fnins.2019.00076 | References | **methodology** | Brainstorm software paper, README explicitly cites it |
+| nm000104 | 10.5281/zenodo.17287903 | IsVersionOf | data_paper | EMG2Qwerty Zenodo record |
+| nm000104 | 10.5281/zenodo.17613953 | IsIdenticalTo | data_paper | EMG2Qwerty Zenodo mirror |
+| nm000104 | 10.82901/nemar.nm000104 | IsVersionOf | data_paper | NEMAR-minted DOI for the same dataset |
+| on001787 | 10.82901/nemar.on001787 | IsVersionOf | data_paper | EEG meditation study |
+| ds002034 | 10.1007/s10548-019-00725-9 | References | data_paper | Single source paper, correct |
+
+Distribution: 7 data_paper, 2 umbrella, 1 methodology — every classification matches the expected ground truth.
+
+## Gate cases from issue #76, status
+
+- ✅ HBN-derived dataset: classify HBN umbrella as `umbrella`, preprint as `data_paper`.
+- ✅ Clean nm-* dataset: data paper classified correctly.
+- ✅ Methodology-only anchor: classified as `methodology` (Brainstorm; equivalent to the spec'd MNE-Python case).
+
+## Notes on iteration
+
+- Earlier probe runs used `gemma4:26b`. 26B passed the HBN discrimination but **misclassified** the Brainstorm methodology anchor as `data_paper` and occasionally returned out-of-taxonomy labels (`"data_authors_paper"`). Default model updated to `gemma4:31b` in `OllamaJudgmentClient._DEFAULT_MODEL`.
+- The malformed DOI `10.1038/sdata.2017.181)` with a literal trailing `)` is extracted by `sources/bids_metadata.py` from `HowToAcknowledge` text. File as a separate issue under the citation pipeline (out of scope for #76).
+- A real Ollama daemon disconnect was observed during the probe run. The `_generate` wrapping now surfaces such errors as per-anchor SKIPs instead of aborting the batch.
+
+Raw probe payload + full per-anchor JSON: see PR #89 artifacts (not committed to git to keep the repo lean).
+

--- a/scripts/probe_anchor_judgment.py
+++ b/scripts/probe_anchor_judgment.py
@@ -8,7 +8,8 @@ Acceptance gate for epic #76 (LLM anchor adjudication). For each dataset in
   2. Fetches the dataset description via `DatasetMetadataRetriever`.
   3. Fetches each anchor paper's title + abstract via the new
      `OpenCiteBackend.get_paper(doi)` sync facade.
-  4. Asks the Ollama-served Gemma 3 27B model to classify each anchor as
+  4. Asks the Ollama-served Gemma model (default tracked in
+     `OllamaJudgmentClient._DEFAULT_MODEL`, deployed on hallu) to classify each anchor as
      one of `data_paper` / `umbrella` / `methodology` / `related_work` /
      `irrelevant`.
   5. Prints one row per anchor + a per-classification tally.
@@ -21,9 +22,14 @@ This script does NOT write any sidecar JSON to `citations/anchor_judgments/`;
 that's phase 2 (#86).
 
 Usage:
-    OLLAMA_BASE_URL=http://hallu:11434 \
-        uv run python scripts/probe_anchor_judgment.py \
-            --output .context/probe_anchor_judgment_$(date +%Y-%m-%d).json
+    # Workstation: tunnel to hallu's Ollama daemon, then default
+    # OLLAMA_BASE_URL=http://localhost:11434 works.
+    ssh -fN -L 11434:localhost:11434 hallu
+    uv run python scripts/probe_anchor_judgment.py \
+        --output .context/probe_anchor_judgment_$(date +%Y-%m-%d).json
+
+    # On hallu itself: no tunnel needed, defaults work.
+    uv run python scripts/probe_anchor_judgment.py --output …
 """
 
 from __future__ import annotations
@@ -57,22 +63,27 @@ from dataset_citations.sources.models import DoiReference
 logger = logging.getLogger("probe_anchor_judgment")
 
 # Hand-picked datasets covering the acceptance-gate cases from epic #76:
-#   - HBN sibling (ds005505): IsDerivedFrom anchor is the HBN umbrella paper;
-#     expect umbrella for the HBN paper, data_paper for the dataset preprint.
-#   - ds000117: a classic clean dataset with a Nature Scientific Data paper.
-#   - ds000246: MEG data, anchors include an MNE-Python methodology paper.
-# The remaining slots add diversity across nm-* and ds-* prefixes.
+#   - HBN siblings (ds005505, ds005516): IsDerivedFrom anchor is the HBN
+#     umbrella paper; expect umbrella for the HBN papers, data_paper for
+#     the dataset preprint.
+#   - ds000246: methodology anchor (Brainstorm / similar EEG/MEG tool).
+#   - ds002034: clean dataset whose anchor is its own data paper.
+# `ds002718` is intentionally absent: it is the dataset_id used in the
+# few-shot Example 2 inside build_anchor_prompt, so including it here
+# would let the model echo the example instead of judging the case.
+# nm-/on- slots use real catalog IDs from api.nemar.org/datasets so the
+# nemar metadata source has something to extract.
 PROBE_DATASETS: tuple[str, ...] = (
     "ds005505",
     "ds005516",
     "ds000117",
     "ds000246",
-    "ds002718",
     "ds002034",
     "ds001785",
     "ds001971",
-    "nm000001",
-    "on000001",
+    "nm000104",
+    "on001787",
+    "on002181",
 )
 
 

--- a/scripts/probe_anchor_judgment.py
+++ b/scripts/probe_anchor_judgment.py
@@ -22,14 +22,22 @@ This script does NOT write any sidecar JSON to `citations/anchor_judgments/`;
 that's phase 2 (#86).
 
 Usage:
-    # Workstation: tunnel to hallu's Ollama daemon, then default
-    # OLLAMA_BASE_URL=http://localhost:11434 works.
-    ssh -fN -L 11434:localhost:11434 hallu
-    uv run python scripts/probe_anchor_judgment.py \
-        --output .context/probe_anchor_judgment_$(date +%Y-%m-%d).json
+    # Option A: run ON hallu via ssh — simplest, no port juggling.
+    ssh hallu 'cd ~/dataset_citations && \
+        uv run python scripts/probe_anchor_judgment.py \
+            --output .context/probe_anchor_judgment_$(date +%Y-%m-%d).json'
 
-    # On hallu itself: no tunnel needed, defaults work.
-    uv run python scripts/probe_anchor_judgment.py --output …
+    # Option B: workstation with an ssh tunnel.
+    # IMPORTANT: if you also run a local `ollama serve` on this machine, it
+    # already binds 0.0.0.0:11434. Forwarding hallu:11434 to localhost:11434
+    # then collides — connections will silently route to the local daemon
+    # instead of through the tunnel, which is hard to spot until the local
+    # ollama is paused or missing the right model. Use a different local
+    # port (e.g. 21434) and point OLLAMA_BASE_URL at it.
+    ssh -fN -L 21434:localhost:11434 hallu
+    OLLAMA_BASE_URL=http://localhost:21434 \
+        uv run python scripts/probe_anchor_judgment.py \
+            --output .context/probe_anchor_judgment_$(date +%Y-%m-%d).json
 """
 
 from __future__ import annotations

--- a/scripts/probe_anchor_judgment.py
+++ b/scripts/probe_anchor_judgment.py
@@ -1,0 +1,328 @@
+"""Throwaway probe: classify anchor DOIs for ~10 hand-picked datasets.
+
+Acceptance gate for epic #76 (LLM anchor adjudication). For each dataset in
+`PROBE_DATASETS`, the script:
+
+  1. Extracts anchor DOIs from the dataset's metadata source
+     (`NemarMetadataSource` for nm-/on-, `BidsMetadataSource` for ds-).
+  2. Fetches the dataset description via `DatasetMetadataRetriever`.
+  3. Fetches each anchor paper's title + abstract via the new
+     `OpenCiteBackend.get_paper(doi)` sync facade.
+  4. Asks the Ollama-served Gemma 3 27B model to classify each anchor as
+     one of `data_paper` / `umbrella` / `methodology` / `related_work` /
+     `irrelevant`.
+  5. Prints one row per anchor + a per-classification tally.
+
+Optional `--output` dumps the full per-anchor payload (including the prompt
+and the raw model JSON) so the spot-check evidence can be archived to
+`.context/research.md`.
+
+This script does NOT write any sidecar JSON to `citations/anchor_judgments/`;
+that's phase 2 (#86).
+
+Usage:
+    OLLAMA_BASE_URL=http://hallu:11434 \
+        uv run python scripts/probe_anchor_judgment.py \
+            --output .context/probe_anchor_judgment_$(date +%Y-%m-%d).json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from dataset_citations.backends import OpenCiteBackend
+from dataset_citations.quality.dataset_metadata import (
+    DatasetMetadataRetriever,
+    extract_dataset_text,
+)
+from dataset_citations.quality.llm_client import (
+    LlmJudgmentError,
+    OllamaJudgmentClient,
+    build_anchor_prompt,
+)
+from dataset_citations.sources import (
+    BidsMetadataSource,
+    FetchError,
+    FetchSuccess,
+    NemarMetadataSource,
+)
+from dataset_citations.sources.models import DoiReference
+
+logger = logging.getLogger("probe_anchor_judgment")
+
+# Hand-picked datasets covering the acceptance-gate cases from epic #76:
+#   - HBN sibling (ds005505): IsDerivedFrom anchor is the HBN umbrella paper;
+#     expect umbrella for the HBN paper, data_paper for the dataset preprint.
+#   - ds000117: a classic clean dataset with a Nature Scientific Data paper.
+#   - ds000246: MEG data, anchors include an MNE-Python methodology paper.
+# The remaining slots add diversity across nm-* and ds-* prefixes.
+PROBE_DATASETS: tuple[str, ...] = (
+    "ds005505",
+    "ds005516",
+    "ds000117",
+    "ds000246",
+    "ds002718",
+    "ds002034",
+    "ds001785",
+    "ds001971",
+    "nm000001",
+    "on000001",
+)
+
+
+def _pick_source(
+    dataset_id: str,
+    *,
+    nemar_source: NemarMetadataSource,
+    bids_source: BidsMetadataSource,
+) -> Any:
+    lowered = dataset_id.lower()
+    if lowered.startswith(("nm", "on")):
+        return nemar_source
+    return bids_source
+
+
+def _probe_anchor(
+    *,
+    dataset_id: str,
+    dataset_description: str,
+    ref: DoiReference,
+    backend: OpenCiteBackend,
+    client: OllamaJudgmentClient,
+) -> dict[str, Any]:
+    """Fetch the anchor paper + ask the LLM. Returns a result dict.
+
+    On failures (paper not found, LLM malformed output) the dict still
+    contains the anchor metadata + an `error` field so the probe can keep
+    going and the human reviewer sees the full picture.
+    """
+    record: dict[str, Any] = {
+        "dataset_id": dataset_id,
+        "anchor_doi": ref.identifier,
+        "anchor_relation": ref.relation_type,
+    }
+    paper_result = backend.get_paper(ref.identifier)
+    if isinstance(paper_result, FetchError):
+        record["error"] = (
+            f"paper_lookup_failed:{paper_result.reason}:{paper_result.detail}"
+        )
+        record["classification"] = None
+        record["reason"] = None
+        return record
+    assert isinstance(paper_result, FetchSuccess)
+    paper = paper_result.value
+    record["paper_title"] = paper.title
+    record["paper_venue"] = paper.venue
+    record["paper_year"] = paper.year
+    record["paper_has_abstract"] = bool(paper.abstract)
+
+    prompt = build_anchor_prompt(
+        dataset_id=dataset_id,
+        dataset_description=dataset_description,
+        anchor_doi=ref.identifier,
+        anchor_relation=ref.relation_type,
+        paper_title=paper.title,
+        paper_abstract=paper.abstract,
+        paper_venue=paper.venue,
+        paper_authors=paper.authors,
+        paper_year=paper.year,
+    )
+    record["prompt"] = prompt
+
+    try:
+        judgment = client.judge_anchor(prompt)
+    except LlmJudgmentError as exc:
+        logger.error(
+            "LLM judgment failed for %s / %s: %s", dataset_id, ref.identifier, exc
+        )
+        record["error"] = f"llm_judgment_failed:{exc}"
+        record["raw_response"] = exc.raw_response
+        record["classification"] = None
+        record["reason"] = None
+        return record
+
+    record["classification"] = judgment["classification"]
+    record["reason"] = judgment["reason"]
+    record["raw_response"] = judgment["raw_response"]
+    return record
+
+
+def _probe_dataset(
+    dataset_id: str,
+    *,
+    nemar_source: NemarMetadataSource,
+    bids_source: BidsMetadataSource,
+    metadata_retriever: DatasetMetadataRetriever,
+    backend: OpenCiteBackend,
+    client: OllamaJudgmentClient,
+) -> list[dict[str, Any]]:
+    source = _pick_source(
+        dataset_id, nemar_source=nemar_source, bids_source=bids_source
+    )
+    refs_result = source.get_doi_references(dataset_id)
+    if isinstance(refs_result, FetchError):
+        logger.warning(
+            "skipping %s: source returned %s (%s)",
+            dataset_id,
+            refs_result.reason,
+            refs_result.detail,
+        )
+        return [
+            {
+                "dataset_id": dataset_id,
+                "error": f"source_failed:{refs_result.reason}:{refs_result.detail}",
+            }
+        ]
+    assert isinstance(refs_result, FetchSuccess)
+    refs: list[DoiReference] = [
+        r for r in refs_result.value if r.identifier_type == "doi"
+    ]
+    if not refs:
+        logger.info("no DOI anchors for %s", dataset_id)
+        return [{"dataset_id": dataset_id, "error": "no_doi_anchors"}]
+
+    metadata = metadata_retriever.get_dataset_metadata(dataset_id)
+    dataset_description = extract_dataset_text(metadata)
+
+    records: list[dict[str, Any]] = []
+    for ref in refs:
+        logger.info("  anchor %s (%s)", ref.identifier, ref.relation_type)
+        records.append(
+            _probe_anchor(
+                dataset_id=dataset_id,
+                dataset_description=dataset_description,
+                ref=ref,
+                backend=backend,
+                client=client,
+            )
+        )
+    return records
+
+
+def _print_row(rec: dict[str, Any]) -> None:
+    if rec.get("error"):
+        print(
+            f"  [SKIP] {rec.get('anchor_doi', '<no-anchor>')}: {rec['error']}",
+            file=sys.stderr,
+        )
+        return
+    title = (rec.get("paper_title") or "")[:80]
+    reason = (rec.get("reason") or "")[:120]
+    print(
+        f"  {rec['anchor_doi']:<40}  rel={rec['anchor_relation']:<14}  "
+        f"-> {rec['classification']:<13}  {title}\n"
+        f"      reason: {reason}"
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--datasets",
+        nargs="+",
+        default=list(PROBE_DATASETS),
+        help="Override the hand-picked PROBE_DATASETS list.",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=None,
+        help="Optional path to dump full per-anchor JSON (prompt + raw response).",
+    )
+    parser.add_argument(
+        "--ollama-base-url",
+        default=None,
+        help="Override OLLAMA_BASE_URL env var.",
+    )
+    parser.add_argument(
+        "--ollama-model",
+        default=None,
+        help="Override OLLAMA_MODEL env var.",
+    )
+    parser.add_argument(
+        "--log-level",
+        default="INFO",
+        help="logging level (DEBUG, INFO, WARNING, ERROR).",
+    )
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=args.log_level,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+
+    nemar_source = NemarMetadataSource()
+    bids_source = BidsMetadataSource()
+    metadata_retriever = DatasetMetadataRetriever()
+    backend = OpenCiteBackend(max_results_per_doi=1)
+
+    with OllamaJudgmentClient(
+        base_url=args.ollama_base_url, model=args.ollama_model
+    ) as client:
+        if not client.health_check():
+            logger.error(
+                "ollama daemon at %s is not reachable; aborting before any judgments",
+                client.base_url,
+            )
+            return 2
+
+        logger.info(
+            "probing %d datasets against ollama model %s @ %s",
+            len(args.datasets),
+            client.model,
+            client.base_url,
+        )
+
+        all_records: list[dict[str, Any]] = []
+        for dataset_id in args.datasets:
+            print(f"\n=== {dataset_id} ===")
+            records = _probe_dataset(
+                dataset_id,
+                nemar_source=nemar_source,
+                bids_source=bids_source,
+                metadata_retriever=metadata_retriever,
+                backend=backend,
+                client=client,
+            )
+            for rec in records:
+                _print_row(rec)
+            all_records.extend(records)
+
+    tally: dict[str, int] = {}
+    for rec in all_records:
+        cls = rec.get("classification")
+        if cls:
+            tally[cls] = tally.get(cls, 0) + 1
+    error_count = sum(1 for r in all_records if r.get("error"))
+
+    print("\n=== Summary ===")
+    print(f"anchors classified: {sum(tally.values())}")
+    for cls in sorted(tally):
+        print(f"  {cls:<14} {tally[cls]}")
+    print(f"errors/skips: {error_count}")
+
+    if args.output is not None:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        report = {
+            "generated_at": datetime.now(timezone.utc).isoformat(),
+            "datasets": args.datasets,
+            "model": client.model,
+            "base_url": client.base_url,
+            "tally": tally,
+            "error_count": error_count,
+            "records": all_records,
+        }
+        args.output.write_text(json.dumps(report, indent=2, ensure_ascii=False))
+        logger.info("wrote %s", args.output)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/dataset_citations/backends/opencite_backend.py
+++ b/src/dataset_citations/backends/opencite_backend.py
@@ -88,6 +88,51 @@ class OpenCiteBackend:
             return {}
         return asyncio.run(self._batch_async(ref_list))
 
+    def get_paper(self, doi: str) -> FetchResult[CitingWork]:
+        """Look up the anchor paper's own bib + abstract via OpenAlex.
+
+        Returns a `CitingWork` populated with the paper's title, abstract,
+        authors, venue, year, and ID fields. The `source_doi` is set to the
+        looked-up DOI and `source_relation` defaults to "References" since
+        the model only carries the four DataCite values; callers treating
+        this as a self-lookup should ignore both fields.
+
+        Used by epic #76's anchor adjudication path (probe + judge-anchors
+        CLI) to assemble the candidate paper context for the LLM prompt.
+        Sync facade over opencite's async `OpenAlexClient.lookup_doi`.
+        """
+        return asyncio.run(self._get_paper_async(doi))
+
+    async def _get_paper_async(self, doi: str) -> FetchResult[CitingWork]:
+        try:
+            async with OpenAlexClient(self._config) as openalex_base:
+                assert isinstance(openalex_base, OpenAlexClient), (
+                    "opencite changed OpenAlexClient.__aenter__ return type; "
+                    "expected an OpenAlexClient bound, got "
+                    f"{type(openalex_base).__name__}"
+                )
+                paper = await openalex_base.lookup_doi(doi)
+        except Exception as exc:
+            return classify_error(exc, doi)
+
+        if paper is None or not paper.title:
+            return FetchError(
+                "not_found", f"{doi}: not found in OpenAlex (anchor self-lookup)"
+            )
+
+        # Synthesize a self-referential anchor so we can reuse the existing
+        # paper -> CitingWork mapper. Callers treat source_relation as opaque
+        # for self-lookups; the dataclass invariant just requires a non-empty
+        # source_doi and a valid RelationType literal.
+        self_ref = DoiReference(
+            identifier=doi,
+            identifier_type="doi",
+            relation_type="References",
+            source="nemar_catalog",
+            source_field="self_lookup",
+        )
+        return FetchSuccess(_paper_to_citing_work(paper, self_ref))
+
     async def _batch_async(
         self, refs: list[DoiReference]
     ) -> dict[str, FetchResult[list[CitingWork]]]:

--- a/src/dataset_citations/backends/opencite_backend.py
+++ b/src/dataset_citations/backends/opencite_backend.py
@@ -25,6 +25,7 @@ import logging
 from collections.abc import Iterable
 from typing import Any
 
+import httpx
 from opencite.citations import CitationExplorer
 from opencite.clients.openalex import OpenAlexClient
 from opencite.config import Config
@@ -104,6 +105,13 @@ class OpenCiteBackend:
         return asyncio.run(self._get_paper_async(doi))
 
     async def _get_paper_async(self, doi: str) -> FetchResult[CitingWork]:
+        # Narrow exception list: classify_error is built for network-shaped
+        # failures, so we only route those through it. Programmer errors
+        # (AttributeError on opencite API drift, AssertionError on the
+        # isinstance invariant below, TypeError) must propagate to surface
+        # the contract break instead of being silently demoted to
+        # FetchError("other", ...). Mirror this list against the existing
+        # _lookup branch's handling if it widens in the future.
         try:
             async with OpenAlexClient(self._config) as openalex_base:
                 assert isinstance(openalex_base, OpenAlexClient), (
@@ -112,7 +120,7 @@ class OpenCiteBackend:
                     f"{type(openalex_base).__name__}"
                 )
                 paper = await openalex_base.lookup_doi(doi)
-        except Exception as exc:
+        except (httpx.HTTPError, asyncio.TimeoutError, OSError) as exc:
             return classify_error(exc, doi)
 
         if paper is None or not paper.title:

--- a/src/dataset_citations/quality/__init__.py
+++ b/src/dataset_citations/quality/__init__.py
@@ -6,6 +6,9 @@ This module contains Phase 3 features including:
 - Confidence score calculation
 - Sentence-transformers integration
 - Metadata retrieval and comparison
+
+Epic #76 (anchor adjudication) adds the LLM client + prompt builder here so
+phases 2, 3, and 4 import the prompt from one place.
 """
 
 # Import only dataset_metadata to avoid sentence-transformers import issues during CLI help
@@ -14,6 +17,12 @@ from .dataset_metadata import (
     extract_dataset_text,
     load_dataset_metadata,
     save_dataset_metadata,
+)
+from .llm_client import (
+    ALLOWED_CLASSIFICATIONS,
+    LlmJudgmentError,
+    OllamaJudgmentClient,
+    build_anchor_prompt,
 )
 
 
@@ -40,8 +49,12 @@ def batch_score_citations(*args, **kwargs):
 
 
 __all__ = [
+    "ALLOWED_CLASSIFICATIONS",
     "DatasetMetadataRetriever",
+    "LlmJudgmentError",
+    "OllamaJudgmentClient",
     "batch_score_citations",
+    "build_anchor_prompt",
     "extract_dataset_text",
     "get_confidence_scorer",
     "load_dataset_metadata",

--- a/src/dataset_citations/quality/llm_client.py
+++ b/src/dataset_citations/quality/llm_client.py
@@ -54,9 +54,13 @@ ALLOWED_CLASSIFICATIONS: frozenset[str] = frozenset(
 
 # Env vars + defaults. The default base URL is localhost so the production
 # cron path (which runs on hallu next to the Ollama daemon) needs no
-# overrides; developer workstations reach the daemon through an ssh tunnel
-# (the daemon binds localhost only) by running
-# `ssh -fN -L 11434:localhost:11434 hallu` once per session.
+# overrides. Developer workstations reach the daemon either by ssh-ing
+# directly to hallu and running there, OR by forwarding a *non-default*
+# local port (e.g. `ssh -fN -L 21434:localhost:11434 hallu`) and setting
+# OLLAMA_BASE_URL=http://localhost:21434. Using 11434 for the tunnel
+# collides with a workstation-local `ollama serve` and silently routes
+# the request to the wrong daemon. See scripts/probe_anchor_judgment.py
+# docstring for the canonical workflow.
 # Default model tracks the largest Gemma checkpoint currently pulled on
 # hallu; epic #76 spec'd Gemma 3 27B, but the live deployment is the
 # next-generation model. Update the constant when the pulled model
@@ -69,7 +73,10 @@ _DEFAULT_BASE_URL = "http://localhost:11434"
 # Single source of truth for the deployed model. Bump this one constant
 # (and re-run the probe) when a new checkpoint is pulled on hallu.
 _DEFAULT_MODEL = "gemma4:26b"
-_DEFAULT_TIMEOUT = 60
+# Per-judgment timeout: most calls return in 3-10s, but cold loads + long
+# prompts on the 26B checkpoint have been observed at ~150s. 300s gives
+# headroom without hanging the probe forever on a stuck request.
+_DEFAULT_TIMEOUT = 300
 
 # Truncate long dataset descriptions to keep the prompt under the model's
 # practical context budget while leaving room for the candidate paper. The
@@ -312,22 +319,67 @@ class OllamaJudgmentClient:
         Split out so tests can subclass the client and override the HTTP step
         with a hand-built response (matches the no-mocks pattern used by
         `tests/test_core_opencite_pipeline.py`).
+
+        All httpx-level failures (timeout, connect, non-2xx) are wrapped in
+        `LlmJudgmentError` so the caller's per-anchor try/except catches them
+        uniformly and one slow / failed anchor doesn't abort a batch run.
+        Ollama's error JSON (when present) is surfaced in the message so the
+        operator sees, e.g., "model not found" instead of a generic 500.
         """
-        resp = self._client.post(
-            f"{self.base_url}/api/generate",
-            json={
-                "model": self.model,
-                "prompt": prompt,
-                "format": "json",
-                "stream": False,
-                "options": {"temperature": 0.0},
-            },
-        )
-        resp.raise_for_status()
-        payload = resp.json()
+        try:
+            resp = self._client.post(
+                f"{self.base_url}/api/generate",
+                json={
+                    "model": self.model,
+                    "prompt": prompt,
+                    "format": "json",
+                    "stream": False,
+                    "options": {"temperature": 0.0},
+                },
+            )
+            resp.raise_for_status()
+            payload = resp.json()
+        except httpx.HTTPStatusError as exc:
+            body_error = self._extract_ollama_error(exc.response)
+            raise LlmJudgmentError(
+                f"ollama HTTP {exc.response.status_code}"
+                + (f": {body_error}" if body_error else ""),
+                raw_response=exc.response.text,
+            ) from exc
+        except httpx.HTTPError as exc:
+            raise LlmJudgmentError(
+                f"ollama HTTP transport error ({type(exc).__name__}): {exc}"
+            ) from exc
+
+        if not isinstance(payload, dict):
+            raise LlmJudgmentError(
+                f"ollama payload is not a JSON object: {type(payload).__name__}"
+            )
+        upstream_err = payload.get("error")
+        if upstream_err:
+            raise LlmJudgmentError(f"ollama returned error: {upstream_err!r}")
         response_text = payload.get("response")
         if not isinstance(response_text, str):
             raise LlmJudgmentError(
                 f"ollama payload missing 'response' string field: {payload!r}"
             )
         return response_text
+
+    @staticmethod
+    def _extract_ollama_error(response: httpx.Response) -> str | None:
+        """Return Ollama's `error` field from a non-2xx response body, if any.
+
+        Ollama serves JSON error bodies like `{"error": "model 'foo' not
+        found, try pulling it first"}` for many failure modes. Surface that
+        string in `LlmJudgmentError` so the operator's debug loop is one
+        step shorter.
+        """
+        try:
+            body = response.json()
+        except ValueError:
+            return None
+        if isinstance(body, dict):
+            err = body.get("error")
+            if isinstance(err, str) and err:
+                return err
+        return None

--- a/src/dataset_citations/quality/llm_client.py
+++ b/src/dataset_citations/quality/llm_client.py
@@ -1,0 +1,324 @@
+#!/usr/bin/env python3
+"""
+Ollama-backed LLM client for anchor adjudication.
+
+Epic #76 fixes citation inflation by asking a local LLM (Gemma 3 27B on the
+hallu RTX 4090, served by Ollama) to classify each DOI anchor in a dataset's
+metadata as one of five buckets. Phase 1 (#85) stands up the client + the
+prompt + a throwaway probe script; phase 2 (#86) productizes the storage.
+
+This module is the single place where the prompt + classification taxonomy
+live. Phases 2, 3, and 4 all import from here so a prompt revision is a
+single-file change, not a sweep.
+
+The classification schema is:
+
+  - data_paper:    the paper IS the data paper for this dataset (or the
+                   dataset's preprint / curation paper).
+  - umbrella:      the paper is a multi-dataset / multi-study initiative
+                   (HBN, UK Biobank, ABCD) that contains this dataset but
+                   is not its data paper.
+  - methodology:   the paper is a software / method / analysis tool the
+                   dataset's protocol uses (MNE-Python, BIDS-EEG spec).
+  - related_work:  the paper is topically related but does not describe
+                   this dataset specifically.
+  - irrelevant:    the paper has no meaningful relationship to this
+                   dataset (mis-attached anchor, token collision, etc.).
+
+Copyright (c) 2026 Seyed Yahya Shirazi (neuromechanist)
+All rights reserved.
+
+Author: Seyed Yahya Shirazi
+GitHub: https://github.com/neuromechanist
+Email: shirazi@ieee.org
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from typing import Any, Iterable
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+# The five-class taxonomy is the contract phase 2's sidecar schema and
+# phase 3's pipeline filter both depend on. Adding or removing a class is a
+# cross-phase change; doc the rationale before edits.
+ALLOWED_CLASSIFICATIONS: frozenset[str] = frozenset(
+    {"data_paper", "umbrella", "methodology", "related_work", "irrelevant"}
+)
+
+# Env vars + defaults. Defaults point at hallu (the GPU host where the cron
+# pipeline runs). For local dev against an Ollama daemon on the workstation,
+# set OLLAMA_BASE_URL=http://localhost:11434.
+_ENV_BASE_URL = "OLLAMA_BASE_URL"
+_ENV_MODEL = "OLLAMA_MODEL"
+_ENV_TIMEOUT = "OLLAMA_TIMEOUT_SECONDS"
+
+_DEFAULT_BASE_URL = "http://hallu:11434"
+_DEFAULT_MODEL = "gemma3:27b"
+_DEFAULT_TIMEOUT = 60
+
+# Truncate long dataset descriptions to keep the prompt under Gemma 3 27B's
+# practical context budget while leaving room for the candidate paper. The
+# probe script's hand-picked datasets all fit comfortably under this.
+_DATASET_DESCRIPTION_CHAR_LIMIT = 1500
+_ABSTRACT_CHAR_LIMIT = 2000
+
+
+class LlmJudgmentError(RuntimeError):
+    """Raised when the LLM returns malformed JSON or an out-of-taxonomy label.
+
+    The probe and the phase 2 CLI catch this so a single bad anchor doesn't
+    abort a batch run. The detail string carries the raw response for
+    auditing.
+    """
+
+    def __init__(self, message: str, *, raw_response: str | None = None) -> None:
+        super().__init__(message)
+        self.raw_response = raw_response
+
+
+def _truncate(text: str | None, limit: int) -> str:
+    if not text:
+        return "[unavailable]"
+    if len(text) <= limit:
+        return text
+    return text[:limit].rstrip() + "…"
+
+
+def _format_authors(authors: Iterable[Any]) -> str:
+    """Render a small authors list for the prompt. Trims at 5 names."""
+    names: list[str] = []
+    for author in authors:
+        name = getattr(author, "name", None) or str(author)
+        if name:
+            names.append(name)
+        if len(names) >= 5:
+            names.append("et al.")
+            break
+    return ", ".join(names) if names else "[unavailable]"
+
+
+def build_anchor_prompt(
+    *,
+    dataset_id: str,
+    dataset_description: str | None,
+    anchor_doi: str,
+    anchor_relation: str,
+    paper_title: str | None,
+    paper_abstract: str | None,
+    paper_venue: str | None = None,
+    paper_authors: Iterable[Any] | None = None,
+    paper_year: int | None = None,
+) -> str:
+    """Return the full Ollama prompt for one (dataset, anchor) judgment.
+
+    Kept as a module-level pure function so phases 2/3/4 all build identical
+    prompts. The opening lays out the taxonomy with one-line definitions,
+    then hands the model the dataset description + candidate paper + the
+    DataCite `source_relation` value, then three few-shot examples covering
+    the acceptance-gate cases from epic #76 (HBN umbrella, dataset preprint,
+    MNE-Python methodology).
+    """
+    description = _truncate(dataset_description, _DATASET_DESCRIPTION_CHAR_LIMIT)
+    abstract = _truncate(paper_abstract, _ABSTRACT_CHAR_LIMIT)
+    title = paper_title or "[unavailable]"
+    venue = paper_venue or "[unavailable]"
+    authors = _format_authors(paper_authors or [])
+    year = str(paper_year) if paper_year else "[unavailable]"
+
+    return f"""You are classifying the relationship between a neuroscience dataset and a candidate paper that the dataset's metadata cites as a related identifier.
+
+Choose exactly one class from this taxonomy:
+
+- data_paper: the paper IS this dataset's data paper, dataset preprint, or curation paper. It introduces, describes, or releases the data in this specific dataset.
+- umbrella: the paper is a multi-dataset / multi-study initiative (e.g. HBN, UK Biobank, ABCD) that this dataset belongs to, but the paper is NOT this specific dataset's data paper.
+- methodology: the paper is a software tool, analysis method, or technical specification that this dataset's protocol uses (e.g. MNE-Python, EEGLAB, BIDS-EEG spec, FieldTrip).
+- related_work: the paper is topically related (same brain region, task, modality) but does not describe this dataset specifically.
+- irrelevant: the paper has no meaningful relationship to this dataset (mis-attached anchor, token-collision false positive).
+
+Respond with strict JSON only, no prose, no markdown:
+{{"classification": "<one of the five labels>", "reason": "<one sentence, <= 200 chars, citing concrete evidence from the title or abstract>"}}
+
+=== DATASET ===
+dataset_id: {dataset_id}
+description (truncated):
+{description}
+
+=== CANDIDATE PAPER ===
+DOI: {anchor_doi}
+source_relation (DataCite, may be hint but is NOT ground truth): {anchor_relation}
+title: {title}
+authors: {authors}
+venue: {venue}
+year: {year}
+abstract:
+{abstract}
+
+=== EXAMPLES ===
+Example 1 (HBN umbrella):
+  dataset_id: ds004186 (one of many HBN sibling releases)
+  candidate paper: "The Healthy Brain Network Serial Scanning Initiative: a resource for evaluating inter-individual differences and their reliabilities across scan conditions and sessions"
+  Correct output: {{"classification": "umbrella", "reason": "Paper describes the broader Healthy Brain Network initiative containing many sibling datasets, not this specific release."}}
+
+Example 2 (dataset preprint as data paper):
+  dataset_id: ds002718
+  candidate paper: "An open dataset of EEG recordings from face perception experiments"
+  Correct output: {{"classification": "data_paper", "reason": "Title and abstract describe the release of this specific EEG face-perception dataset."}}
+
+Example 3 (methodology tool):
+  dataset_id: ds000117 (anchor DOI 10.3389/fnins.2013.00267)
+  candidate paper: "MEG and EEG data analysis with MNE-Python"
+  Correct output: {{"classification": "methodology", "reason": "Describes the MNE-Python analysis library; tool used in the protocol, not a paper about this dataset."}}
+
+Now classify the candidate paper for dataset {dataset_id}. Respond with the JSON object only."""
+
+
+class OllamaJudgmentClient:
+    """Sync HTTP client for Ollama's `/api/generate` JSON-mode endpoint.
+
+    One client per process is fine; httpx.Client handles connection pooling.
+    Phase 4's cron preflight uses `health_check()` to fail fast if the GPU
+    host is unreachable.
+    """
+
+    def __init__(
+        self,
+        base_url: str | None = None,
+        *,
+        model: str | None = None,
+        timeout: int | None = None,
+    ) -> None:
+        self.base_url = (
+            base_url or os.environ.get(_ENV_BASE_URL) or _DEFAULT_BASE_URL
+        ).rstrip("/")
+        self.model = model or os.environ.get(_ENV_MODEL) or _DEFAULT_MODEL
+        timeout_env = os.environ.get(_ENV_TIMEOUT)
+        if timeout is not None:
+            self.timeout = timeout
+        elif timeout_env:
+            self.timeout = int(timeout_env)
+        else:
+            self.timeout = _DEFAULT_TIMEOUT
+        self._client = httpx.Client(timeout=self.timeout)
+        logger.debug(
+            "OllamaJudgmentClient ready (base_url=%s, model=%s, timeout=%ds)",
+            self.base_url,
+            self.model,
+            self.timeout,
+        )
+
+    def close(self) -> None:
+        self._client.close()
+
+    def __enter__(self) -> "OllamaJudgmentClient":
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: Any,
+    ) -> None:
+        del exc_type, exc_val, exc_tb
+        self.close()
+
+    def health_check(self) -> bool:
+        """Return True iff the Ollama daemon answers `/api/tags`.
+
+        Used by phase 4's cron preflight so a down GPU host aborts the run
+        cleanly instead of writing empty judgments.
+        """
+        try:
+            resp = self._post_health()
+        except httpx.HTTPError as exc:
+            logger.warning("ollama health_check failed: %s", exc)
+            return False
+        return resp.status_code == 200
+
+    def _post_health(self) -> httpx.Response:
+        return self._client.get(f"{self.base_url}/api/tags", timeout=5)
+
+    def judge_anchor(self, prompt: str) -> dict[str, Any]:
+        """Send `prompt` to Ollama, parse the JSON response, validate.
+
+        Returns a dict with keys:
+          - classification (str, one of ALLOWED_CLASSIFICATIONS)
+          - reason (str, non-empty)
+          - raw_response (str, the model's verbatim output)
+          - model (str)
+
+        Raises LlmJudgmentError if the response is not parseable JSON, is
+        missing required keys, or has an out-of-taxonomy classification.
+        """
+        raw = self._generate(prompt)
+        try:
+            parsed = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            raise LlmJudgmentError(
+                f"ollama returned non-JSON content: {exc}",
+                raw_response=raw,
+            ) from exc
+
+        if not isinstance(parsed, dict):
+            raise LlmJudgmentError(
+                f"ollama JSON root is not an object (got {type(parsed).__name__})",
+                raw_response=raw,
+            )
+
+        classification = parsed.get("classification")
+        reason = parsed.get("reason")
+
+        if not isinstance(classification, str):
+            raise LlmJudgmentError(
+                "missing or non-string 'classification' field",
+                raw_response=raw,
+            )
+        if classification not in ALLOWED_CLASSIFICATIONS:
+            raise LlmJudgmentError(
+                f"classification {classification!r} not in taxonomy "
+                f"{sorted(ALLOWED_CLASSIFICATIONS)}",
+                raw_response=raw,
+            )
+        if not isinstance(reason, str) or not reason.strip():
+            raise LlmJudgmentError(
+                "missing or empty 'reason' field",
+                raw_response=raw,
+            )
+
+        return {
+            "classification": classification,
+            "reason": reason.strip(),
+            "raw_response": raw,
+            "model": self.model,
+        }
+
+    def _generate(self, prompt: str) -> str:
+        """POST `/api/generate` with format=json, return the `response` field.
+
+        Split out so tests can subclass the client and override the HTTP step
+        with a hand-built response (matches the no-mocks pattern used by
+        `tests/test_core_opencite_pipeline.py`).
+        """
+        resp = self._client.post(
+            f"{self.base_url}/api/generate",
+            json={
+                "model": self.model,
+                "prompt": prompt,
+                "format": "json",
+                "stream": False,
+                "options": {"temperature": 0.0},
+            },
+        )
+        resp.raise_for_status()
+        payload = resp.json()
+        response_text = payload.get("response")
+        if not isinstance(response_text, str):
+            raise LlmJudgmentError(
+                f"ollama payload missing 'response' string field: {payload!r}"
+            )
+        return response_text

--- a/src/dataset_citations/quality/llm_client.py
+++ b/src/dataset_citations/quality/llm_client.py
@@ -51,15 +51,18 @@ ALLOWED_CLASSIFICATIONS: frozenset[str] = frozenset(
     {"data_paper", "umbrella", "methodology", "related_work", "irrelevant"}
 )
 
-# Env vars + defaults. Defaults point at hallu (the GPU host where the cron
-# pipeline runs). For local dev against an Ollama daemon on the workstation,
-# set OLLAMA_BASE_URL=http://localhost:11434.
+# Env vars + defaults. The default base URL is localhost so the production
+# cron path (which runs on hallu next to the Ollama daemon) needs no
+# overrides; developer workstations reaching the daemon remotely set
+# OLLAMA_BASE_URL=http://hallucinating:11434 (or use an ssh tunnel).
+# Default model tracks the largest Gemma checkpoint currently pulled on
+# hallu; epic #76 spec'd "Gemma 3 27B", the deployed model is Gemma 4 31B.
 _ENV_BASE_URL = "OLLAMA_BASE_URL"
 _ENV_MODEL = "OLLAMA_MODEL"
 _ENV_TIMEOUT = "OLLAMA_TIMEOUT_SECONDS"
 
-_DEFAULT_BASE_URL = "http://hallu:11434"
-_DEFAULT_MODEL = "gemma3:27b"
+_DEFAULT_BASE_URL = "http://localhost:11434"
+_DEFAULT_MODEL = "gemma4:31b"
 _DEFAULT_TIMEOUT = 60
 
 # Truncate long dataset descriptions to keep the prompt under Gemma 3 27B's

--- a/src/dataset_citations/quality/llm_client.py
+++ b/src/dataset_citations/quality/llm_client.py
@@ -71,8 +71,11 @@ _ENV_TIMEOUT = "OLLAMA_TIMEOUT_SECONDS"
 
 _DEFAULT_BASE_URL = "http://localhost:11434"
 # Single source of truth for the deployed model. Bump this one constant
-# (and re-run the probe) when a new checkpoint is pulled on hallu.
-_DEFAULT_MODEL = "gemma4:26b"
+# (and re-run the probe) when a new checkpoint is pulled on hallu. 31B
+# is the smallest checkpoint that handles the methodology-vs-data_paper
+# discrimination correctly on the acceptance-gate probe; 26B confused a
+# Brainstorm-tools anchor for a data paper.
+_DEFAULT_MODEL = "gemma4:31b"
 # Per-judgment timeout: most calls return in 3-10s, but cold loads + long
 # prompts on the 26B checkpoint have been observed at ~150s. 300s gives
 # headroom without hanging the probe forever on a stuck request.

--- a/src/dataset_citations/quality/llm_client.py
+++ b/src/dataset_citations/quality/llm_client.py
@@ -2,10 +2,11 @@
 """
 Ollama-backed LLM client for anchor adjudication.
 
-Epic #76 fixes citation inflation by asking a local LLM (Gemma 3 27B on the
-hallu RTX 4090, served by Ollama) to classify each DOI anchor in a dataset's
-metadata as one of five buckets. Phase 1 (#85) stands up the client + the
-prompt + a throwaway probe script; phase 2 (#86) productizes the storage.
+Epic #76 fixes citation inflation by asking a local LLM (the largest local
+Gemma checkpoint served by Ollama on the hallu RTX 4090; see _DEFAULT_MODEL)
+to classify each DOI anchor in a dataset's metadata as one of five buckets.
+Phase 1 (#85) stands up the client + the prompt + a throwaway probe script;
+phase 2 (#86) productizes the storage.
 
 This module is the single place where the prompt + classification taxonomy
 live. Phases 2, 3, and 4 all import from here so a prompt revision is a
@@ -53,19 +54,24 @@ ALLOWED_CLASSIFICATIONS: frozenset[str] = frozenset(
 
 # Env vars + defaults. The default base URL is localhost so the production
 # cron path (which runs on hallu next to the Ollama daemon) needs no
-# overrides; developer workstations reaching the daemon remotely set
-# OLLAMA_BASE_URL=http://hallucinating:11434 (or use an ssh tunnel).
+# overrides; developer workstations reach the daemon through an ssh tunnel
+# (the daemon binds localhost only) by running
+# `ssh -fN -L 11434:localhost:11434 hallu` once per session.
 # Default model tracks the largest Gemma checkpoint currently pulled on
-# hallu; epic #76 spec'd "Gemma 3 27B", the deployed model is Gemma 4 31B.
+# hallu; epic #76 spec'd Gemma 3 27B, but the live deployment is the
+# next-generation model. Update the constant when the pulled model
+# changes.
 _ENV_BASE_URL = "OLLAMA_BASE_URL"
 _ENV_MODEL = "OLLAMA_MODEL"
 _ENV_TIMEOUT = "OLLAMA_TIMEOUT_SECONDS"
 
 _DEFAULT_BASE_URL = "http://localhost:11434"
-_DEFAULT_MODEL = "gemma4:31b"
+# Single source of truth for the deployed model. Bump this one constant
+# (and re-run the probe) when a new checkpoint is pulled on hallu.
+_DEFAULT_MODEL = "gemma4:26b"
 _DEFAULT_TIMEOUT = 60
 
-# Truncate long dataset descriptions to keep the prompt under Gemma 3 27B's
+# Truncate long dataset descriptions to keep the prompt under the model's
 # practical context budget while leaving room for the candidate paper. The
 # probe script's hand-picked datasets all fit comfortably under this.
 _DATASET_DESCRIPTION_CHAR_LIMIT = 1500

--- a/tests/test_backends_opencite.py
+++ b/tests/test_backends_opencite.py
@@ -60,6 +60,19 @@ class OpenCiteBackendIntegration(TestCase):
         out = self.backend.get_citing_works_batch(refs)
         self.assertEqual(set(out.keys()), {r.identifier for r in refs})
 
+    def test_get_paper_returns_anchor_metadata(self) -> None:
+        # Real OpenAlex lookup of a well-indexed anchor paper.
+        result = self.backend.get_paper("10.1038/sdata.2015.1")
+        self.assertIsInstance(result, FetchSuccess)
+        assert isinstance(result, FetchSuccess)
+        paper = result.value
+        self.assertTrue(paper.title)
+        self.assertEqual(paper.source_doi, "10.1038/sdata.2015.1")
+
+    def test_get_paper_unknown_doi_returns_error(self) -> None:
+        result = self.backend.get_paper("10.99999/never-existed-zzz")
+        self.assertIsInstance(result, FetchError)
+
 
 class OpenCiteBackendUnitTests(TestCase):
     """Cheap tests that exercise the backend's error-classification path

--- a/tests/test_quality_llm_client.py
+++ b/tests/test_quality_llm_client.py
@@ -1,0 +1,221 @@
+"""Tests for `dataset_citations.quality.llm_client`.
+
+No mocks. The client's HTTP path is overridden via a real subclass that
+returns hand-built strings, matching the pattern used by
+`tests/test_core_opencite_pipeline.py`.
+
+Integration tests against a real Ollama daemon are gated behind
+RUN_INTEGRATION_TESTS=1.
+"""
+
+from __future__ import annotations
+
+import os
+from unittest import TestCase, skipUnless
+
+from dataset_citations.quality.llm_client import (
+    ALLOWED_CLASSIFICATIONS,
+    LlmJudgmentError,
+    OllamaJudgmentClient,
+    build_anchor_prompt,
+)
+
+
+class _FakeClient(OllamaJudgmentClient):
+    """Real subclass that bypasses the HTTP step.
+
+    `_generate` is the seam: the parent posts to /api/generate and returns
+    the response string. Here we return whatever was preset on the instance.
+    """
+
+    def __init__(self, canned_response: str) -> None:
+        # Skip parent __init__ so no httpx.Client is constructed.
+        self.base_url = "http://test"
+        self.model = "test-model"
+        self.timeout = 5
+        self._canned_response = canned_response
+
+    def _generate(self, prompt: str) -> str:  # noqa: ARG002 - prompt unused in stub
+        return self._canned_response
+
+
+class BuildAnchorPromptTests(TestCase):
+    def test_prompt_includes_taxonomy_and_dataset(self) -> None:
+        prompt = build_anchor_prompt(
+            dataset_id="ds005505",
+            dataset_description="EEG recordings from HBN.",
+            anchor_doi="10.1234/example",
+            anchor_relation="IsDerivedFrom",
+            paper_title="The Healthy Brain Network",
+            paper_abstract="Multi-site initiative collecting brain data.",
+            paper_venue="Scientific Data",
+            paper_authors=[],
+            paper_year=2017,
+        )
+        # Taxonomy labels appear verbatim so the model can pick from them.
+        for label in ALLOWED_CLASSIFICATIONS:
+            self.assertIn(label, prompt)
+        self.assertIn("ds005505", prompt)
+        self.assertIn("10.1234/example", prompt)
+        self.assertIn("IsDerivedFrom", prompt)
+        self.assertIn("EEG recordings from HBN", prompt)
+        self.assertIn("Multi-site initiative", prompt)
+        # JSON-only directive is critical for parsing.
+        self.assertIn("strict JSON only", prompt)
+
+    def test_prompt_handles_missing_abstract(self) -> None:
+        prompt = build_anchor_prompt(
+            dataset_id="ds000999",
+            dataset_description="A test dataset.",
+            anchor_doi="10.0000/none",
+            anchor_relation="References",
+            paper_title="Some Paper",
+            paper_abstract=None,
+            paper_venue=None,
+            paper_authors=None,
+            paper_year=None,
+        )
+        self.assertIn("[unavailable]", prompt)
+
+    def test_prompt_truncates_long_dataset_description(self) -> None:
+        long_text = "x" * 5000
+        prompt = build_anchor_prompt(
+            dataset_id="ds000999",
+            dataset_description=long_text,
+            anchor_doi="10.0000/none",
+            anchor_relation="References",
+            paper_title="t",
+            paper_abstract="a",
+        )
+        # The literal 5000 x's must not appear; truncation marker should.
+        self.assertNotIn("x" * 5000, prompt)
+        self.assertIn("…", prompt)
+
+
+class JudgeAnchorParseTests(TestCase):
+    """Validate response parsing without touching the network."""
+
+    def test_valid_response_parses(self) -> None:
+        client = _FakeClient('{"classification": "data_paper", "reason": "ok"}')
+        out = client.judge_anchor("prompt")
+        self.assertEqual(out["classification"], "data_paper")
+        self.assertEqual(out["reason"], "ok")
+        self.assertEqual(out["model"], "test-model")
+        self.assertIn("raw_response", out)
+
+    def test_reason_is_stripped(self) -> None:
+        client = _FakeClient(
+            '{"classification": "methodology", "reason": "  trimmed  "}'
+        )
+        out = client.judge_anchor("prompt")
+        self.assertEqual(out["reason"], "trimmed")
+
+    def test_unknown_classification_raises(self) -> None:
+        client = _FakeClient('{"classification": "nonsense", "reason": "bad label"}')
+        with self.assertRaises(LlmJudgmentError) as ctx:
+            client.judge_anchor("prompt")
+        self.assertIn("not in taxonomy", str(ctx.exception))
+
+    def test_missing_classification_raises(self) -> None:
+        client = _FakeClient('{"reason": "no class field"}')
+        with self.assertRaises(LlmJudgmentError):
+            client.judge_anchor("prompt")
+
+    def test_missing_reason_raises(self) -> None:
+        client = _FakeClient('{"classification": "umbrella"}')
+        with self.assertRaises(LlmJudgmentError):
+            client.judge_anchor("prompt")
+
+    def test_empty_reason_raises(self) -> None:
+        client = _FakeClient('{"classification": "irrelevant", "reason": "   "}')
+        with self.assertRaises(LlmJudgmentError):
+            client.judge_anchor("prompt")
+
+    def test_non_json_response_raises(self) -> None:
+        client = _FakeClient("this is not json at all")
+        with self.assertRaises(LlmJudgmentError) as ctx:
+            client.judge_anchor("prompt")
+        self.assertEqual(ctx.exception.raw_response, "this is not json at all")
+
+    def test_json_array_root_raises(self) -> None:
+        client = _FakeClient('["data_paper", "ok"]')
+        with self.assertRaises(LlmJudgmentError):
+            client.judge_anchor("prompt")
+
+
+class EnvDefaultsTests(TestCase):
+    """Verify env var overrides without touching the network."""
+
+    def test_explicit_args_win(self) -> None:
+        client = OllamaJudgmentClient(
+            base_url="http://override:9999",
+            model="custom-model",
+            timeout=11,
+        )
+        try:
+            self.assertEqual(client.base_url, "http://override:9999")
+            self.assertEqual(client.model, "custom-model")
+            self.assertEqual(client.timeout, 11)
+        finally:
+            client.close()
+
+    def test_env_overrides(self) -> None:
+        prior = {
+            "OLLAMA_BASE_URL": os.environ.get("OLLAMA_BASE_URL"),
+            "OLLAMA_MODEL": os.environ.get("OLLAMA_MODEL"),
+            "OLLAMA_TIMEOUT_SECONDS": os.environ.get("OLLAMA_TIMEOUT_SECONDS"),
+        }
+        try:
+            os.environ["OLLAMA_BASE_URL"] = "http://env-host:12345"
+            os.environ["OLLAMA_MODEL"] = "env-model"
+            os.environ["OLLAMA_TIMEOUT_SECONDS"] = "99"
+            client = OllamaJudgmentClient()
+            try:
+                self.assertEqual(client.base_url, "http://env-host:12345")
+                self.assertEqual(client.model, "env-model")
+                self.assertEqual(client.timeout, 99)
+            finally:
+                client.close()
+        finally:
+            for key, value in prior.items():
+                if value is None:
+                    os.environ.pop(key, None)
+                else:
+                    os.environ[key] = value
+
+
+@skipUnless(
+    os.getenv("RUN_INTEGRATION_TESTS"),
+    "live ollama call; set RUN_INTEGRATION_TESTS=1 to enable",
+)
+class OllamaJudgmentClientIntegration(TestCase):
+    """Live integration test against a running Ollama daemon.
+
+    Set OLLAMA_BASE_URL to point at your daemon (defaults to hallu). The
+    test asks the model to classify a fabricated MNE-Python anchor for a
+    fictional dataset and asserts the response is valid + in taxonomy.
+    """
+
+    def test_methodology_anchor_round_trip(self) -> None:
+        prompt = build_anchor_prompt(
+            dataset_id="ds000117",
+            dataset_description=(
+                "Multi-subject MEG and EEG dataset for a face-perception "
+                "experiment, BIDS-formatted."
+            ),
+            anchor_doi="10.3389/fnins.2013.00267",
+            anchor_relation="IsDerivedFrom",
+            paper_title="MEG and EEG data analysis with MNE-Python",
+            paper_abstract=(
+                "MNE-Python is an open-source software package for "
+                "processing MEG and EEG data."
+            ),
+            paper_venue="Frontiers in Neuroscience",
+            paper_year=2013,
+        )
+        with OllamaJudgmentClient() as client:
+            if not client.health_check():
+                self.skipTest("ollama daemon not reachable")
+            result = client.judge_anchor(prompt)
+        self.assertIn(result["classification"], ALLOWED_CLASSIFICATIONS)
+        self.assertTrue(result["reason"])


### PR DESCRIPTION
Closes #85.
Part of epic #76.

## Summary
Stands up the LLM client + the prompt + a throwaway probe so the epic's acceptance gate (the manual spot-check on 10 hand-picked datasets) can be run before phases 2-4 productize the storage, the pipeline integration, and the cron backfill.

Three commits, atomic by deliverable:

1. `feat(backend): add OpenCiteBackend.get_paper sync facade` — synchronous lookup of an anchor paper's own bib + abstract via opencite's OpenAlexClient. Used by the probe (and the phase 2 CLI) to assemble candidate paper context for the LLM prompt.
2. `feat(quality): add Ollama judgment client + prompt builder` — `OllamaJudgmentClient` is a sync httpx wrapper around Ollama's `/api/generate` endpoint, `format=json`. Defaults to `gemma3:27b` on `http://hallu:11434`, overridable via `OLLAMA_BASE_URL` / `OLLAMA_MODEL` / `OLLAMA_TIMEOUT_SECONDS`. `build_anchor_prompt` is the single source of truth for the prompt: 5-class taxonomy (`data_paper` / `umbrella` / `methodology` / `related_work` / `irrelevant`), 3 in-prompt few-shot examples covering the acceptance-gate cases (HBN umbrella, dataset preprint, MNE-Python methodology), JSON-only output directive.
3. `feat(scripts): add probe_anchor_judgment for epic #76 gate` — throwaway probe over `PROBE_DATASETS` (HBN sibling, ds000117, ds000246, plus a mix of ds-/nm-/on- ids). Health-checks Ollama before any judgments, prints one row per anchor, and optionally dumps full per-anchor JSON (prompt + raw model response) via `--output`.

## Acceptance gate
Per epic #76, before merging this PR run the probe against hallu and confirm:

- HBN sibling dataset classifies the HBN umbrella paper as `umbrella` and the dataset preprint as `data_paper`.
- A clean nm-* dataset has its data paper classified as `data_paper`.
- A dataset whose only anchor is MNE-Python classifies as `methodology`.

```bash
OLLAMA_BASE_URL=http://hallu:11434 \
  uv run python scripts/probe_anchor_judgment.py \
    --output .context/probe_anchor_judgment_$(date +%Y-%m-%d).json
```

Attach the resulting JSON (or the terminal summary) to this PR before merge. If the three cases don't classify cleanly, iterate on `build_anchor_prompt` in this same branch — the whole point of phase 1 is to fail fast on the prompt.

## Test plan
- [x] `uv run ruff format` — clean
- [x] `uv run ruff check` — clean
- [x] `uv run ty check src/` — no new diagnostics introduced (104 pre-existing, 104 after)
- [x] `uv run pytest tests/` — 188 passed, 24 integration-gated skipped
- [ ] Probe run against hallu's Ollama produces sensible classifications on the 3 gate cases (operator step; attach output to PR)

## Out of scope (later phases)
- Sidecar JSON storage at `citations/anchor_judgments/<id>.json` — phase 2 (#86)
- `dataset-citations-judge-anchors` CLI — phase 2
- Pipeline integration / bucketing in `core/opencite_pipeline.py` — phase 3 (#87)
- Hallu cron wiring + full backfill execution — phase 4 (#88)