### PR TITLE
Phase 5: simplify deploy-dashboard.yml

### DIFF
--- a/.github/workflows/deploy-dashboard.yml
+++ b/.github/workflows/deploy-dashboard.yml
@@ -3,10 +3,12 @@ name: Deploy Citation Dashboard
 # Two triggers:
 #   1. workflow_dispatch — manual rebuild + deploy (e.g. after a code-only
 #      change to the dashboard generator).
-#   2. push to main when citations/json_opencite/ or datasets/ change —
-#      this is what closes the hallu cron loop: hallu opens a PR with
-#      refreshed data, CI auto-merges, the merge push fires this workflow,
-#      dashboard.nemar.org updates with no human in the loop.
+#   2. push to main when citation data, analysis outputs, embeddings, or
+#      the workflow itself change. This closes the hallu cron loop: the
+#      hallu cron now produces `citations/json_opencite/`, `dashboard_data/`,
+#      and `embeddings/` itself (epic #96, phases 2 + 3). When its
+#      auto-update PR merges, the resulting push to main fires this
+#      workflow and Cloudflare Pages picks up the refreshed analysis.
 on:
   workflow_dispatch:
   push:
@@ -15,6 +17,8 @@ on:
     paths:
       - "citations/json_opencite/**"
       - "datasets/**"
+      - "dashboard_data/**"
+      - "embeddings/**"
       - ".github/workflows/deploy-dashboard.yml"
 
 jobs:
@@ -30,32 +34,54 @@ jobs:
         with:
           enable-cache: true
 
+      # CPU-only torch keeps this job light. The dashboard generator itself
+      # does not import torch, but `sentence-transformers` is a transitive
+      # dep of the package (used by score-confidence on hallu), so a plain
+      # `uv sync` would pull CUDA wheels onto a GitHub-hosted runner. The
+      # CPU index avoids that and keeps cold-start under a minute.
       - name: Sync project (CPU-only torch)
         env:
           UV_EXTRA_INDEX_URL: https://download.pytorch.org/whl/cpu
           UV_INDEX_STRATEGY: unsafe-best-match
         run: uv sync --python 3.13 --all-extras
 
+      # Fail-fast guard: the hallu cron is now the sole producer of
+      # `dashboard_data/themes/`, `dashboard_data/network/`,
+      # `dashboard_data/temporal/`, and `embeddings/`. If any of those
+      # are missing on main, something upstream broke (hallu cron
+      # skipped a step, PR landed without analysis outputs, etc.). We
+      # refuse to deploy a half-rendered dashboard over the live one;
+      # the previous deploy stays live on Cloudflare Pages until a fix
+      # lands. See epic #96, issue #101.
+      - name: Verify hallu-produced inputs are present
+        run: |
+          set -e
+          missing=0
+          for dir in \
+            "dashboard_data/themes" \
+            "dashboard_data/network" \
+            "dashboard_data/temporal" \
+            "embeddings" \
+            "citations/json_opencite"; do
+            if [ ! -d "$dir" ] || [ -z "$(ls -A "$dir" 2>/dev/null)" ]; then
+              echo "::error::Required input directory missing or empty: $dir"
+              missing=1
+            else
+              count=$(find "$dir" -type f | wc -l | tr -d ' ')
+              echo "OK: $dir ($count files)"
+            fi
+          done
+          if [ "$missing" -ne 0 ]; then
+            echo "::error::Refusing to deploy; hallu cron outputs are incomplete."
+            echo "::error::The previous Cloudflare Pages deploy stays live."
+            exit 1
+          fi
+
       - name: Generate dashboard
         run: |
-          mkdir -p dashboard_data/{network,themes,temporal,visualizations}
+          mkdir -p dashboard_data/visualizations
 
-          echo "Generating theme analysis..."
-          uv run python -m dataset_citations.analysis.generate_themes \
-            --citations-dir citations/json_opencite \
-            --output-dir dashboard_data/themes || echo "Theme generation had issues"
-
-          echo "Generating network analysis..."
-          uv run python -m dataset_citations.analysis.generate_network \
-            --citations-dir citations/json_opencite \
-            --output-dir dashboard_data/network || echo "Network analysis had issues"
-
-          echo "Generating temporal analysis..."
-          uv run python -m dataset_citations.analysis.generate_temporal \
-            --citations-dir citations/json_opencite \
-            --output-dir dashboard_data/temporal || echo "Temporal analysis had issues"
-
-          echo "Building dashboard..."
+          echo "Building dashboard from hallu-produced analysis outputs..."
           uv run python -c "
           from dataset_citations.dashboard.core import DashboardGenerator
           from pathlib import Path

--- a/.github/workflows/deploy-dashboard.yml
+++ b/.github/workflows/deploy-dashboard.yml
@@ -71,6 +71,18 @@ jobs:
               echo "OK: $dir ($count files)"
             fi
           done
