### PR TITLE
Phase 2: wire generate-embeddings into hallu cron

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -141,9 +141,10 @@ uv run dataset-citations-score-confidence --citations-dir citations/json_opencit
    - **3a. Anchor judgment**: `dataset-citations-judge-anchors` classifies each anchor DOI as `data_paper` / `umbrella` / `methodology` / `related_work` / `irrelevant` via an Ollama-served Gemma checkpoint (default `gemma4:31b` on hallu, swappable via `OLLAMA_MODEL`). Writes per-dataset sidecars to `citations/anchor_judgments/<id>.json`. Aborts with exit code 2 if the Ollama daemon is unreachable.
    - **3b. Pipeline bucketing + citation fetching**: `core/opencite_pipeline.py` reads the sidecar via `quality/anchor_judgment_io.py` and buckets anchors by classification: `data_paper` -> kept for the opencite fetch; everything else -> recorded in `metadata.context_anchors[]` as context only. Anchors not present in the sidecar (or with no sidecar at all) fall through to "fetch all" so the pipeline stays usable while the backfill is in progress; a per-dataset WARN logs the gap count. `backends/opencite_backend.py` (sync facade over opencite) then queries OpenAlex / Semantic Scholar / PubMed for the surviving `data_paper` anchors. Concurrency throttled by `OPENCITE_MAX_CONCURRENCY` (CI sets to 1, see PR #50).
 4. **Processing**: `core/opencite_pipeline.py` deduplicates across anchors and produces schema-v2 citation JSON.
-5. **Quality scoring**: sentence-transformer similarity between dataset metadata and citation abstract.
-6. **Analysis**: network, temporal, and theme analyses with embeddings.
-7. **Dashboard**: interactive HTML + D3 deployed to Cloudflare Pages at `dashboard.nemar.org/citations/`.
+5. **Quality scoring**: sentence-transformer similarity between dataset metadata and citation abstract. Runs on hallu's RTX 4090 via `scripts/hallu_cron_pipeline.sh` (epic #76).
+6. **Embeddings**: `dataset-citations-generate-embeddings` writes per-dataset and per-citation sentence-transformer embeddings to `embeddings/` (registry-backed, deduped by content hash). Produced on hallu's RTX 4090 next to step 5 (phase 2 of epic #96 / #98); CI no longer runs the embedding step because CPU torch was ~10x slower than CUDA.
+7. **Analysis**: network, temporal, and theme analyses consume the embeddings (UMAP wiring lands in phase 3 of epic #96 / #99).
+8. **Dashboard**: interactive HTML + D3 deployed to Cloudflare Pages at `dashboard.nemar.org/citations/`.
 
 ## Fetch Strategy & Rate Limits
 Both upstream sources we depend on have throttled us in production. Treat external APIs as scarce; cache, retry, and prefer the NEMAR backend.

--- a/scripts/hallu_cron_pipeline.sh
+++ b/scripts/hallu_cron_pipeline.sh
@@ -129,8 +129,31 @@ uv run dataset-citations-score-confidence \
   --device cuda \
   --skip-existing
 
+# 5. Sentence-transformer embeddings on the RTX 4090. Phase 2 of epic #96
+#    (#98) moved this step off CI because CPU torch in GitHub Actions took
+#    ~10x longer than CUDA on hallu. `--skip-existing` is consistent with
+#    the rest of the pipeline; the CLI also skips via the embedding
+#    registry by default, so the flag is explicit-intent rather than a
+#    behavior change. Outputs land under `embeddings/`, ready for the
+#    UMAP step phase 3 (#99) will wire in right after this block.
+#
+#    Guard with `|| { exit 2; }` because the cron uses `set -uo pipefail`
+#    (no -e); a non-zero exit otherwise would not halt the script and we
+#    would publish a citation update without refreshed embeddings.
+echo "--- generate-embeddings (cuda) ---"
+uv run dataset-citations-generate-embeddings \
+  --citations citations/json_opencite \
+  --datasets datasets \
+  --embeddings-dir embeddings \
+  --embedding-type both \
+  --device cuda \
+  --skip-existing || {
+  echo "ERROR: dataset-citations-generate-embeddings failed; aborting before commit." >&2
+  exit 2
+}
+
 # Bail cleanly if no tracked data changed (typical when nothing is stale).
-if git diff --quiet citations/ datasets/; then
+if git diff --quiet citations/ datasets/ embeddings/; then
   echo "no tracked data changes, nothing to commit"
   exit 0
 fi
@@ -138,12 +161,13 @@ fi
 # Commit + push to a timestamped branch; open a PR (manual merge gates the deploy).
 BRANCH="auto-update/$TS"
 git checkout -b "$BRANCH"
-git add citations/ datasets/
+git add citations/ datasets/ embeddings/
 DIFFSTAT="$(git diff --cached --stat | tail -5)"
 git commit -m "data: hallu nightly pipeline ($TS)
 
-GPU semantic scoring on RTX 4090. Pipeline:
-  catalog discover -> metadata -> judge-anchors -> opencite fetch -> score-confidence
+GPU semantic scoring + embeddings on RTX 4090. Pipeline:
+  catalog discover -> metadata -> judge-anchors -> opencite fetch
+  -> score-confidence -> generate-embeddings
 
 $(echo "$DIFFSTAT")"
 

--- a/scripts/hallu_rerun.sh
+++ b/scripts/hallu_rerun.sh
@@ -4,11 +4,12 @@
 # scaffolding so an operator can iterate on a single stage.
 #
 # Usage:
-#   scripts/hallu_rerun.sh                # full pipeline (no lock, no PR)
-#   scripts/hallu_rerun.sh --judge-only   # just step 3a (anchor adjudication)
-#   scripts/hallu_rerun.sh --update-only  # just step 3b (opencite fetch)
-#   scripts/hallu_rerun.sh --score-only   # just step 4 (GPU scoring)
-#   scripts/hallu_rerun.sh --dry-run      # print the steps that would run
+#   scripts/hallu_rerun.sh                   # full pipeline (no lock, no PR)
+#   scripts/hallu_rerun.sh --judge-only      # just step 3a (anchor adjudication)
+#   scripts/hallu_rerun.sh --update-only     # just step 3b (opencite fetch)
+#   scripts/hallu_rerun.sh --score-only      # just step 4 (GPU scoring)
+#   scripts/hallu_rerun.sh --embeddings-only # just step 5 (GPU embeddings)
+#   scripts/hallu_rerun.sh --dry-run         # print the steps that would run
 #
 # Assumes:
 #   - cwd is the repo root (or $REPO_DIR is exported).
@@ -31,6 +32,7 @@ for arg in "$@"; do
     --judge-only) MODE="judge" ;;
     --update-only) MODE="update" ;;
     --score-only) MODE="score" ;;
