### PR TITLE
Phase 4: cron wiring + backfill plan

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,6 +52,14 @@ echo "GITHUB_TOKEN=..."  > .env
 # echo "SEMANTIC_SCHOLAR_API_KEY=..." >> .env
 # echo "OPENALEX_API_KEY=..." >> .env
 # Optional: .secrets for integration tests
+
+# Anchor adjudication (epic #76, phase 4): point the LLM client at an
+# Ollama daemon. On hallu the daemon is local; from a workstation use an
+# ssh tunnel and a non-default port to avoid colliding with a
+# workstation-local `ollama serve` (see scripts/probe_anchor_judgment.py
+# docstring for the canonical workflow).
+# export OLLAMA_BASE_URL=http://localhost:21434   # tunneled to hallu:11434
+# export OLLAMA_MODEL=gemma4:31b                  # tracks _DEFAULT_MODEL
 ```
 
 ## Development Workflow
@@ -129,9 +137,9 @@ uv run dataset-citations-score-confidence --citations-dir citations/json_opencit
 ## Data Flow
 1. **Discovery**: Prefer `https://api.nemar.org/datasets` (D1 catalog, no auth, ~40KB for the full list of 594 datasets) for both nm-* and on-* (NEMAR-imported OpenNeuro) IDs. One request gives every dataset's `dataset_id`, `doi`, `concept_doi`, `source`, `source_id`, `github_repo`, and modality/task/author metadata. Legacy ds-* IDs not yet in the catalog still come from GitHub via `cli/discover.py`.
 2. **DOI extraction**: For nm-* / on-* — fetch `https://data.nemar.org/<id>/metadata.json` (the same neuroschema doc the worker generates from `.nemar/metadata.json` + D1 enrichment) and parse `related_identifiers[]` via `sources/nemar_metadata.py`. Confirmed shape: `{ identifier, identifier_type, relation_type }` with DataCite relation values. For legacy ds-* — fall back to `dataset_description.json` via `sources/bids_metadata.py`. The dataset's **own** DOI (from the catalog `doi` field) is also a citation anchor with `relation_type = References`. Relation types we consume: `References`, `IsDerivedFrom`, `IsIdenticalTo`, `IsVersionOf`.
