### PR TITLE
Phase 4: dashboard template fixes (#77 timeline + #79 wordcloud)

### DIFF
--- a/src/dataset_citations/dashboard/components/charts.py
+++ b/src/dataset_citations/dashboard/components/charts.py
@@ -41,13 +41,42 @@ class ChartGenerator:
         }
 
     def _generate_growth_chart(self, data: Dict[str, Any]) -> Dict[str, Any]:
-        """Generate citation growth timeline chart."""
-        # This would use temporal analysis data
+        """Generate citation growth timeline chart.
+
+        Reads `temporal_analysis.temporal_summary` (list of per-year rows with
+        `year` and `total_citations`), sorts by year, and emits a cumulative
+        citation series. Closes #77: previously this returned a hardcoded
+        series that capped near 1,200 even though the headline showed 14k+
+        high-confidence citations — the chart never read the real data.
+        """
+        temporal = data.get("temporal_analysis", {})
+        rows = temporal.get("temporal_summary", [])
+
+        parsed: list[tuple[int, int]] = []
+        for row in rows:
+            try:
+                year = int(row.get("year", 0))
+                count = int(row.get("total_citations", 0))
+            except (TypeError, ValueError):
+                continue
+            if year <= 0:
+                continue
+            parsed.append((year, count))
+        parsed.sort(key=lambda yc: yc[0])
+
+        years: list[int] = []
+        cumulative: list[int] = []
+        running = 0
+        for year, count in parsed:
+            running += count
+            years.append(year)
+            cumulative.append(running)
+
         return {
             "type": "scatter",
             "data": {
-                "x": [2018, 2019, 2020, 2021, 2022, 2023, 2024, 2025],
-                "y": [20, 65, 150, 370, 650, 950, 1040, 1140],
+                "x": years,
+                "y": cumulative,
                 "mode": "lines+markers",
             },
         }

--- a/src/dataset_citations/dashboard/components/charts.py
+++ b/src/dataset_citations/dashboard/components/charts.py
@@ -44,10 +44,17 @@ class ChartGenerator:
         """Generate citation growth timeline chart.
 
         Reads `temporal_analysis.temporal_summary` (list of per-year rows with
-        `year` and `total_citations`), sorts by year, and emits a cumulative
-        citation series. Closes #77: previously this returned a hardcoded
-        series that capped near 1,200 even though the headline showed 14k+
-        high-confidence citations — the chart never read the real data.
+        `year` and `high_confidence_citations`), sorts by year, and emits a
+        cumulative series whose endpoint matches the
+        `summary_stats.high_confidence_citations` headline KPI.
+
+        Closes #77: previously this returned a hardcoded array that capped
+        near 1,200 even though the headline showed ~14k. The first fix
+        bound the chart to `total_citations` instead, but `total_citations`
+        is all citations regardless of confidence — distinct from the
+        headline's high-confidence count. Binding to
+        `high_confidence_citations` keeps the two quantities consistent
+        (review finding on PR #106).
         """
         temporal = data.get("temporal_analysis", {})
         rows = temporal.get("temporal_summary", [])
@@ -56,7 +63,10 @@ class ChartGenerator:
         for row in rows:
             try:
                 year = int(row.get("year", 0))
-                count = int(row.get("total_citations", 0))
+                # Per-year high-confidence count so the cumulative endpoint
+                # reconciles with summary_stats.high_confidence_citations.
+                # `total_citations` (the previous binding) would over-count.
+                count = int(row.get("high_confidence_citations", 0))
             except (TypeError, ValueError):
                 continue
             if year <= 0:

--- a/src/dataset_citations/dashboard/components/themes.py
+++ b/src/dataset_citations/dashboard/components/themes.py
@@ -61,21 +61,27 @@ class ThemeGenerator:
             theme_size = theme.get("size", 0)
             top_words = theme.get("top_words", []) or []
 
-            wordcloud_path = f"data/themes/theme_{theme_id}_wordcloud.png"
-
+            # Track whether the PNG was actually produced. If rendering fails
+            # (or no output_dir / empty top_words), `wordcloud` is set to None
+            # so the payload doesn't advertise a non-existent asset; the
+            # template's tag-cloud fallback covers the visual.
+            wordcloud_path: str | None = None
             if self.output_dir is not None and top_words:
                 target = self.output_dir / "data" / "themes"
                 try:
                     self._render_wordcloud_png(top_words, target, theme_id)
                 except Exception as exc:  # noqa: BLE001
                     # Defensive: never let a rendering failure kill the whole
-                    # dashboard build. Log and surface an empty card.
+                    # dashboard build. Log and leave wordcloud=None so the
+                    # template renders the tag-cloud fallback only.
                     logger.warning(
                         "Failed to render wordcloud for theme %s (%s): %s",
                         theme_id,
                         theme_name,
                         exc,
                     )
+                else:
+                    wordcloud_path = f"data/themes/theme_{theme_id}_wordcloud.png"
 
             themes.append(
                 {
@@ -94,14 +100,17 @@ class ThemeGenerator:
                     "id": 0,
                     "title": "Theme 1",
                     "subtitle": "Themes will be generated when analysis is run",
-                    "wordcloud": "data/themes/theme_0_wordcloud.png",
+                    "wordcloud": None,
                     "top_words": [],
                 }
             ]
 
         return {
             "themes": themes,
-            "wordcloud_images": [t["wordcloud"] for t in themes],
+            # Only advertise wordcloud paths that actually exist on disk;
+            # None entries are dropped so the template's <img> tags don't
+            # point at non-existent files.
+            "wordcloud_images": [t["wordcloud"] for t in themes if t["wordcloud"]],
         }
 
     @staticmethod

--- a/src/dataset_citations/dashboard/components/themes.py
+++ b/src/dataset_citations/dashboard/components/themes.py
@@ -1,40 +1,89 @@
 """
 Theme visualization component for dashboard.
+
+Closes #79: renders word clouds from
+`theme_analysis.comprehensive_theme_analysis.themes[]` so the Research Themes
+tab actually shows the per-theme content. Previously this component only
+emitted metadata + image paths, and if no upstream step had generated the
+PNGs the tab rendered as four empty cards. The generator now materializes a
+PNG for each theme from its `top_words` list at dashboard-build time using
+the `wordcloud` library (already a runtime dependency).
 """
 
-from typing import Any, Dict
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional, Sequence
+
+logger = logging.getLogger(__name__)
 
 
 class ThemeGenerator:
     """Generate research theme visualizations."""
 
-    def generate_themes(self, data: Dict[str, Any]) -> Dict[str, Any]:
-        """
-        Generate theme visualization data.
+    def __init__(self, output_dir: Optional[Path] = None) -> None:
+        """Initialize the theme generator.
 
         Args:
-            data: Aggregated data from DataAggregator
+            output_dir: Dashboard output directory. When provided, wordcloud
+                PNGs are written under `<output_dir>/data/themes/` so the
+                generated HTML can reference them with a stable relative
+                path (`data/themes/theme_N_wordcloud.png`).
+        """
+        self.output_dir = Path(output_dir) if output_dir is not None else None
+
+    def generate_themes(self, data: Dict[str, Any]) -> Dict[str, Any]:
+        """Generate theme visualization data.
+
+        Reads themes from
+        `data["theme_analysis"]["comprehensive_theme_analysis"]["themes"]`.
+        Each theme is expected to have `id`, `name`, `size`, and a non-empty
+        `top_words` list (phrases). When `output_dir` was provided to
+        `__init__`, this method also writes a PNG wordcloud per theme.
+
+        Args:
+            data: Aggregated data from `DataAggregator`.
 
         Returns:
-            Dictionary containing theme configurations
+            Dictionary with `themes` (renderable entries) and the list of
+            wordcloud image paths that the HTML template references.
         """
         theme_data = data.get("theme_analysis", {}).get(
             "comprehensive_theme_analysis", {}
         )
         generated_themes = theme_data.get("themes", [])
 
-        themes = []
+        themes: List[Dict[str, Any]] = []
         for theme in generated_themes:
             theme_id = theme.get("id", 0)
             theme_name = theme.get("name", f"Theme {theme_id + 1}")
             theme_size = theme.get("size", 0)
+            top_words = theme.get("top_words", []) or []
+
+            wordcloud_path = f"data/themes/theme_{theme_id}_wordcloud.png"
+
+            if self.output_dir is not None and top_words:
+                target = self.output_dir / "data" / "themes"
+                try:
+                    self._render_wordcloud_png(top_words, target, theme_id)
+                except Exception as exc:  # noqa: BLE001
+                    # Defensive: never let a rendering failure kill the whole
+                    # dashboard build. Log and surface an empty card.
+                    logger.warning(
+                        "Failed to render wordcloud for theme %s (%s): %s",
+                        theme_id,
+                        theme_name,
+                        exc,
+                    )
 
             themes.append(
                 {
                     "id": theme_id,
                     "title": f"Theme {theme_id + 1} - {theme_name}",
                     "subtitle": f"{theme_size} citations in this cluster",
-                    "wordcloud": f"data/themes/theme_{theme_id}_wordcloud.png",
+                    "wordcloud": wordcloud_path,
+                    "top_words": list(top_words),
                 }
             )
 
@@ -46,7 +95,58 @@ class ThemeGenerator:
                     "title": "Theme 1",
                     "subtitle": "Themes will be generated when analysis is run",
                     "wordcloud": "data/themes/theme_0_wordcloud.png",
+                    "top_words": [],
                 }
             ]
 
-        return {"themes": themes, "wordcloud_images": [t["wordcloud"] for t in themes]}
+        return {
+            "themes": themes,
+            "wordcloud_images": [t["wordcloud"] for t in themes],
+        }
+
+    @staticmethod
+    def _render_wordcloud_png(
+        top_words: Sequence[str],
+        target_dir: Path,
+        theme_id: Any,
+    ) -> Path:
+        """Render `top_words` to a PNG using the `wordcloud` library.
+
+        The list of phrases is fed to `WordCloud.generate_from_frequencies`
+        with a decaying weight so the first phrase appears largest. This keeps
+        the visual order aligned with the analysis output and avoids needing
+        the raw text corpus at dashboard-build time.
+        """
+        # Local import keeps the dashboard module importable even in
+        # environments where the heavy `wordcloud`/`matplotlib` stack is
+        # unavailable (e.g., minimal smoke tests).
+        from wordcloud import WordCloud
+
+        target_dir.mkdir(parents=True, exist_ok=True)
+        frequencies = _build_frequency_map(top_words)
+        if not frequencies:
+            raise ValueError("top_words is empty after normalization")
+
+        cloud = WordCloud(
+            width=800,
+            height=400,
+            background_color="white",
+            max_words=len(frequencies),
+        ).generate_from_frequencies(frequencies)
+
+        path = target_dir / f"theme_{theme_id}_wordcloud.png"
+        cloud.to_file(str(path))
+        return path
+
+
+def _build_frequency_map(top_words: Iterable[str]) -> Dict[str, float]:
+    """Turn an ordered list of phrases into a frequency map.
+
+    Earlier phrases get higher weights (linear decay) so the resulting
+    wordcloud's visual prominence matches the upstream ranking.
+    """
+    cleaned = [w.strip() for w in top_words if isinstance(w, str) and w.strip()]
+    if not cleaned:
+        return {}
+    n = len(cleaned)
+    return {phrase: float(n - idx) for idx, phrase in enumerate(cleaned)}

--- a/src/dataset_citations/dashboard/core.py
+++ b/src/dataset_citations/dashboard/core.py
@@ -56,7 +56,9 @@ class DashboardGenerator:
         if not embeddings_dir.exists():
             embeddings_dir = Path("embeddings")  # Fallback to current directory
         self.network_generator = NetworkGenerator(embeddings_dir=embeddings_dir)
-        self.theme_generator = ThemeGenerator()
+        # Pass output_dir so the generator can materialize wordcloud PNGs
+        # from each theme's `top_words` at build time (fix for #79).
+        self.theme_generator = ThemeGenerator(output_dir=self.output_dir)
         self.modal_generator = ModalGenerator()
         self.template_builder = TemplateBuilder()
         self.asset_manager = AssetManager(output_dir=self.output_dir)

--- a/src/dataset_citations/dashboard/templates/components/charts.py
+++ b/src/dataset_citations/dashboard/templates/components/charts.py
@@ -57,10 +57,12 @@ def generate_chart_javascript(stats: Dict[str, Any], charts: Dict[str, Any]) -> 
     )
     quality_y = quality.get("data", {}).get("y", [0, 0])
 
-    growth_x = growth.get("data", {}).get(
-        "x", [2018, 2019, 2020, 2021, 2022, 2023, 2024, 2025]
-    )
-    growth_y = growth.get("data", {}).get("y", [20, 65, 150, 370, 650, 950, 1040, 1140])
+    # Growth series comes from ChartGenerator._generate_growth_chart which
+    # reads `temporal_analysis.temporal_summary`. Default to empty arrays so
+    # we surface "no data" rather than a misleading hardcoded curve (the
+    # source of #77's 10x scale bug).
+    growth_x = growth.get("data", {}).get("x", [])
+    growth_y = growth.get("data", {}).get("y", [])
 
     modality_values = modality.get("data", {}).get("values", [120, 45, 25])
     modality_labels = modality.get("data", {}).get("labels", ["EEG", "MEG", "iEEG"])

--- a/src/dataset_citations/dashboard/templates/nemar_simple.py
+++ b/src/dataset_citations/dashboard/templates/nemar_simple.py
@@ -44,7 +44,10 @@ def generate_nemar_dashboard(
     for theme in theme_list:
         title = html_lib.escape(str(theme.get("title", "")))
         subtitle = html_lib.escape(str(theme.get("subtitle", "")))
-        wordcloud_src = html_lib.escape(str(theme.get("wordcloud", "")))
+        # `wordcloud` is None when PNG rendering failed (or no output_dir
+        # was supplied); only emit the <img> tag when a real path is set.
+        wordcloud_path = theme.get("wordcloud")
+        wordcloud_src = html_lib.escape(str(wordcloud_path)) if wordcloud_path else None
         top_words = theme.get("top_words", []) or []
         # Decaying font sizes (1.6rem -> ~0.75rem) so the first phrase is
         # visually the largest, mirroring the upstream ranking.
@@ -80,11 +83,17 @@ def generate_nemar_dashboard(
                                 </small>
                             </div>
                             <div class="card-body text-center">
-                                <img src="{wordcloud_src}"
-                                     alt="{title} Word Cloud"
-                                     class="img-fluid rounded theme-wordcloud-img"
-                                     style="max-height: 300px; width: auto;"
-                                     onerror="this.style.display='none';">
+                                {
+            (
+                f'<img src="{wordcloud_src}" '
+                f'alt="{title} Word Cloud" '
+                f'class="img-fluid rounded theme-wordcloud-img" '
+                f'style="max-height: 300px; width: auto;" '
+                f"onerror=\"this.style.display='none';\">"
+            )
+            if wordcloud_src
+            else ""
+        }
                                 {tags_html}
                             </div>
                         </div>

--- a/src/dataset_citations/dashboard/templates/nemar_simple.py
+++ b/src/dataset_citations/dashboard/templates/nemar_simple.py
@@ -2,6 +2,7 @@
 Simplified NEMAR dashboard template using modular components.
 """
 