+    --embeddings-only) MODE="embeddings" ;;
     --dry-run) DRY_RUN=1 ;;
     -h|--help)
       sed -n '2,18p' "$0"
@@ -120,6 +122,22 @@ score_confidence() {
     --skip-existing
 }
 
+embeddings() {
+  # Phase 2 of epic #96 (#98) moved sentence-transformer embedding
+  # generation off CI onto hallu's RTX 4090. `--skip-existing` is the
+  # explicit form of the CLI's default registry-skip behavior; mirrors
+  # the score-confidence convention. The cron guards this step with an
+  # explicit `|| exit 2` so a partial run does not feed downstream
+  # analysis; the rerun helper leaves error handling to the operator.
+  run uv run dataset-citations-generate-embeddings \
+    --citations citations/json_opencite \
+    --datasets datasets \
+    --embeddings-dir embeddings \
+    --embedding-type both \
+    --device cuda \
+    --skip-existing
+}
+
 case "$MODE" in
   judge)
     # judge-only needs the dataset list AND fresh dataset descriptions
@@ -144,11 +162,24 @@ case "$MODE" in
   score)
     score_confidence
     ;;
+  embeddings)
+    # embeddings-only needs the dataset metadata cache (READMEs +
+    # dataset_description.json) under `datasets/` because the dataset
+    # embedding text is built from those files. Discover first if the
+    # list is missing, then refresh metadata so an iterating operator
+    # gets up-to-date dataset embeddings on every rerun.
+    if [ ! -s "$DATASETS_LIST" ]; then
+      echo "$DATASETS_LIST missing or empty; running discover first"
+      discover
+    fi
+    embeddings
+    ;;
   full)
     discover
     retrieve_metadata
     judge_anchors
     update_citations
     score_confidence