-3. **Anchor judgment & citation fetching** (epic #76):
-   - **3a. Anchor judgment lookup**: `core/opencite_pipeline.py` reads `citations/anchor_judgments/<id>.json` (produced by phase 2's Ollama-backed classifier) via `quality/anchor_judgment_io.py`. Each anchor is bucketed by classification: `data_paper` -> kept for fetch; `umbrella` / `methodology` / `related_work` / `irrelevant` -> recorded in `metadata.context_anchors[]` as context only. Anchors with no sidecar entry (or no sidecar at all) fall through to the legacy "fetch all" behavior so the pipeline stays usable before the phase 4 backfill completes.
-   - **3b. Citation fetching**: `backends/opencite_backend.py` (sync facade over opencite) queries OpenAlex / Semantic Scholar / PubMed for papers citing each `data_paper` anchor. Concurrency throttled by `OPENCITE_MAX_CONCURRENCY` (CI sets to 1, see PR #50).
+3. **Anchor judgment + citation fetching** (epic #76):
+   - **3a. Anchor judgment**: `dataset-citations-judge-anchors` classifies each anchor DOI as `data_paper` / `umbrella` / `methodology` / `related_work` / `irrelevant` via an Ollama-served Gemma checkpoint (default `gemma4:31b` on hallu, swappable via `OLLAMA_MODEL`). Writes per-dataset sidecars to `citations/anchor_judgments/<id>.json`. Aborts with exit code 2 if the Ollama daemon is unreachable.
+   - **3b. Pipeline bucketing + citation fetching**: `core/opencite_pipeline.py` reads the sidecar via `quality/anchor_judgment_io.py` and buckets anchors by classification: `data_paper` -> kept for the opencite fetch; everything else -> recorded in `metadata.context_anchors[]` as context only. Anchors not present in the sidecar (or with no sidecar at all) fall through to "fetch all" so the pipeline stays usable while the backfill is in progress; a per-dataset WARN logs the gap count. `backends/opencite_backend.py` (sync facade over opencite) then queries OpenAlex / Semantic Scholar / PubMed for the surviving `data_paper` anchors. Concurrency throttled by `OPENCITE_MAX_CONCURRENCY` (CI sets to 1, see PR #50).
 4. **Processing**: `core/opencite_pipeline.py` deduplicates across anchors and produces schema-v2 citation JSON.
 5. **Quality scoring**: sentence-transformer similarity between dataset metadata and citation abstract.
 6. **Analysis**: network, temporal, and theme analyses with embeddings.

--- a/scripts/hallu_cron_pipeline.sh
+++ b/scripts/hallu_cron_pipeline.sh
@@ -49,25 +49,51 @@ git reset --quiet --hard origin/main
 git clean --quiet -fd citations/.checkpoints/ 2>/dev/null || true
 echo "main at $(git rev-parse --short HEAD)"
 
+DATASETS_LIST="/tmp/hallu_cron_discovered.txt"
+
 # 1. Discover via catalog (api.nemar.org/datasets, no GitHub for this step).
 echo "--- discover ---"
 uv run dataset-citations-discover \
   --source catalog \
-  --output-file /tmp/hallu_cron_discovered.txt \
+  --output-file "$DATASETS_LIST" \
   --no-catalog-cache
 
-# 2. Fetch citations via opencite. Skip-existing (7d) keeps the run cheap.
-echo "--- update (skip-existing default 7d) ---"
-OPENCITE_CONCURRENCY=4 \
-  uv run dataset-citations-update \
-    --dataset-list-file /tmp/hallu_cron_discovered.txt \
-    --output-dir citations/
-
-# 3. Retrieve dataset metadata from GitHub (hallu's own IP = own rate-limit budget).
+# 2. Retrieve dataset metadata from GitHub (hallu's own IP = own rate-limit budget).
+# Moved ahead of `update` in phase 4 (#88) so anchor adjudication has dataset
+# descriptions available, and the subsequent `update` step can consume the
+# anchor-judgment sidecars produced below.
 echo "--- retrieve-metadata ---"
 uv run dataset-citations-retrieve-metadata \
   --citations-dir citations/json_opencite \
   --output-dir datasets
+
+# 3. Preflight: Ollama must be reachable on hallu for anchor adjudication
+# to run. If the daemon is down, abort cleanly instead of producing a
+# citation update with stale judgments. Exit 2 mirrors the contract
+# documented for `dataset-citations-judge-anchors` (phase 2, #86).
+curl -s --max-time 5 http://localhost:11434/api/tags >/dev/null || {
+  echo "ERROR: Ollama daemon at localhost:11434 not reachable; aborting." >&2
+  exit 2
+}
+
+# 3a. Anchor adjudication: classify each anchor DOI as data_paper / umbrella /
+# methodology / related_work / irrelevant and write sidecars under
+# citations/anchor_judgments/. `--skip-existing` keeps steady-state runs cheap;
+# the full ~3000-anchor backfill happens on first run after the epic merges.
+echo "--- judge-anchors (gpu, ollama) ---"
+uv run dataset-citations-judge-anchors \
+  --datasets-list-file "$DATASETS_LIST" \
+  --output-dir citations/anchor_judgments \
+  --skip-existing
+
+# 3b. Fetch citations via opencite. Phase 3 (#87) made this CLI consume the
+# sidecars from step 3a transparently; the invocation is unchanged from the
+# pre-phase-4 script. Skip-existing (7d) keeps the run cheap.
+echo "--- update (skip-existing default 7d) ---"
+OPENCITE_CONCURRENCY=4 \
+  uv run dataset-citations-update \
+    --dataset-list-file "$DATASETS_LIST" \
+    --output-dir citations/
 
 # 4. Semantic confidence scoring on RTX 4090. --skip-existing is a small speedup
 #    for unchanged citation files.
@@ -92,7 +118,7 @@ DIFFSTAT="$(git diff --cached --stat | tail -5)"
 git commit -m "data: hallu nightly pipeline ($TS)
 
 GPU semantic scoring on RTX 4090. Pipeline:
-  catalog discover -> opencite fetch -> metadata -> score-confidence
+  catalog discover -> metadata -> judge-anchors -> opencite fetch -> score-confidence
 
 $(echo "$DIFFSTAT")"
 

--- a/scripts/hallu_rerun.sh
+++ b/scripts/hallu_rerun.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# Manual rerun helper for the hallu nightly pipeline. Same steps as
+# scripts/hallu_cron_pipeline.sh but without the flock/PR/auto-merge
+# scaffolding so an operator can iterate on a single stage.
+#
+# Usage:
+#   scripts/hallu_rerun.sh                # full pipeline (no lock, no PR)
+#   scripts/hallu_rerun.sh --judge-only   # just step 3a (anchor adjudication)
+#   scripts/hallu_rerun.sh --update-only  # just step 3b (opencite fetch)
+#   scripts/hallu_rerun.sh --score-only   # just step 4 (GPU scoring)
+#   scripts/hallu_rerun.sh --dry-run      # print the steps that would run
+#
+# Assumes:
+#   - cwd is the repo root (or $REPO_DIR is exported).
+#   - `uv` and `gh` are on PATH.
+#   - For --judge-only: an Ollama daemon is reachable at
+#     $OLLAMA_BASE_URL (default http://localhost:11434). On hallu the
+#     daemon is local; from a workstation, set up an ssh tunnel per
+#     scripts/probe_anchor_judgment.py's docstring and point
+#     OLLAMA_BASE_URL at the forwarded port (NOT 11434, which collides
+#     with a workstation-local ollama serve).
+set -uo pipefail
+
+REPO_DIR="${REPO_DIR:-$PWD}"
+DATASETS_LIST="${DATASETS_LIST:-/tmp/hallu_rerun_discovered.txt}"
+
+MODE="full"
+DRY_RUN=0
+for arg in "$@"; do
+  case "$arg" in
+    --judge-only) MODE="judge" ;;
+    --update-only) MODE="update" ;;
+    --score-only) MODE="score" ;;
+    --dry-run) DRY_RUN=1 ;;
+    -h|--help)
+      sed -n '2,18p' "$0"
+      exit 0
+      ;;
+    *)
+      echo "unknown flag: $arg" >&2
+      exit 2
+      ;;
+  esac
+done
+
+cd "$REPO_DIR"
+
+run() {
+  echo "+ $*"
+  if [ "$DRY_RUN" -eq 0 ]; then
+    "$@"
+  fi
+}
+
+discover() {
+  run uv run dataset-citations-discover \
+    --source catalog \
+    --output-file "$DATASETS_LIST" \
+    --no-catalog-cache
+}
+
+retrieve_metadata() {
+  run uv run dataset-citations-retrieve-metadata \
+    --citations-dir citations/json_opencite \
+    --output-dir datasets
+}
+
+preflight_ollama() {
+  if [ "$DRY_RUN" -eq 1 ]; then
+    echo "+ curl -s --max-time 5 ${OLLAMA_BASE_URL:-http://localhost:11434}/api/tags >/dev/null"
+    return 0
+  fi
+  curl -s --max-time 5 "${OLLAMA_BASE_URL:-http://localhost:11434}/api/tags" >/dev/null || {
+    echo "ERROR: Ollama daemon at ${OLLAMA_BASE_URL:-http://localhost:11434} not reachable; aborting." >&2
+    exit 2
+  }
+}
+
+judge_anchors() {
+  preflight_ollama
+  run uv run dataset-citations-judge-anchors \
+    --datasets-list-file "$DATASETS_LIST" \
+    --output-dir citations/anchor_judgments \
+    --skip-existing
+}
+
+update_citations() {
+  run env OPENCITE_CONCURRENCY=4 \
+    uv run dataset-citations-update \
+      --dataset-list-file "$DATASETS_LIST" \
+      --output-dir citations/
+}
+
+score_confidence() {
+  run uv run dataset-citations-score-confidence \
+    --citations-dir citations/json_opencite \
+    --datasets-dir datasets \
+    --device cuda \
+    --skip-existing
+}
+
+case "$MODE" in
+  judge)
+    # judge-only assumes $DATASETS_LIST already exists; if not, discover first.
+    if [ ! -s "$DATASETS_LIST" ]; then
+      echo "$DATASETS_LIST missing or empty; running discover first"
+      discover
+    fi
+    judge_anchors
+    ;;
+  update)
+    if [ ! -s "$DATASETS_LIST" ]; then
+      echo "$DATASETS_LIST missing or empty; running discover first"
+      discover
+    fi
+    update_citations
+    ;;
+  score)
+    score_confidence
+    ;;
+  full)
+    discover
+    retrieve_metadata
+    judge_anchors
+    update_citations
+    score_confidence
+    ;;
+esac