+          # UMAP outputs (phase 3, #99) live FLAT in dashboard_data/ as
+          # *similarities*.csv so the aggregator's non-recursive glob picks
+          # them up. Missing CSVs would render an empty Citation Similarities
+          # panel without otherwise breaking the build; catch that here.
+          sim_count=$(find dashboard_data -maxdepth 1 -name "*similarities*.csv" -type f 2>/dev/null | wc -l | tr -d ' ')
+          if [ "$sim_count" -eq 0 ]; then
+            echo "::error::No *similarities*.csv files at dashboard_data/ top level"
+            echo "::error::Phase 3 of epic #96 expects hallu's analyze-umap step to write them flat there"
+            missing=1
+          else
+            echo "OK: dashboard_data/*similarities*.csv ($sim_count files)"
+          fi
           if [ "$missing" -ne 0 ]; then
             echo "::error::Refusing to deploy; hallu cron outputs are incomplete."
             echo "::error::The previous Cloudflare Pages deploy stays live."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -203,7 +203,7 @@ Both upstream sources we depend on have throttled us in production. Treat extern
 ## CI/CD
 - `.github/workflows/test.yml` — Lint (ruff format/check, ty), pytest 3.13, integration tests
 - `.github/workflows/update_citations.yml`: weekly cron (Sunday 06:00 UTC) plus `workflow_dispatch`. Fetches citations via opencite, regenerates the dashboard, deploys to Cloudflare Pages, opens PR.
-- `.github/workflows/deploy-dashboard.yml` — Manual rebuild + deploy
+- `.github/workflows/deploy-dashboard.yml` — Builds the HTML from already-produced `dashboard_data/` + `embeddings/` and deploys to Cloudflare Pages. The heavy analysis steps (themes, network, temporal, embeddings, UMAP) now run on the hallu GPU host via `scripts/hallu_cron_pipeline.sh` (epic #96, phases 2 + 3); CI just consumes the artifacts the hallu auto-update PR commits. The workflow fires on `push` to main when `citations/json_opencite/**`, `datasets/**`, `dashboard_data/**`, or `embeddings/**` change, and has a fail-fast guard that refuses to deploy if any required input directory is missing or empty (the previous Cloudflare Pages deploy stays live in that case).
 - Required secrets: `GITHUB_TOKEN`, `CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ACCOUNT_ID`. Optional: `OPENALEX_API_KEY` (politeness pool), `SEMANTIC_SCHOLAR_API_KEY` (only while S2 is still wired in opencite — see retirement note in Fetch Strategy).
 - Known blocker (May 2026): the full opencite backfill has not yet produced data; `citations/json_opencite/` is empty and the public dashboard still shows January 2026 scholarly-format JSON. Last `workflow_dispatch` run (`26030534541`) was cancelled at the 6h GitHub Actions ceiling during the fetch step. Resolve before relying on cron output.
 


### PR DESCRIPTION
Closes #101. Part of epic #96.

## DO NOT MERGE until phases 2 + 3 (#98 + #99) are merged first.

This PR removes the in-CI analysis steps because hallu's cron will start producing them itself once phases 2 + 3 land. Merging this before those land will deploy a broken dashboard (themes / network / temporal / embeddings outputs would be missing from main).

The fail-fast guard added here would catch that and refuse to deploy, leaving the previous Cloudflare Pages deploy live. But the right ordering is still phases 2 + 3 first, then this.

## What changed

`.github/workflows/deploy-dashboard.yml`:
- Removed the in-CI invocations of `generate_themes`, `generate_network`, and `generate_temporal`. These move to the hallu cron pipeline (phases 2 + 3).
- Kept the `DashboardGenerator` invocation, which renders HTML from `dashboard_data/` + `citations/json_opencite/`. Verified the dashboard module imports no torch / sentence-transformers / sklearn, so it does not need GPU or even the ML stack at runtime.
- Extended the `paths:` filter to include `dashboard_data/**` and `embeddings/**` so a hallu auto-update PR landing fresh analysis outputs correctly triggers a redeploy.
- Added a `Verify hallu-produced inputs are present` step that fails fast if `dashboard_data/themes/`, `dashboard_data/network/`, `dashboard_data/temporal/`, `embeddings/`, or `citations/json_opencite/` is missing or empty. Cloudflare Pages keeps the previous deploy live on failure, so this is a safe fallback.

`AGENTS.md`:
- Updated the CI/CD section to reflect that the heavy analysis runs on hallu, with deploy-dashboard.yml as a thin consumer.

## CPU-only torch sync

Kept the `Sync project (CPU-only torch)` step. The dashboard generator itself does not need torch, but `sentence-transformers` is a core dependency of the `dataset_citations` package (used by `score-confidence` on hallu) and `uv sync` resolves the whole dependency tree. Without the CPU-only index hint, uv would pull CUDA wheels onto a GitHub-hosted runner, which wastes time and disk. Trimming this further would mean splitting the package into a `[dashboard]` extra, which is out of phase 5 scope, tracked as a follow-up.

## Test plan

- [ ] After phases 2 + 3 land and produce `dashboard_data/` + `embeddings/` outputs on the epic branch, run `workflow_dispatch` on this branch and confirm the dashboard renders with UMAP + wordcloud panels.
- [ ] Force-empty one of the required directories on a scratch branch and confirm the verify step fails the run cleanly without invoking the Cloudflare deploy action.
- [ ] YAML lints cleanly (`uv run python -c "import yaml; yaml.safe_load(open('.github/workflows/deploy-dashboard.yml'))"`).