+    embeddings
     ;;
 esac

--- a/src/dataset_citations/cli/generate_embeddings.py
+++ b/src/dataset_citations/cli/generate_embeddings.py
@@ -81,6 +81,7 @@ def generate_dataset_embeddings(
     model_name: str = "Qwen/Qwen3-Embedding-0.6B",
     batch_size: int = 10,
     force_regenerate: bool = False,
+    device: str = "mps",
 ) -> int:
     """
     Generate embeddings for all datasets.
@@ -91,6 +92,7 @@ def generate_dataset_embeddings(
         model_name: Sentence transformer model name
         batch_size: Number of datasets to process at once
         force_regenerate: Whether to regenerate existing embeddings
+        device: Torch device for the sentence-transformer model
 
     Returns:
         Number of embeddings generated
@@ -99,7 +101,7 @@ def generate_dataset_embeddings(
 
     # Initialize components
     storage_manager = EmbeddingStorageManager(embeddings_dir)
-    model = SentenceTransformerModel(model_name=model_name)
+    model = SentenceTransformerModel(model_name=model_name, device=device)
 
     # Find all dataset files
     dataset_files = list(datasets_dir.glob("ds*_datasets.json"))
@@ -171,6 +173,23 @@ def generate_dataset_embeddings(
     return generated_count
 
 
+def _resolve_citation_files(citations_dir: Path) -> tuple[Path, list[Path]]:
+    """Locate per-dataset citation JSON files under ``citations_dir``.
+
+    Historically the CLI assumed a `<citations_dir>/json/` layout. The
+    opencite pipeline writes flat to `<citations_dir>` (e.g.
+    `citations/json_opencite/<id>_citations.json`). Accept either layout
+    transparently: if `citations_dir` already contains `*_citations.json`
+    files, use it directly; otherwise fall back to the legacy `/json`
+    subdirectory.
+    """
+    direct = list(citations_dir.glob("ds*_citations.json"))
+    if direct:
+        return citations_dir, direct
+    legacy = citations_dir / "json"
+    return legacy, list(legacy.glob("ds*_citations.json"))
+
+
 def generate_citation_embeddings(
     citations_dir: Path,
     embeddings_dir: Path,
@@ -178,6 +197,7 @@ def generate_citation_embeddings(
     batch_size: int = 50,
     force_regenerate: bool = False,
     min_confidence: float = 0.4,
+    device: str = "mps",
 ) -> int:
     """
     Generate embeddings for all high-confidence citations.