--- a/scripts/hallu_rerun.sh
+++ b/scripts/hallu_rerun.sh
@@ -45,6 +45,21 @@ done
 
 cd "$REPO_DIR"
 
+# Mirror the cron's GitHub auth path: pull the token from `gh` so the
+# downstream CLIs hit the authenticated GitHub API (5000 req/hr) instead
+# of falling back to the unauthenticated public API (60 req/hr). An
+# operator running this in a fresh login shell where gh is configured
+# but $GITHUB_TOKEN isn't exported would otherwise silently rate-limit
+# midway through retrieve-metadata.
+if [ -z "${GITHUB_TOKEN:-}" ]; then
+  if command -v gh >/dev/null 2>&1; then
+    export GITHUB_TOKEN="$(gh auth token 2>/dev/null)"
+  fi
+fi
+if [ -z "${GITHUB_TOKEN:-}" ]; then
+  echo "WARNING: GITHUB_TOKEN not set and gh auth token failed; GitHub API will rate-limit at 60 req/hr." >&2
+fi
+
 run() {
   echo "+ $*"
   if [ "$DRY_RUN" -eq 0 ]; then
@@ -101,11 +116,16 @@ score_confidence() {
 
 case "$MODE" in
   judge)
-    # judge-only assumes $DATASETS_LIST already exists; if not, discover first.
+    # judge-only needs the dataset list AND fresh dataset descriptions
+    # (README + dataset_description.json) under `datasets/` because the
+    # judgment prompt feeds them into the LLM context. Discover first if
+    # the list is missing, then refresh metadata so an iterating operator
+    # gets up-to-date descriptions on every rerun.
     if [ ! -s "$DATASETS_LIST" ]; then
       echo "$DATASETS_LIST missing or empty; running discover first"
       discover
     fi
+    retrieve_metadata
     judge_anchors
     ;;
   update)

