### PR TITLE
fix(ops): wire themes/network/temporal analyses into hallu cron

### DIFF
--- a/scripts/hallu_cron_pipeline.sh
+++ b/scripts/hallu_cron_pipeline.sh
@@ -192,6 +192,41 @@ uv run dataset-citations-analyze-umap \
   exit 2
 }
 
+# 6. Theme / network / temporal analyses. Epic #96 phase 5 removed these
+#    invocations from `.github/workflows/deploy-dashboard.yml` on the
+#    expectation that the cron produces them; the initial epic ship only
+#    wired generate-embeddings + analyze-umap and missed these three. They
+#    are CPU-only and cheap; running here keeps the "hallu is the sole
+#    producer" invariant true so the CI verify step at deploy time finds
+#    the populated dirs. Each is guarded so a single analysis failure
+#    aborts cleanly under `set -uo pipefail` (no -e).
+echo "--- generate-themes ---"
+mkdir -p dashboard_data/themes
+uv run python -m dataset_citations.analysis.generate_themes \
+  --citations-dir citations/json_opencite \
+  --output-dir dashboard_data/themes || {
+  echo "ERROR: generate-themes failed; aborting before commit." >&2
+  exit 2
+}
+
+echo "--- generate-network ---"
+mkdir -p dashboard_data/network
+uv run python -m dataset_citations.analysis.generate_network \
+  --citations-dir citations/json_opencite \
+  --output-dir dashboard_data/network || {
+  echo "ERROR: generate-network failed; aborting before commit." >&2
+  exit 2
+}
+
+echo "--- generate-temporal ---"
+mkdir -p dashboard_data/temporal
+uv run python -m dataset_citations.analysis.generate_temporal \
+  --citations-dir citations/json_opencite \
+  --output-dir dashboard_data/temporal || {
+  echo "ERROR: generate-temporal failed; aborting before commit." >&2
+  exit 2
+}
+
 # Bail cleanly if no tracked data changed (typical when nothing is stale).
 # `dashboard_data/` and `embeddings/` are included because deploy-dashboard.yml
 # verifies their presence on a fresh CI checkout (epic #96 / #101 / #103). The


### PR DESCRIPTION
Hotfix for the just-merged epic #96 (PR #107). 

## What's missing
Phase 5 (#103) removed the three analysis invocations from `.github/workflows/deploy-dashboard.yml` on the expectation that the hallu cron produces them. But phases 2 + 3 only wired `generate-embeddings` and `analyze-umap` into the cron — `generate_themes` / `generate_network` / `generate_temporal` were forgotten.

## Net effect without this fix
After any auto-update PR merges to main, the new deploy-dashboard verify step (added in phase 5) checks that `dashboard_data/themes/`, `dashboard_data/network/`, and `dashboard_data/temporal/` exist and are non-empty. They never will, because nobody runs the producing CLIs anymore. Every deploy fails fast and the previous (January) dashboard stays live.

## Fix
Adds the three analysis steps between `analyze-umap` and the commit step in `scripts/hallu_cron_pipeline.sh`. CPU-only and cheap (~minutes). Each uses the same `|| { exit 2; }` guard pattern that the rest of the cron uses under `set -uo pipefail`. `mkdir -p` on the output dirs first.

## Test plan
- [x] `bash -n scripts/hallu_cron_pipeline.sh` clean
- [x] `tests/test_hallu_cron_preflight.py` 9/9 pass (existing tests unaffected)
- [ ] Next hallu cron tick (about to be kicked) produces all three dirs and the auto-update PR contains them
- [ ] Deploy-dashboard.yml verify step passes after that PR merges

Closes the integration gap surfaced post-merge of #107.