### PR TITLE
Phase 1: cron retrieve-metadata --skip-existing

### DIFF
--- a/scripts/hallu_cron_pipeline.sh
+++ b/scripts/hallu_cron_pipeline.sh
@@ -62,10 +62,18 @@ uv run dataset-citations-discover \
 # Moved ahead of `update` in phase 4 (#88) so anchor adjudication has dataset
 # descriptions available, and the subsequent `update` step can consume the
 # anchor-judgment sidecars produced below.
+# `--skip-existing` keeps steady-state runs cheap and (more importantly) ducks
+# the GitHub secondary rate limit that bit us during the post-#76 backfill:
+# refetching ~3000 unchanged dataset_description.json + README files every
+# weekly run is wasted quota. Trade-off: a dataset's GitHub-side description
+# / README will only refresh when the cached file is deleted; #82 (follow-up)
+# adds a `--max-age-days` flag mirroring `update.py` so the freshness window
+# is configurable without an explicit wipe.
 echo "--- retrieve-metadata ---"
 uv run dataset-citations-retrieve-metadata \
   --citations-dir citations/json_opencite \
-  --output-dir datasets
+  --output-dir datasets \
+  --skip-existing
 
 # 3. Preflight: Ollama must be reachable for anchor adjudication. If the
 # daemon is down, abort cleanly instead of producing a citation update


### PR DESCRIPTION
Closes #97. Closes #81.
Part of epic #96.

## Summary
One-line fix to `scripts/hallu_cron_pipeline.sh`: pass `--skip-existing` to `dataset-citations-retrieve-metadata` so the cron doesn't re-fetch ~3000 unchanged dataset_description.json / README files on every weekly run.

This bit us today: during the post-#76 backfill kick-off, the cron hit GitHub's secondary rate limit ~5h in and entered a 1-hour PyGithub backoff. With `--skip-existing` in place, the steady-state run touches GitHub only for new or changed datasets, ducking the rate-limit pressure entirely.

`score-confidence` in the same script already has `--skip-existing`; this aligns the two heavy steps.

## Trade-off
A dataset's GitHub-side README / dataset_description.json refresh only when the cached file is deleted. Follow-up #82 will add a `--max-age-days` flag mirroring `update.py`'s freshness semantics so the refresh window is configurable. Until then, `rm datasets/<id>_datasets.json` is the manual escape hatch.

## Test plan
- [x] `bash -n scripts/hallu_cron_pipeline.sh` clean
- [x] `tests/test_hallu_cron_preflight.py` still green (5/5 passed)
- [x] `dataset-citations-retrieve-metadata --help` confirms `--skip-existing` flag exists
- [ ] CI green on this PR (will validate on push)