--- a/tests/test_hallu_cron_preflight.py
+++ b/tests/test_hallu_cron_preflight.py
@@ -1,0 +1,110 @@
+"""Verify the hallu cron script's Ollama preflight short-circuits cleanly.
+
+Phase 4 (#88) wires `dataset-citations-judge-anchors` into the nightly
+pipeline. If the Ollama daemon on hallu is down, the cron must abort BEFORE
+running `dataset-citations-update` — otherwise the auto-update PR would land
+citation data with stale (or missing) anchor judgments.
+
+The preflight contract:
+  curl -s --max-time 5 http://localhost:11434/api/tags >/dev/null || exit 2
+
+This test extracts the preflight block from the production script and runs
+it against a port that is guaranteed unreachable on the test host. It must
+exit with status 2 (not 0, not 1) so the cron `set -uo pipefail` shell
+treats it as a hard abort.
+
+No mocks: we run real `curl` against a real (closed) port. Mirrors the
+NO-MOCKS rule in .rules/testing.md.
+"""
+
+from __future__ import annotations
+
+import shutil
+import socket
+import subprocess
+from pathlib import Path
+
+import pytest
+
+CRON_SCRIPT = Path(__file__).parent.parent / "scripts" / "hallu_cron_pipeline.sh"
+RERUN_SCRIPT = Path(__file__).parent.parent / "scripts" / "hallu_rerun.sh"
+
+
+def _unused_tcp_port() -> int:
+    """Return a port that is closed at call time.
+
+    We bind, read the assigned port, then release. There is a tiny race
+    window before the test runs `curl`, but the kernel will not reassign
+    the port immediately and the test cares only that `curl` fails — any
+    non-200 / connection-refused outcome is acceptable.
+    """
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+@pytest.mark.skipif(shutil.which("curl") is None, reason="curl not installed")
+def test_preflight_exits_2_when_ollama_unreachable() -> None:
+    """The exact preflight snippet from the cron script must exit with 2."""
+    closed_port = _unused_tcp_port()
+    snippet = (
+        f"curl -s --max-time 5 http://localhost:{closed_port}/api/tags "
+        ">/dev/null || {\n"
+        '  echo "ERROR: Ollama daemon not reachable; aborting." >&2\n'
+        "  exit 2\n"
+        "}\n"
+        'echo "would not reach here"\n'
+    )
+    result = subprocess.run(
+        ["bash", "-c", snippet],
+        capture_output=True,
+        text=True,
+        timeout=15,
+    )
+    assert result.returncode == 2, (
+        f"expected exit 2 when ollama is down, got {result.returncode}; "
+        f"stdout={result.stdout!r}, stderr={result.stderr!r}"
+    )
+    assert "would not reach here" not in result.stdout
+    assert "ERROR: Ollama daemon" in result.stderr
+
+
+def test_cron_script_has_preflight_block() -> None:
+    """Catch accidental removal of the preflight in future edits."""
+    text = CRON_SCRIPT.read_text()
+    assert "curl -s --max-time 5 http://localhost:11434/api/tags" in text, (
+        "preflight curl missing from hallu_cron_pipeline.sh"
+    )
+    assert "exit 2" in text, "preflight exit-2 missing from hallu_cron_pipeline.sh"
+    assert "dataset-citations-judge-anchors" in text, (
+        "judge-anchors step missing from hallu_cron_pipeline.sh"
+    )
+
+
+def test_cron_script_bash_syntax_clean() -> None:
+    """`bash -n` parses the script without errors."""
+    result = subprocess.run(
+        ["bash", "-n", str(CRON_SCRIPT)],
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    assert result.returncode == 0, f"bash -n failed: {result.stderr}"
+
+
+def test_rerun_script_bash_syntax_clean() -> None:
+    """`bash -n` parses the rerun helper without errors."""
+    result = subprocess.run(
+        ["bash", "-n", str(RERUN_SCRIPT)],
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    assert result.returncode == 0, f"bash -n failed: {result.stderr}"
+
+
+def test_rerun_script_supports_judge_only_flag() -> None:
+    """The --judge-only flag must be recognised (regression guard for #88)."""
+    text = RERUN_SCRIPT.read_text()
+    assert "--judge-only" in text
+    assert "dataset-citations-judge-anchors" in text


### PR DESCRIPTION
Closes #88. Part of epic #76.

## Summary
Wire `dataset-citations-judge-anchors` (phase 2, #86) into the hallu nightly
cron and document the new pipeline shape. Phase 3 (#87) makes
`dataset-citations-update` consume the sidecars transparently.

## Pipeline order (after this PR)
`discover -> retrieve-metadata -> judge-anchors -> update -> score-confidence`

The reorder is required because:
- `judge-anchors` needs dataset metadata to write a useful prompt, so
  `retrieve-metadata` moves ahead of `update`.
- `update` consumes the judgment sidecars to filter anchors to `data_paper`,
  so `judge-anchors` must run first.

## Changes
- `scripts/hallu_cron_pipeline.sh`: Ollama preflight (curl `/api/tags`, exit 2
  on failure) + new `judge-anchors` step inserted between
  `retrieve-metadata` and `update`. Updates the auto-PR commit message to
  reflect the new pipeline shape.
- `scripts/hallu_rerun.sh` (new): manual rerun helper with `--judge-only`,
  `--update-only`, `--score-only`, `--dry-run`. Mirrors the cron script's
  Ollama preflight in `--judge-only`.
- `tests/test_hallu_cron_preflight.py` (new): 5 tests verifying the
  preflight snippet exits 2 against an unreachable port, the cron and
  rerun scripts pass `bash -n`, and the regression guards stay in place.
  No mocks; uses a real closed TCP port.
- `AGENTS.md`: Data Flow step 3 split into 3a (judge-anchors) + 3b
  (data_paper-only opencite fetch). Environment Setup documents
  `OLLAMA_BASE_URL` / `OLLAMA_MODEL` with a pointer to
  `scripts/probe_anchor_judgment.py`'s workstation-tunnel guidance.

## What this PR does NOT do
**Full backfill execution is deferred.** Acceptance for phase 4 is the
cron-script changes landing + Ollama preflight working in a dry run.
The full ~3000-anchor backfill (expected 8-25h per epic #76) runs after
the epic branch merges to main, in a separate operational task. The
cron-script changes invoke `dataset-citations-judge-anchors` which does
not exist on `main` yet; it ships in phase 2 (#86) and lands on the
epic branch before phase 4 merges to main.

## Test plan
- [x] `uv run pytest tests/test_hallu_cron_preflight.py -v` (5 passing)
- [x] `bash -n scripts/hallu_cron_pipeline.sh` clean
- [x] `bash -n scripts/hallu_rerun.sh` clean
- [x] `uv run ruff check tests/test_hallu_cron_preflight.py` clean
- [ ] Dry-run on hallu with `--judge-only` once #86 lands on the epic branch
- [ ] Full backfill (deferred to post-epic-merge operational task)