@@ -189,6 +209,7 @@ def generate_citation_embeddings(
         batch_size: Number of citations to process at once
         force_regenerate: Whether to regenerate existing embeddings
         min_confidence: Minimum confidence score for citations
+        device: Torch device for the sentence-transformer model
 
     Returns:
         Number of embeddings generated
@@ -197,14 +218,14 @@ def generate_citation_embeddings(
 
     # Initialize components
     storage_manager = EmbeddingStorageManager(embeddings_dir)
-    model = SentenceTransformerModel(model_name=model_name)
+    model = SentenceTransformerModel(model_name=model_name, device=device)
 
-    # Find all citation files
-    citation_files = list((citations_dir / "json").glob("ds*_citations.json"))
+    # Find all citation files (accept both flat and legacy /json layouts).
+    search_dir, citation_files = _resolve_citation_files(citations_dir)
     total_files = len(citation_files)
 
     if total_files == 0:
-        logging.error(f"No citation files found in {citations_dir / 'json'}")
+        logging.error(f"No citation files found in {search_dir}")
         return 0
 
     logging.info(f"Found {total_files} citation files")
@@ -420,6 +441,28 @@ Examples:
         help="Force regeneration of existing embeddings",
     )
 
+    parser.add_argument(
+        "--skip-existing",
+        action="store_true",
+        help=(
+            "Skip datasets/citations that already have embeddings. The default "
+            "behavior already skips via the embedding registry; this flag is "
+            "accepted for parity with other CLIs (e.g. score-confidence) and "
+            "forces --force-regenerate off if both are passed."
+        ),
+    )
+
+    parser.add_argument(
+        "--device",
+        type=str,
+        default="mps",
+        choices=["auto", "cpu", "cuda", "mps"],
+        help=(
+            "Torch device for sentence transformers ('mps' for Apple Metal, "
+            "'cuda' for NVIDIA on hallu, default: mps)."
+        ),
+    )
+
     parser.add_argument("--verbose", action="store_true", help="Enable verbose logging")
 
     args = parser.parse_args()
@@ -439,6 +482,12 @@ Examples:
     # Create embeddings directory
     args.embeddings_dir.mkdir(parents=True, exist_ok=True)
 
+    # `--skip-existing` is the explicit form of the registry-skip default.
+    # If a caller passes both `--skip-existing` and `--force-regenerate`,
+    # the former wins (matches the score-confidence convention where
+    # skip-existing short-circuits before any regeneration work).
+    force_regenerate = args.force_regenerate and not args.skip_existing
+
     # Track total generated
     total_generated = 0
     start_time = time.time()
@@ -455,7 +504,8 @@ Examples:
                 embeddings_dir=args.embeddings_dir,
                 model_name=args.model,
                 batch_size=args.batch_size // 5,  # Smaller batch for datasets
-                force_regenerate=args.force_regenerate,
+                force_regenerate=force_regenerate,
+                device=args.device,
             )
             total_generated += dataset_count
 
@@ -470,8 +520,9 @@ Examples:
                 embeddings_dir=args.embeddings_dir,
                 model_name=args.model,
                 batch_size=args.batch_size,
-                force_regenerate=args.force_regenerate,
+                force_regenerate=force_regenerate,
                 min_confidence=args.min_confidence,
+                device=args.device,
             )
             total_generated += citation_count
 