+import html as html_lib
 import json
 from typing import Any, Dict, Optional
 
@@ -34,24 +35,57 @@ def generate_nemar_dashboard(
     chart_containers = generate_chart_containers()
     chart_js = generate_chart_javascript(stats, charts)
 
-    # Build themes section
+    # Build themes section. Closes #79: each card always renders the
+    # `top_words` as a styled tag cloud so the Research Themes tab has
+    # content even if the wordcloud PNG generation failed. When the PNG is
+    # present it is shown above the tags.
     theme_list = themes.get("themes", [])
     themes_html = '<div class="row">'
     for theme in theme_list:
+        title = html_lib.escape(str(theme.get("title", "")))
+        subtitle = html_lib.escape(str(theme.get("subtitle", "")))
+        wordcloud_src = html_lib.escape(str(theme.get("wordcloud", "")))
+        top_words = theme.get("top_words", []) or []
+        # Decaying font sizes (1.6rem -> ~0.75rem) so the first phrase is
+        # visually the largest, mirroring the upstream ranking.
+        if top_words:
+            tags = []
+            n = max(len(top_words), 1)
+            for idx, phrase in enumerate(top_words):
+                phrase_text = html_lib.escape(str(phrase))
+                weight = 1 - (idx / (n + 1))
+                size_rem = round(0.75 + weight * 0.85, 2)
+                tags.append(
+                    f'<span class="theme-word" '
+                    f'style="display:inline-block;'
+                    f"margin:0.15rem 0.35rem;"
+                    f"font-size:{size_rem}rem;"
+                    f'color:#083d94;">{phrase_text}</span>'
+                )
+            tags_html = (
+                '<div class="theme-words" style="line-height:1.8;'
+                'text-align:center;margin-top:0.5rem;">' + "".join(tags) + "</div>"
+            )
+        else:
+            tags_html = (
+                '<p class="text-muted small">No top words available for this theme.</p>'
+            )
         themes_html += f"""
                     <div class="col-md-6 mb-4">
                         <div class="card analysis-card">
                             <div class="card-header">
-                                <h5><i class="fas fa-cloud me-2"></i>{theme["title"]}</h5>
+                                <h5><i class="fas fa-cloud me-2"></i>{title}</h5>
                                 <small class="text-muted" style="color: rgba(255, 255, 255, 0.9) !important;">
-                                    {theme["subtitle"]}
+                                    {subtitle}
                                 </small>
                             </div>
                             <div class="card-body text-center">
-                                <img src="{theme["wordcloud"]}" 
-                                     alt="{theme["title"]} Word Cloud" 
-                                     class="img-fluid rounded" 
-                                     style="max-height: 300px; width: auto;">
+                                <img src="{wordcloud_src}"
+                                     alt="{title} Word Cloud"
+                                     class="img-fluid rounded theme-wordcloud-img"
+                                     style="max-height: 300px; width: auto;"
+                                     onerror="this.style.display='none';">
+                                {tags_html}
                             </div>
                         </div>
                     </div>"""

--- a/tests/test_dashboard_charts.py
+++ b/tests/test_dashboard_charts.py
@@ -1,0 +1,188 @@
+"""Tests for the dashboard chart generator.
+
+Locks in the fix for issue #77: the Growth Timeline chart used to return a
+hardcoded series (capping near 1,200) that ignored the real temporal data.
+The chart now reads `temporal_analysis.temporal_summary` and emits a
+cumulative series whose endpoint matches the headline count.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+from dataset_citations.dashboard.components.charts import ChartGenerator
+from dataset_citations.dashboard.templates.components.charts import (
+    generate_chart_javascript,
+)
+
+
+def _build_temporal_data(rows: list[dict[str, str]]) -> dict[str, dict]:
+    """Wrap CSV-style temporal rows in the aggregator's data shape."""
+    return {"temporal_analysis": {"temporal_summary": rows}}
+
+
+def test_growth_chart_reads_temporal_summary_total_citations():
+    """The growth chart must compute cumulative `total_citations` per year."""
+    data = _build_temporal_data(
+        [
+            {"year": "2018", "total_citations": "100", "unique_datasets": "5"},
+            {"year": "2019", "total_citations": "200", "unique_datasets": "8"},
+            {"year": "2020", "total_citations": "300", "unique_datasets": "12"},
+        ]
+    )
+
+    chart = ChartGenerator()._generate_growth_chart(data)
+
+    assert chart["data"]["x"] == [2018, 2019, 2020]
+    # Cumulative: 100, 300, 600 — NOT the unique_datasets values (5, 13, 25).
+    assert chart["data"]["y"] == [100, 300, 600]
+
+
+def test_growth_chart_endpoint_matches_headline():
+    """The cumulative endpoint must equal the high-confidence headline count.
+
+    This is the exact failure mode reported in issue #77: the headline read
+    14,198 high-confidence citations but the chart capped at ~1,200. The fix
+    makes the final cumulative value match the sum across years.
+    """
+    rows = [
+        {"year": "2018", "total_citations": "120", "unique_datasets": "10"},
+        {"year": "2019", "total_citations": "480", "unique_datasets": "25"},
+        {"year": "2020", "total_citations": "1100", "unique_datasets": "60"},
+        {"year": "2021", "total_citations": "2400", "unique_datasets": "120"},
+        {"year": "2022", "total_citations": "3500", "unique_datasets": "180"},
+        {"year": "2023", "total_citations": "3800", "unique_datasets": "210"},
+        {"year": "2024", "total_citations": "2798", "unique_datasets": "190"},
+    ]
+    expected_total = sum(int(r["total_citations"]) for r in rows)  # 14,198
+
+    chart = ChartGenerator()._generate_growth_chart(
+        _build_temporal_data(rows),
+    )
+
+    assert chart["data"]["y"][-1] == expected_total
+    assert chart["data"]["x"][-1] == 2024
+
+
+def test_growth_chart_sorts_by_year_when_csv_is_unordered():
+    """CSV row order is not guaranteed; we sort by year before cumulating."""
+    data = _build_temporal_data(
+        [
+            {"year": "2020", "total_citations": "50", "unique_datasets": "3"},
+            {"year": "2018", "total_citations": "10", "unique_datasets": "1"},
+            {"year": "2019", "total_citations": "30", "unique_datasets": "2"},
+        ]
+    )
+
+    chart = ChartGenerator()._generate_growth_chart(data)
+
+    assert chart["data"]["x"] == [2018, 2019, 2020]
+    assert chart["data"]["y"] == [10, 40, 90]
+
+
+def test_growth_chart_does_not_fall_back_to_unique_datasets():
+    """Regression guard: chart must read `total_citations`, not the 10x-smaller
+    `unique_datasets` field. This was the suspected root cause in #77."""
+    data = _build_temporal_data(
+        [
+            {"year": "2023", "total_citations": "5000", "unique_datasets": "50"},
+        ]
+    )
+
+    chart = ChartGenerator()._generate_growth_chart(data)
+
+    assert chart["data"]["y"] == [5000]
+    assert chart["data"]["y"] != [50]
+
+
+def test_growth_chart_handles_missing_temporal_data():
+    """An empty payload yields empty arrays, NOT a hardcoded misleading curve."""
+    chart = ChartGenerator()._generate_growth_chart({})
+
+    assert chart["data"]["x"] == []
+    assert chart["data"]["y"] == []
+
+
+def test_growth_chart_skips_malformed_rows():
+    """Rows with non-integer years/counts are skipped, not silently mangled."""
+    data = _build_temporal_data(
+        [
+            {"year": "2020", "total_citations": "100"},
+            {"year": "not-a-year", "total_citations": "999"},
+            {"year": "2021", "total_citations": "garbage"},
+            {"year": "2022", "total_citations": "200"},
+        ]
+    )
+
+    chart = ChartGenerator()._generate_growth_chart(data)
+
+    assert chart["data"]["x"] == [2020, 2022]
+    assert chart["data"]["y"] == [100, 300]
+
+
+def test_chart_javascript_embeds_real_growth_series():
+    """The HTML/JS template must embed the computed series, not defaults."""
+    rows = [
+        {"year": "2020", "total_citations": "1000", "unique_datasets": "10"},
+        {"year": "2021", "total_citations": "4000", "unique_datasets": "40"},
+    ]
+    data = _build_temporal_data(rows)
+    charts = ChartGenerator().generate_all_charts(data)
+
+    js = generate_chart_javascript(stats={}, charts=charts)
+
+    # The embedded series should be the cumulative growth (1000, 5000), not
+    # the old hardcoded [20, 65, 150, 370, ...] fallback.
+    assert "[1000, 5000]" in js or "[1000,5000]" in js
+    assert "[20, 65, 150, 370, 650, 950, 1040, 1140]" not in js
+
+
+def test_chart_javascript_falls_back_to_empty_arrays_not_hardcoded_curve():
+    """With no temporal data, the JS must NOT contain the old fake curve."""
+    js = generate_chart_javascript(stats={}, charts={})
+
+    # Locate the growth chart x/y plot calls and inspect their arguments.
+    # The old defaults were x=[2018..2025], y=[20, 65, 150, ...].
+    forbidden_y_sequences = [
+        "[20, 65, 150",
+        "[20,65,150",
+    ]
+    for needle in forbidden_y_sequences:
+        assert needle not in js, (
+            f"Growth chart still embeds hardcoded fallback series: {needle!r}"
+        )
+
+
+def test_smoke_dashboard_payload_roundtrip(tmp_path: Path):
+    """Smoke test: a realistic payload flows through generate_chart_javascript
+    without raising and the growth series ends at the expected total."""
+    # A small realistic shape based on the live dashboard payload.
+    rows = [
+        {"year": str(y), "total_citations": str(c), "unique_datasets": str(d)}
+        for y, c, d in [
+            (2018, 120, 10),
+            (2019, 480, 25),
+            (2020, 1100, 60),
+            (2021, 2400, 120),
+            (2022, 3500, 180),
+            (2023, 3800, 210),
+            (2024, 2798, 190),
+        ]
+    ]
+    data = _build_temporal_data(rows)
+    charts = ChartGenerator().generate_all_charts(data)
+
+    js = generate_chart_javascript(stats={}, charts=charts)
+    # Extract the y array literal that follows "y: " in createGrowthChart and
+    # confirm its last value is 14,198 (matches the headline in #77).
+    match = re.search(r"createGrowthChart\(\)\s*\{[\s\S]*?y:\s*(\[[^\]]*\])", js)
+    assert match, "Could not locate growth chart y series in generated JS"
+    series = json.loads(match.group(1))
+    assert series[-1] == 14198, f"expected cumulative endpoint 14198, got {series[-1]}"
+
+    # Smoke-write the JS to disk so a downstream HTML builder could embed it.
+    out = tmp_path / "growth.js"
+    out.write_text(js)
+    assert out.stat().st_size > 0

--- a/tests/test_dashboard_charts.py
+++ b/tests/test_dashboard_charts.py
@@ -23,56 +23,97 @@ def _build_temporal_data(rows: list[dict[str, str]]) -> dict[str, dict]:
     return {"temporal_analysis": {"temporal_summary": rows}}
 
 
-def test_growth_chart_reads_temporal_summary_total_citations():
-    """The growth chart must compute cumulative `total_citations` per year."""
+def test_growth_chart_reads_high_confidence_citations():
+    """The growth chart must compute cumulative `high_confidence_citations`
+    per year so the endpoint reconciles with the headline KPI."""
     data = _build_temporal_data(
         [
-            {"year": "2018", "total_citations": "100", "unique_datasets": "5"},
-            {"year": "2019", "total_citations": "200", "unique_datasets": "8"},
-            {"year": "2020", "total_citations": "300", "unique_datasets": "12"},
+            {
+                "year": "2018",
+                "total_citations": "200",
+                "high_confidence_citations": "100",
+                "unique_datasets": "5",
+            },
+            {
+                "year": "2019",
+                "total_citations": "350",
+                "high_confidence_citations": "200",
+                "unique_datasets": "8",
+            },
+            {
+                "year": "2020",
+                "total_citations": "500",
+                "high_confidence_citations": "300",
+                "unique_datasets": "12",
+            },
         ]
     )
 
     chart = ChartGenerator()._generate_growth_chart(data)
 
     assert chart["data"]["x"] == [2018, 2019, 2020]
-    # Cumulative: 100, 300, 600 — NOT the unique_datasets values (5, 13, 25).
+    # Cumulative HIGH-CONF (100, 300, 600), NOT total_citations (200, 550, 1050)
+    # and definitely NOT unique_datasets (5, 13, 25).
     assert chart["data"]["y"] == [100, 300, 600]
 
 
-def test_growth_chart_endpoint_matches_headline():
-    """The cumulative endpoint must equal the high-confidence headline count.
+def test_growth_chart_endpoint_matches_high_confidence_headline():
+    """The cumulative endpoint must equal `summary_stats.high_confidence_citations`.
 
-    This is the exact failure mode reported in issue #77: the headline read
-    14,198 high-confidence citations but the chart capped at ~1,200. The fix
-    makes the final cumulative value match the sum across years.
+    This is the exact reconciliation #77 was about: headline read 14k+ but
+    chart capped at ~1.2k. The PR-#106 reviewer flagged that the initial
+    fix bound to `total_citations` instead, which is a different quantity
+    (all citations regardless of confidence). The chart now reads the
+    per-year `high_confidence_citations` so the running sum matches the
+    headline by construction.
     """
     rows = [
-        {"year": "2018", "total_citations": "120", "unique_datasets": "10"},
-        {"year": "2019", "total_citations": "480", "unique_datasets": "25"},
-        {"year": "2020", "total_citations": "1100", "unique_datasets": "60"},
-        {"year": "2021", "total_citations": "2400", "unique_datasets": "120"},
-        {"year": "2022", "total_citations": "3500", "unique_datasets": "180"},
-        {"year": "2023", "total_citations": "3800", "unique_datasets": "210"},
-        {"year": "2024", "total_citations": "2798", "unique_datasets": "190"},
+        {"year": "2018", "total_citations": "220", "high_confidence_citations": "120"},
+        {"year": "2019", "total_citations": "750", "high_confidence_citations": "480"},
+        {
+            "year": "2020",
+            "total_citations": "1800",
+            "high_confidence_citations": "1100",
+        },
+        {
+            "year": "2021",
+            "total_citations": "3600",
+            "high_confidence_citations": "2400",
+        },
+        {
+            "year": "2022",
+            "total_citations": "4500",
+            "high_confidence_citations": "3500",
+        },
+        {
+            "year": "2023",
+            "total_citations": "4700",
+            "high_confidence_citations": "3800",
+        },
+        {
+            "year": "2024",
+            "total_citations": "3300",
+            "high_confidence_citations": "2592",
+        },
     ]
-    expected_total = sum(int(r["total_citations"]) for r in rows)  # 14,198
+    expected_headline = sum(int(r["high_confidence_citations"]) for r in rows)  # 13,992
 
-    chart = ChartGenerator()._generate_growth_chart(
-        _build_temporal_data(rows),
-    )
+    chart = ChartGenerator()._generate_growth_chart(_build_temporal_data(rows))
 
-    assert chart["data"]["y"][-1] == expected_total
+    assert chart["data"]["y"][-1] == expected_headline
     assert chart["data"]["x"][-1] == 2024
+    # The endpoint must NOT pick up `total_citations` (which would be ~3000
+    # higher and over-count by including low-confidence citations).
+    assert chart["data"]["y"][-1] != sum(int(r["total_citations"]) for r in rows)
 
 
 def test_growth_chart_sorts_by_year_when_csv_is_unordered():
     """CSV row order is not guaranteed; we sort by year before cumulating."""
     data = _build_temporal_data(
         [
-            {"year": "2020", "total_citations": "50", "unique_datasets": "3"},
-            {"year": "2018", "total_citations": "10", "unique_datasets": "1"},
-            {"year": "2019", "total_citations": "30", "unique_datasets": "2"},
+            {"year": "2020", "high_confidence_citations": "50", "unique_datasets": "3"},
+            {"year": "2018", "high_confidence_citations": "10", "unique_datasets": "1"},
+            {"year": "2019", "high_confidence_citations": "30", "unique_datasets": "2"},
         ]
     )
 
@@ -82,18 +123,26 @@ def test_growth_chart_sorts_by_year_when_csv_is_unordered():
     assert chart["data"]["y"] == [10, 40, 90]
 
 
-def test_growth_chart_does_not_fall_back_to_unique_datasets():
-    """Regression guard: chart must read `total_citations`, not the 10x-smaller
-    `unique_datasets` field. This was the suspected root cause in #77."""
+def test_growth_chart_does_not_fall_back_to_other_fields():
+    """Regression guard: chart must read `high_confidence_citations`. It must
+    NOT fall back to `total_citations` (over-counts by including low-conf
+    citations) or `unique_datasets` (the original 10x-smaller smell from #77).
+    """
     data = _build_temporal_data(
         [
-            {"year": "2023", "total_citations": "5000", "unique_datasets": "50"},
+            {
+                "year": "2023",
+                "total_citations": "8000",
+                "high_confidence_citations": "5000",
+                "unique_datasets": "50",
+            },
         ]
     )
 
     chart = ChartGenerator()._generate_growth_chart(data)
 
     assert chart["data"]["y"] == [5000]
+    assert chart["data"]["y"] != [8000]
     assert chart["data"]["y"] != [50]
 
 
@@ -109,10 +158,10 @@ def test_growth_chart_skips_malformed_rows():
     """Rows with non-integer years/counts are skipped, not silently mangled."""
     data = _build_temporal_data(
         [
-            {"year": "2020", "total_citations": "100"},
-            {"year": "not-a-year", "total_citations": "999"},
-            {"year": "2021", "total_citations": "garbage"},
-            {"year": "2022", "total_citations": "200"},
+            {"year": "2020", "high_confidence_citations": "100"},
+            {"year": "not-a-year", "high_confidence_citations": "999"},
+            {"year": "2021", "high_confidence_citations": "garbage"},
+            {"year": "2022", "high_confidence_citations": "200"},
         ]
     )
 
@@ -125,8 +174,8 @@ def test_growth_chart_skips_malformed_rows():
 def test_chart_javascript_embeds_real_growth_series():
     """The HTML/JS template must embed the computed series, not defaults."""
     rows = [
-        {"year": "2020", "total_citations": "1000", "unique_datasets": "10"},
-        {"year": "2021", "total_citations": "4000", "unique_datasets": "40"},
+        {"year": "2020", "high_confidence_citations": "1000", "unique_datasets": "10"},
+        {"year": "2021", "high_confidence_citations": "4000", "unique_datasets": "40"},
     ]
     data = _build_temporal_data(rows)
     charts = ChartGenerator().generate_all_charts(data)
@@ -157,30 +206,45 @@ def test_chart_javascript_falls_back_to_empty_arrays_not_hardcoded_curve():
 
 def test_smoke_dashboard_payload_roundtrip(tmp_path: Path):
     """Smoke test: a realistic payload flows through generate_chart_javascript
-    without raising and the growth series ends at the expected total."""
-    # A small realistic shape based on the live dashboard payload.
+    without raising and the growth series ends at the headline total.
+
+    Rows include both `total_citations` (all citations) and
+    `high_confidence_citations` (the field the chart now sums) so the test
+    proves the binding actually reads the right column — endpoint is
+    13,992 (sum of high_confidence_citations) NOT 14,198 (sum of total).
+    """
     rows = [
-        {"year": str(y), "total_citations": str(c), "unique_datasets": str(d)}
-        for y, c, d in [
-            (2018, 120, 10),
-            (2019, 480, 25),
-            (2020, 1100, 60),
-            (2021, 2400, 120),
-            (2022, 3500, 180),
-            (2023, 3800, 210),
-            (2024, 2798, 190),
+        {
+            "year": str(y),
+            "total_citations": str(total),
+            "high_confidence_citations": str(high_conf),
+            "unique_datasets": str(d),
+        }
+        for y, total, high_conf, d in [
+            (2018, 220, 120, 10),
+            (2019, 750, 480, 25),
+            (2020, 1800, 1100, 60),
+            (2021, 3600, 2400, 120),
+            (2022, 4500, 3500, 180),
+            (2023, 4700, 3800, 210),
+            (2024, 3300, 2592, 190),
         ]
     ]
     data = _build_temporal_data(rows)
     charts = ChartGenerator().generate_all_charts(data)
 
     js = generate_chart_javascript(stats={}, charts=charts)
-    # Extract the y array literal that follows "y: " in createGrowthChart and
-    # confirm its last value is 14,198 (matches the headline in #77).
+    # Extract the y array literal that follows "y: " in createGrowthChart.
+    # The endpoint must equal sum(high_confidence_citations) so the chart
+    # reconciles with summary_stats.high_confidence_citations.
     match = re.search(r"createGrowthChart\(\)\s*\{[\s\S]*?y:\s*(\[[^\]]*\])", js)
     assert match, "Could not locate growth chart y series in generated JS"
     series = json.loads(match.group(1))
-    assert series[-1] == 14198, f"expected cumulative endpoint 14198, got {series[-1]}"
+    expected = sum(int(r["high_confidence_citations"]) for r in rows)  # 13,992
+    assert series[-1] == expected, (
+        f"expected cumulative endpoint {expected} (sum of "
+        f"high_confidence_citations), got {series[-1]}"
+    )
 
     # Smoke-write the JS to disk so a downstream HTML builder could embed it.
     out = tmp_path / "growth.js"

--- a/tests/test_dashboard_themes.py
+++ b/tests/test_dashboard_themes.py
@@ -1,0 +1,269 @@
+"""Tests for the dashboard theme generator and template rendering.
+
+Locks in the fix for issue #79: the Research Themes tab used to render four
+empty cards because the template referenced wordcloud PNGs that no upstream
+step produced, even though `top_words` were already in the payload. The
+generator now materializes a PNG per theme from its `top_words` list at
+dashboard-build time, and the template includes the words as a styled
+fallback so the cards always have content.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict
+
+import pytest
+
+from dataset_citations.dashboard.components.themes import ThemeGenerator
+from dataset_citations.dashboard.templates.nemar_simple import (
+    generate_nemar_dashboard,
+)
+
+
+def _sample_themes_payload() -> Dict[str, Any]:
+    """Minimal payload matching the live dashboard shape (issue #79 example)."""
+    return {
+        "theme_analysis": {
+            "comprehensive_theme_analysis": {
+                "themes": [
+                    {
+                        "id": 0,
+                        "name": "Core EEG",
+                        "size": 8187,
+                        "top_words": [
+                            "Brain Computer",
+                            "computer interface",
+                            "EEG based",
+                            "motor imagery",
+                            "EEG Signal",
+                            "resting state",
+                        ],
+                    },
+                    {
+                        "id": 1,
+                        "name": "Audio & Stimulation",
+                        "size": 1432,
+                        "top_words": ["auditory cortex", "speech", "music"],
+                    },
+                    {
+                        "id": 2,
+                        "name": "Task Performance",
+                        "size": 945,
+                        "top_words": ["cognitive load", "working memory"],
+                    },
+                    {
+                        "id": 3,
+                        "name": "Advanced Methods",
+                        "size": 614,
+                        "top_words": ["deep learning", "transformer", "CNN"],
+                    },
+                ]
+            }
+        }
+    }
+
+
+def test_generator_emits_one_entry_per_payload_theme():
+    """All four themes from the payload must end up in the rendered list."""
+    gen = ThemeGenerator()
+    out = gen.generate_themes(_sample_themes_payload())
+
+    assert len(out["themes"]) == 4
+    titles = [t["title"] for t in out["themes"]]
+    assert titles == [
+        "Theme 1 - Core EEG",
+        "Theme 2 - Audio & Stimulation",
+        "Theme 3 - Task Performance",
+        "Theme 4 - Advanced Methods",
+    ]
+
+
+def test_generator_passes_top_words_through():
+    """`top_words` must reach the template so the tag-cloud fallback works."""
+    gen = ThemeGenerator()
+    out = gen.generate_themes(_sample_themes_payload())
+
+    assert out["themes"][0]["top_words"][:2] == ["Brain Computer", "computer interface"]
+    assert "transformer" in out["themes"][3]["top_words"]
+
+
+def test_generator_writes_wordcloud_pngs(tmp_path: Path):
+    """When given an output_dir, the generator writes one PNG per theme."""
+    pytest.importorskip("wordcloud")
+    gen = ThemeGenerator(output_dir=tmp_path)
+    gen.generate_themes(_sample_themes_payload())
+
+    themes_dir = tmp_path / "data" / "themes"
+    assert themes_dir.is_dir()
+    pngs = sorted(themes_dir.glob("theme_*_wordcloud.png"))
+    assert len(pngs) == 4
+    # PNGs must be non-empty and start with the PNG magic bytes.
+    for png in pngs:
+        contents = png.read_bytes()
+        assert contents, f"empty file: {png}"
+        assert contents[:8] == b"\x89PNG\r\n\x1a\n", f"not a PNG: {png}"
+
+
+def test_generator_no_pngs_without_output_dir(tmp_path: Path):
+    """The generator runs in metadata-only mode when output_dir is None."""
+    gen = ThemeGenerator()
+    out = gen.generate_themes(_sample_themes_payload())
+    assert len(out["themes"]) == 4
+    # No data/themes directory was created (we did not pass a path).
+    assert not (tmp_path / "data" / "themes").exists()
+
+
+def test_generator_skips_theme_with_empty_top_words(tmp_path: Path):
+    """A theme with no top_words should still render (empty card) without
+    crashing wordcloud generation."""
+    pytest.importorskip("wordcloud")
+    payload = {
+        "theme_analysis": {
+            "comprehensive_theme_analysis": {
+                "themes": [
+                    {"id": 0, "name": "Empty", "size": 0, "top_words": []},
+                    {
+                        "id": 1,
+                        "name": "Has Words",
+                        "size": 5,
+                        "top_words": ["alpha", "beta"],
+                    },
+                ]
+            }
+        }
+    }
+    gen = ThemeGenerator(output_dir=tmp_path)
+    out = gen.generate_themes(payload)
+    assert len(out["themes"]) == 2
+    # Only the second theme produced a PNG.
+    pngs = list((tmp_path / "data" / "themes").glob("*.png"))
+    assert len(pngs) == 1
+    assert pngs[0].name == "theme_1_wordcloud.png"
+
+
+def test_template_renders_all_four_top_words_as_tags():
+    """The Research Themes tab must include every `top_words` phrase, so the
+    tab is no longer empty even when the PNG isn't available."""
+    gen = ThemeGenerator()
+    themes_data = gen.generate_themes(_sample_themes_payload())
+    html = generate_nemar_dashboard(
+        stats={"cards": []},
+        charts={},
+        networks={},
+        themes=themes_data,
+        modals={},
+        data=None,
+        data_file=None,
+        timestamp="2026-05-22 00:00:00",
+    )
+
+    # Every top word from every theme should be present in the rendered HTML.
+    for theme in _sample_themes_payload()["theme_analysis"][
+        "comprehensive_theme_analysis"
+    ]["themes"]:
+        for phrase in theme["top_words"]:
+            assert phrase in html, (
+                f"phrase {phrase!r} from theme {theme['name']!r} missing "
+                f"from rendered Research Themes tab"
+            )
+
+
+def test_template_card_includes_theme_name_and_size():
+    """Each rendered card must show the theme name and citation count."""
+    gen = ThemeGenerator()
+    themes_data = gen.generate_themes(_sample_themes_payload())
+    html = generate_nemar_dashboard(
+        stats={"cards": []},
+        charts={},
+        networks={},
+        themes=themes_data,
+        modals={},
+        data=None,
+        data_file=None,
+        timestamp="2026-05-22 00:00:00",
+    )
+
+    assert "Theme 1 - Core EEG" in html
+    assert "8187 citations in this cluster" in html
+    assert "Theme 4 - Advanced Methods" in html
+
+
+def test_template_renders_when_no_themes_in_payload():
+    """An empty themes payload still renders the placeholder card without
+    crashing."""
+    gen = ThemeGenerator()
+    themes_data = gen.generate_themes({})
+    html = generate_nemar_dashboard(
+        stats={"cards": []},
+        charts={},
+        networks={},
+        themes=themes_data,
+        modals={},
+        data=None,
+        data_file=None,
+        timestamp="2026-05-22 00:00:00",
+    )
+    # Placeholder copy from the fallback themes entry.
+    assert "Themes will be generated" in html
+
+
+def test_template_does_not_emit_empty_card_body():
+    """Regression guard for #79: previously the card body contained only an
+    <img> tag pointing at a non-existent PNG, yielding a blank card. Now the
+    card must contain either the tag cloud or a graceful empty-state notice."""
+    gen = ThemeGenerator()
+    themes_data = gen.generate_themes(_sample_themes_payload())
+    html = generate_nemar_dashboard(
+        stats={"cards": []},
+        charts={},
+        networks={},
+        themes=themes_data,
+        modals={},
+        data=None,
+        data_file=None,
+        timestamp="2026-05-22 00:00:00",
+    )
+
+    # The tag cloud wrapper must appear once per theme.
+    assert html.count('class="theme-words"') == 4
+
+
+def test_smoke_full_dashboard_build(tmp_path: Path):
+    """End-to-end smoke test: regenerate the dashboard against a tiny fixture
+    and verify the HTML doesn't error and contains both the wordcloud images
+    and the tag-cloud fallback content."""
+    pytest.importorskip("wordcloud")
+
+    results_dir = tmp_path / "results"
+    output_dir = tmp_path / "out"
+    results_dir.mkdir()
+    output_dir.mkdir()
+
+    gen = ThemeGenerator(output_dir=output_dir)
+    themes_data = gen.generate_themes(_sample_themes_payload())
+
+    html = generate_nemar_dashboard(
+        stats={"cards": []},
+        charts={},
+        networks={},
+        themes=themes_data,
+        modals={},
+        data=None,
+        data_file=None,
+        timestamp="2026-05-22 00:00:00",
+    )
+
+    # PNGs were materialized.
+    pngs = list((output_dir / "data" / "themes").glob("*.png"))
+    assert len(pngs) == 4
+
+    # HTML references each PNG path and ends with </html>.
+    for theme_id in range(4):
+        assert f"data/themes/theme_{theme_id}_wordcloud.png" in html
+    assert html.strip().endswith("</html>")
+
+    # Persist for downstream smoke inspection.
+    out_html = output_dir / "dashboard.html"
+    out_html.write_text(html, encoding="utf-8")
+    assert out_html.stat().st_size > 1000

--- a/tests/test_dashboard_themes.py
+++ b/tests/test_dashboard_themes.py
@@ -230,22 +230,60 @@ def test_template_does_not_emit_empty_card_body():
 
 
 def test_smoke_full_dashboard_build(tmp_path: Path):
-    """End-to-end smoke test: regenerate the dashboard against a tiny fixture
-    and verify the HTML doesn't error and contains both the wordcloud images
-    and the tag-cloud fallback content."""
+    """End-to-end smoke test covering BOTH bug fixes from this PR:
+
+    - #79 (wordcloud): four real PNGs materialize and the HTML references
+      each one.
+    - #77 (growth chart): the growth chart's JS is embedded and its
+      cumulative endpoint matches the per-year high_confidence_citations
+      sum, NOT the hardcoded `[20, 65, ..., 1140]` placeholder.
+
+    The previous smoke test passed `charts={}` and so left #77 uncovered;
+    PR-#106 reviewer flagged that as a gap.
+    """
     pytest.importorskip("wordcloud")
+
+    # Avoid a circular-import-style dependency: defer the chart helpers
+    # to runtime so this themes-test file stays self-contained.
+    from dataset_citations.dashboard.components.charts import ChartGenerator
+    from dataset_citations.dashboard.templates.components.charts import (
+        generate_chart_javascript,
+    )
 
     results_dir = tmp_path / "results"
     output_dir = tmp_path / "out"
     results_dir.mkdir()
     output_dir.mkdir()
 
+    # Themes side of the smoke.
     gen = ThemeGenerator(output_dir=output_dir)
     themes_data = gen.generate_themes(_sample_themes_payload())
 
+    # Charts side: realistic per-year rows with high_confidence_citations
+    # so we can pin the endpoint against the headline.
+    temporal_rows = [
+        {
+            "year": str(y),
+            "total_citations": str(total),
+            "high_confidence_citations": str(high_conf),
+            "unique_datasets": str(d),
+        }
+        for y, total, high_conf, d in [
+            (2020, 1800, 1100, 60),
+            (2021, 3600, 2400, 120),
+            (2022, 4500, 3500, 180),
+            (2023, 4700, 3800, 210),
+            (2024, 3300, 2592, 190),
+        ]
+    ]
+    charts_data = ChartGenerator().generate_all_charts(
+        {"temporal_analysis": {"temporal_summary": temporal_rows}}
+    )
+    expected_endpoint = sum(int(r["high_confidence_citations"]) for r in temporal_rows)
+
     html = generate_nemar_dashboard(
         stats={"cards": []},
-        charts={},
+        charts=charts_data,
         networks={},
         themes=themes_data,
         modals={},
@@ -254,14 +292,21 @@ def test_smoke_full_dashboard_build(tmp_path: Path):
         timestamp="2026-05-22 00:00:00",
     )
 
-    # PNGs were materialized.
+    # #79: PNGs materialized + HTML references each path.
     pngs = list((output_dir / "data" / "themes").glob("*.png"))
     assert len(pngs) == 4
-
-    # HTML references each PNG path and ends with </html>.
     for theme_id in range(4):
         assert f"data/themes/theme_{theme_id}_wordcloud.png" in html
     assert html.strip().endswith("</html>")
+
+    # #77: growth-chart JS is embedded with the right endpoint.
+    js = generate_chart_javascript(stats={}, charts=charts_data)
+    assert str(expected_endpoint) in js, (
+        f"growth-chart JS does not embed the expected cumulative endpoint "
+        f"{expected_endpoint}; chart binding may have regressed."
+    )
+    # Hardcoded fallback must NOT appear.
+    assert "[20, 65, 150, 370, 650, 950, 1040, 1140]" not in js
 
     # Persist for downstream smoke inspection.
     out_html = output_dir / "dashboard.html"


### PR DESCRIPTION
Part of epic #96. Closes #100, #77, #79.

## Scope
Two independent dashboard-template bugs delivered as two atomic commits. No cron, embedding, or deploy-workflow changes (phases 2/3/5 own those).

## a) #77 — Growth Timeline 10x scale bug
**Root cause:** `ChartGenerator._generate_growth_chart` returned a hardcoded series `[20, 65, 150, 370, 650, 950, 1040, 1140]` that capped near 1,200 even though the headline showed 14k+ high-confidence citations. The chart never read the real temporal data.

**Fix:** read `data["temporal_analysis"]["temporal_summary"]`, sort by year, and emit the cumulative `total_citations` series. The JS template fallback in `templates/components/charts.py` was also stripped of its old hardcoded curve so an empty payload now shows "no data" rather than a misleading fake line.

**Files:**
- `src/dataset_citations/dashboard/components/charts.py`
- `src/dataset_citations/dashboard/templates/components/charts.py`
- `tests/test_dashboard_charts.py` (new, 9 tests)

## b) #79 — 4-theme wordcloud renders empty
**Root cause:** `ThemeGenerator` emitted only metadata + a static PNG path (`data/themes/theme_N_wordcloud.png`) and the template rendered `<img src="...">`. No upstream step was producing those PNGs at dashboard-build time, so the tab showed four empty cards even though `themes[].top_words` was already in the payload.

**Fix:** `ThemeGenerator(output_dir=...)` now materializes a PNG per theme from each theme's `top_words` list using the `wordcloud` library (already in `pyproject.toml`). The template additionally renders `top_words` as a styled inline tag cloud, so the cards always show content even if PNG generation fails.

**Files:**
- `src/dataset_citations/dashboard/components/themes.py`
- `src/dataset_citations/dashboard/core.py` (wires `output_dir` into the theme generator)
- `src/dataset_citations/dashboard/templates/nemar_simple.py`
- `tests/test_dashboard_themes.py` (new, 10 tests)

## Test plan
- [x] `uv run pytest tests/` — 248 passed, 25 skipped (integration), 0 failed
- [x] `uv run ruff format src/ tests/` — no changes
- [x] `uv run ruff check src/ tests/` — clean
- [x] New unit tests lock in both fixed behaviors with no mocks (real `ChartGenerator`, real `ThemeGenerator`, real `wordcloud` PNG output)
- [x] Smoke test in `test_dashboard_themes.py::test_smoke_full_dashboard_build` regenerates the Research Themes section against a sample payload and verifies the HTML ends with `</html>` and references all four PNGs

## Out of scope
- Cron scripts (phase 2/3)
- Deploy workflow (phase 5)
- Re-running the citation pipeline; these are template-only fixes