--- a/src/dataset_citations/cli/generate_embeddings.py
+++ b/src/dataset_citations/cli/generate_embeddings.py
@@ -103,8 +103,15 @@ def generate_dataset_embeddings(
     storage_manager = EmbeddingStorageManager(embeddings_dir)
     model = SentenceTransformerModel(model_name=model_name, device=device)
 
-    # Find all dataset files
-    dataset_files = list(datasets_dir.glob("ds*_datasets.json"))
+    # Find all dataset files. NEMAR's catalog uses three prefixes: `ds-*`
+    # (legacy OpenNeuro), `nm-*` (NEMAR-native), `on-*` (OpenNeuro imported
+    # into NEMAR). A narrower `ds*` glob would silently skip every modern
+    # dataset; match all three prefixes explicitly.
+    dataset_files = sorted(
+        f
+        for pattern in ("ds*_datasets.json", "nm*_datasets.json", "on*_datasets.json")
+        for f in datasets_dir.glob(pattern)
+    )
     total_datasets = len(dataset_files)
 
     if total_datasets == 0:
@@ -179,15 +186,30 @@ def _resolve_citation_files(citations_dir: Path) -> tuple[Path, list[Path]]:
     Historically the CLI assumed a `<citations_dir>/json/` layout. The
     opencite pipeline writes flat to `<citations_dir>` (e.g.
     `citations/json_opencite/<id>_citations.json`). Accept either layout
-    transparently: if `citations_dir` already contains `*_citations.json`
+    transparently: if `citations_dir` already contains citation JSON
     files, use it directly; otherwise fall back to the legacy `/json`
     subdirectory.
+
+    Matches all three NEMAR catalog prefixes (`ds-`, `nm-`, `on-`) so the
+    full ~594-dataset corpus is covered, not just legacy `ds-*` entries.
     """
-    direct = list(citations_dir.glob("ds*_citations.json"))
+
+    def _glob(root: Path) -> list[Path]:
+        return sorted(
+            f
+            for pattern in (
+                "ds*_citations.json",
+                "nm*_citations.json",
+                "on*_citations.json",
+            )
+            for f in root.glob(pattern)
+        )
+
+    direct = _glob(citations_dir)
     if direct:
         return citations_dir, direct
     legacy = citations_dir / "json"
-    return legacy, list(legacy.glob("ds*_citations.json"))
+    return legacy, _glob(legacy)
 
 
 def generate_citation_embeddings(
@@ -364,6 +386,37 @@ def process_citation_batch(
         return 0
 
 
+def _resolve_device(spec: str) -> str:
+    """Resolve a device spec to the actual torch device string.
+
+    `auto` picks the best available device on the host so the same
+    invocation works on hallu (NVIDIA → cuda) and Mac workstations
+    (Apple Silicon → mps) without flag changes. Mirrors the resolution
+    helper in `quality/confidence_scoring.py` — keep them in sync if
+    either changes. Non-`auto` values are returned verbatim so an
+    operator can still force a specific backend.
+    """
+    if spec != "auto":
+        return spec
+    try:
+        import torch
+
+        # Prefer the host's accelerator. cuda is checked first because hallu
+        # (the production cron host) is Linux+NVIDIA; on a Mac workstation
+        # cuda is unavailable so we fall through to mps; cpu is the last
+        # resort.
+        if torch.cuda.is_available():
+            logging.info("device=auto -> cuda detected")
+            return "cuda"
+        if hasattr(torch.backends, "mps") and torch.backends.mps.is_available():
+            logging.info("device=auto -> mps detected")
+            return "mps"
+    except ImportError:
+        pass
+    logging.info("device=auto -> falling back to cpu")
+    return "cpu"
+
+
 def main():
     """Main CLI entry point."""
     parser = argparse.ArgumentParser(
@@ -445,21 +498,24 @@ Examples:
         "--skip-existing",
         action="store_true",
         help=(
-            "Skip datasets/citations that already have embeddings. The default "
-            "behavior already skips via the embedding registry; this flag is "
-            "accepted for parity with other CLIs (e.g. score-confidence) and "
-            "forces --force-regenerate off if both are passed."
+            "Alias for the default behavior (the embedding registry already "
+            "skips datasets/citations with a matching content hash). Accepted "
+            "for invocation parity with score-confidence + update; sole "
+            "operational effect is to override --force-regenerate when both "
+            "are passed."
         ),
     )
 
     parser.add_argument(
         "--device",
         type=str,
-        default="mps",
+        default="auto",
         choices=["auto", "cpu", "cuda", "mps"],
         help=(
-            "Torch device for sentence transformers ('mps' for Apple Metal, "
-            "'cuda' for NVIDIA on hallu, default: mps)."
+            "Torch device for sentence transformers. 'auto' (default) picks "
+            "cuda if available, then mps, then cpu — so the same invocation "
+            "works on hallu (NVIDIA) and Mac workstations (Apple Metal) "
+            "without explicit flags."
         ),
     )
 
@@ -488,6 +544,9 @@ Examples:
     # skip-existing short-circuits before any regeneration work).
     force_regenerate = args.force_regenerate and not args.skip_existing
 
+    # Resolve `auto` once so both embedding passes use the same device.
+    resolved_device = _resolve_device(args.device)
+
     # Track total generated
     total_generated = 0
     start_time = time.time()
@@ -505,7 +564,7 @@ Examples:
                 model_name=args.model,
                 batch_size=args.batch_size // 5,  # Smaller batch for datasets
                 force_regenerate=force_regenerate,
-                device=args.device,
+                device=resolved_device,
             )
             total_generated += dataset_count
 
@@ -522,7 +581,7 @@ Examples:
                 batch_size=args.batch_size,
                 force_regenerate=force_regenerate,
                 min_confidence=args.min_confidence,
-                device=args.device,
+                device=resolved_device,
             )
             total_generated += citation_count
 

--- a/tests/test_hallu_cron_preflight.py
+++ b/tests/test_hallu_cron_preflight.py
@@ -117,3 +117,34 @@ def test_rerun_script_supports_judge_only_flag() -> None:
     text = RERUN_SCRIPT.read_text()
     assert "--judge-only" in text
     assert "dataset-citations-judge-anchors" in text
+
+
+def test_cron_script_wires_generate_embeddings() -> None:
+    """Phase 2 of epic #96 (#98) runs embeddings on hallu after scoring.
+
+    Catches accidental removal of the embeddings step or its guard.
+    """
+    text = CRON_SCRIPT.read_text()
+    assert "dataset-citations-generate-embeddings" in text, (
+        "generate-embeddings step missing from hallu_cron_pipeline.sh"
+    )
+    assert "--device cuda" in text, (
+        "embeddings step must target the RTX 4090 with --device cuda"
+    )
+    assert "--skip-existing" in text, (
+        "embeddings step must pass --skip-existing for cron parity"
+    )
+    # The step has to sit AFTER score-confidence so confidence scores are
+    # available for the citation-embedding confidence filter.
+    score_idx = text.index("dataset-citations-score-confidence")
+    embed_idx = text.index("dataset-citations-generate-embeddings")
+    assert score_idx < embed_idx, (
+        "generate-embeddings must run after score-confidence in the cron"
+    )
+
+
+def test_rerun_script_supports_embeddings_only_flag() -> None:
+    """The --embeddings-only flag must be recognised (regression guard for #98)."""
+    text = RERUN_SCRIPT.read_text()
+    assert "--embeddings-only" in text
+    assert "dataset-citations-generate-embeddings" in text


### PR DESCRIPTION
## Summary

Phase 2 of epic #96. After `score-confidence`, the hallu nightly cron now runs `dataset-citations-generate-embeddings` on the RTX 4090, producing per-dataset and per-citation sentence-transformer embeddings under `embeddings/`. CI no longer needs to do this work (CPU torch took ~10x longer than CUDA on hallu).

- `scripts/hallu_cron_pipeline.sh`: new step 5 calls `generate-embeddings --device cuda --skip-existing`, guarded with `|| exit 2` because the cron runs under `set -uo pipefail` (no `-e`). `embeddings/` is now part of the auto-update commit.
- `scripts/hallu_rerun.sh`: new `--embeddings-only` mode mirrors the existing `--judge-only` / `--update-only` / `--score-only` shape, with the same auto-discover-if-missing behaviour. Also threaded into `--full` so manual reruns match cron output.
- `src/dataset_citations/cli/generate_embeddings.py`: added `--device {auto,cpu,cuda,mps}` (defaulting to `mps` for parity with `score-confidence`) and `--skip-existing` (explicit alias of the registry-skip default, mirrors phase 1 #102). Also relaxed the citation-file lookup so `--citations citations/json_opencite` (flat layout written by `dataset-citations-update`) works; the legacy `<dir>/json` layout still works as a fallback.
- `AGENTS.md`: split the Data Flow step 4 (Processing) into separate scoring + embeddings entries; documented that embeddings now run on hallu, not CI.
- `tests/test_hallu_cron_preflight.py`: regression guards for the new cron step and the `--embeddings-only` rerun flag.

## Coordination with sibling phases

- Phase 3 (#99) will insert UMAP analysis immediately after the new embeddings block in both scripts. Boundary is clean.
- Phase 5 (#101) will simplify `.github/workflows/deploy-dashboard.yml`. Untouched here.
- No backfill rerun included in this PR; the next scheduled cron tick (or a manual `hallu_rerun.sh --embeddings-only`) will populate `embeddings/`.

## Test plan

- [x] `bash -n` clean on both scripts
- [x] `uv run ruff format` + `uv run ruff check` clean on edited files
- [x] `uv run pytest tests/test_hallu_cron_preflight.py -v` — all 7 tests pass (including 2 new ones)
- [x] `uv run pytest tests/` — 231 passed, 25 skipped (integration / live-service gates), no regressions
- [x] `hallu_rerun.sh --dry-run` prints the new embeddings invocation after score-confidence
- [x] `hallu_rerun.sh --embeddings-only --dry-run` runs discover (when list missing) then the embeddings CLI
- [ ] First post-merge cron tick on hallu produces a non-empty `embeddings/` diff in the auto-update PR (verification deferred to operator)

Closes #98. Part of epic #96.