### PR TITLE
feat(quality): cross-dataset citation attribution audit + true-count report

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,6 +68,17 @@ jobs:
             -v \
             --maxfail=5
 
+      - name: Citation attribution audit (report-only)
+        # Surfaces the summed-vs-unique inflation and over-spread umbrella
+        # anchors on every run. Report-only for now: flip to --fail-on-violation
+        # on the deploy workflow once the anchor-judgment backfill is complete.
+        continue-on-error: true
+        run: |
+          uv run dataset-citations-audit-attribution \
+            --citations-dir citations/json_opencite \
+            --max-datasets-per-anchor 5 \
+            --top 25
+
       - name: Upload coverage to Codecov
         if: matrix.python-version == '3.13'
         uses: codecov/codecov-action@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,6 +95,7 @@ dataset-citations-automate-updates = "dataset_citations.cli.automate_updates:mai
 dataset-citations-create-reports = "dataset_citations.cli.create_interactive_reports_modular:main"
 dataset-citations-export-external-tools = "dataset_citations.cli.export_external_tools:main"
 dataset-citations-automate-visualization-updates = "dataset_citations.cli.automate_visualization_updates:main"
+dataset-citations-audit-attribution = "dataset_citations.cli.audit_attribution:main"
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/src/dataset_citations/analysis/attribution_audit.py
+++ b/src/dataset_citations/analysis/attribution_audit.py
@@ -1,0 +1,301 @@
+"""Cross-dataset citation attribution audit.
+
+Detects the inflation failure mode where a shared anchor DOI (a methods,
+standards, or umbrella paper) is listed as a citation anchor in many datasets,
+so the opencite fetch attributes all of that anchor's citing papers to every
+dataset that lists it. Each per-file schema looks healthy in isolation, so this
+audit only surfaces the problem by working across the whole corpus.
+
+Definitions
+-----------
+- A *citing paper* is one entry in ``citation_details[]``. Its identity key is
+  the normalized DOI when present, else the OpenAlex id, else ``pmid:<n>``,
+  else the normalized title. This mirrors the pipeline's DOI-first dedup intent
+  so the unique count aligns with what a correctly-deduped corpus would hold.
+- An *anchor* is the ``source_doi`` that pulled a citing paper in. An anchor's
+  *spread* is the number of distinct datasets in which it appears as a
+  ``source_doi`` inside ``citation_details`` (its citers were fetched and
+  counted, not bucketed into ``metadata.context_anchors``).
+- A *violation* is an anchor whose spread exceeds ``max_datasets_per_anchor``.
+  These are the umbrella / methods anchors that anchor judgment (epic #76) is
+  meant to bucket out; once judged they move to ``context_anchors`` and no
+  longer inflate per-dataset counts.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections import Counter, defaultdict
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from dataset_citations.sources.doi import normalize_doi
+
+logger = logging.getLogger(__name__)
+
+_NO_ANCHOR = "<no-anchor>"
+
+
+def _normalize_title(title: str | None) -> str:
+    return " ".join((title or "").lower().split())
+
+
+def _citing_key(citation: dict[str, Any]) -> str:
+    """Stable identity for a citing paper, DOI-first to match dedup intent."""
+    doi = citation.get("doi")
+    if doi:
+        return f"doi:{normalize_doi(doi)}"
+    openalex_id = citation.get("openalex_id")
+    if openalex_id:
+        return f"openalex:{str(openalex_id).strip().lower()}"
+    pmid = citation.get("pmid")
+    if pmid:
+        return f"pmid:{str(pmid).strip()}"
+    return f"title:{_normalize_title(citation.get('title'))}"
+
+
+def _anchor_key(source_doi: str | None) -> str:
+    return normalize_doi(source_doi) if source_doi else _NO_ANCHOR
+
+
+@dataclass
+class AnchorSpread:
+    """How widely a single anchor's citers are attributed across datasets."""
+
+    anchor: str
+    dataset_count: int
+    total_attributed: int
+    datasets: list[str]
+    paper_title: str | None
+    context_classified: int
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "anchor": self.anchor,
+            "dataset_count": self.dataset_count,
+            "total_attributed": self.total_attributed,
+            "datasets": self.datasets,
+            "paper_title": self.paper_title,
+            "context_classified": self.context_classified,
+        }
+
+
+@dataclass
+class AttributionReport:
+    """Corpus-wide attribution audit result."""
+
+    n_files: int
+    summed_citations: int
+    unique_citations: int
+    max_datasets_per_anchor: int
+    anchor_spreads: list[AnchorSpread]
+    per_dataset: dict[str, dict[str, int]]
+
+    @property
+    def inflation_ratio(self) -> float:
+        if self.unique_citations == 0:
+            return 0.0
+        return self.summed_citations / self.unique_citations
+
+    @property
+    def violations(self) -> list[AnchorSpread]:
+        return [
+            a
+            for a in self.anchor_spreads
+            if a.anchor != _NO_ANCHOR and a.dataset_count > self.max_datasets_per_anchor
+        ]
+
+    @property
+    def estimated_true_total(self) -> int:
+        """Summed citations after dropping rows whose only anchor is a violation.
+
+        A lower-bound estimate: each ``citation_details`` row carries a single
+        ``source_doi`` after dedup, so a citer pulled in solely via an
+        over-spread anchor is dropped. Genuine per-dataset citers (via a
+        data-paper anchor) are retained.
+        """
+        return sum(d["cleaned"] for d in self.per_dataset.values())
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "n_files": self.n_files,
+            "summed_citations": self.summed_citations,
+            "unique_citations": self.unique_citations,
+            "inflation_ratio": round(self.inflation_ratio, 4),
+            "estimated_true_total": self.estimated_true_total,
+            "max_datasets_per_anchor": self.max_datasets_per_anchor,
+            "n_violations": len(self.violations),
+            "anchor_spreads": [a.to_dict() for a in self.anchor_spreads],
+            "per_dataset": self.per_dataset,
+        }
+
+
+def load_corpus(citations_dir: Path) -> list[dict[str, Any]]:
+    """Read every ``*_citations.json`` file in ``citations_dir``."""
+    records: list[dict[str, Any]] = []
+    for path in sorted(citations_dir.glob("*_citations.json")):
+        try:
+            records.append(json.loads(path.read_text(encoding="utf-8")))
+        except (OSError, json.JSONDecodeError) as exc:
+            logger.warning("Skipping unreadable citation file %s: %s", path.name, exc)
+    return records
+
+
+def build_report(
+    records: list[dict[str, Any]], max_datasets_per_anchor: int = 5
+) -> AttributionReport:
+    """Compute the attribution audit over already-loaded citation records."""
+    anchor_datasets: dict[str, set[str]] = defaultdict(set)
+    anchor_total: Counter[str] = Counter()
+    anchor_title: dict[str, str] = {}
+    anchor_context: dict[str, set[str]] = defaultdict(set)
+    global_unique: set[str] = set()
+    summed = 0
+    per_dataset_counts: dict[str, Counter[str]] = {}
+
+    for rec in records:
+        dataset_id = rec.get("dataset_id") or "<unknown>"
+        details = rec.get("citation_details") or []
+        summed += len(details)
+
+        counts: Counter[str] = Counter()
+        for citation in details:
+            global_unique.add(_citing_key(citation))
+            akey = _anchor_key(citation.get("source_doi"))
+            anchor_datasets[akey].add(dataset_id)
+            anchor_total[akey] += 1
+            counts[akey] += 1
+        per_dataset_counts[dataset_id] = counts
+
+        # context_anchors carry the anchor's own paper title and confirm which
+        # anchors judgment already buckets out (informational columns).
+        meta = rec.get("metadata") or {}
+        for ctx in meta.get("context_anchors") or []:
+            identifier = ctx.get("anchor_identifier")
+            if not identifier:
+                continue
+            ckey = _anchor_key(identifier)
+            anchor_context[ckey].add(dataset_id)
+            if ckey not in anchor_title and ctx.get("paper_title"):
+                anchor_title[ckey] = ctx["paper_title"]
+
+    spreads = [
+        AnchorSpread(
+            anchor=akey,
+            dataset_count=len(datasets),
+            total_attributed=anchor_total[akey],
+            datasets=sorted(datasets),
+            paper_title=anchor_title.get(akey),
+            context_classified=len(anchor_context.get(akey, set())),
+        )
+        for akey, datasets in anchor_datasets.items()
+    ]
+    spreads.sort(key=lambda a: (a.dataset_count, a.total_attributed), reverse=True)
+
+    violation_anchors = {
+        a.anchor
+        for a in spreads
+        if a.anchor != _NO_ANCHOR and a.dataset_count > max_datasets_per_anchor
+    }
+
+    per_dataset: dict[str, dict[str, int]] = {}
+    for dataset_id, counts in per_dataset_counts.items():
+        per_dataset[dataset_id] = {
+            "summed": sum(counts.values()),
+            "cleaned": sum(n for a, n in counts.items() if a not in violation_anchors),
+        }
+
+    return AttributionReport(
+        n_files=len(records),
+        summed_citations=summed,
+        unique_citations=len(global_unique),
+        max_datasets_per_anchor=max_datasets_per_anchor,
+        anchor_spreads=spreads,
+        per_dataset=per_dataset,
+    )
+
+
+def format_text(report: AttributionReport, top: int = 20) -> str:
+    """Human-readable console summary."""
+    lines = [
+        "=== CITATION ATTRIBUTION AUDIT ===",
+        f"Files:             {report.n_files}",
+        f"Summed citations:  {report.summed_citations}",
+        f"Unique citations:  {report.unique_citations}",
+        f"Inflation ratio:   {report.inflation_ratio:.2f}x",
+        f"Est. true total:   {report.estimated_true_total} "
+        f"(after dropping {len(report.violations)} over-spread anchors)",
+        f"Threshold:         > {report.max_datasets_per_anchor} datasets per anchor",
+        f"Violations:        {len(report.violations)} anchors exceed the threshold",
+        "",
+        f"Top {min(top, len(report.anchor_spreads))} anchors by dataset spread "
+        "(! = violation, ctx = datasets that bucket it as context):",
+        f"  {'#ds':>4} {'attr':>6} {'ctx':>4}  anchor / title",
+    ]
+    for anchor in report.anchor_spreads[:top]:
+        flag = "!" if anchor in report.violations else " "
+        title = (anchor.paper_title or "")[:48]
+        lines.append(
+            f" {flag}{anchor.dataset_count:>4} {anchor.total_attributed:>6} "
+            f"{anchor.context_classified:>4}  {anchor.anchor}  {title}"
+        )
+    return "\n".join(lines)
+
+
+def format_markdown(report: AttributionReport, top: int = 20) -> str:
+    """Markdown report suitable for a PR comment or artifact."""
+    lines = [
+        "# Citation attribution audit",
+        "",
+        f"- Files: **{report.n_files}**",
+        f"- Summed citations: **{report.summed_citations}**",
+        f"- Globally unique citations: **{report.unique_citations}**",
+        f"- Inflation ratio: **{report.inflation_ratio:.2f}x**",
+        f"- Estimated true total: **{report.estimated_true_total}**",
+        f"- Violations (> {report.max_datasets_per_anchor} datasets/anchor): "
+        f"**{len(report.violations)}**",
+        "",
+        f"## Top {min(top, len(report.anchor_spreads))} anchors by dataset spread",
+        "",
+        "| ! | datasets | attributed | context | anchor | title |",
+        "|---|---|---|---|---|---|",
+    ]
+    violations = set(report.violations)
+    for anchor in report.anchor_spreads[:top]:
+        flag = "x" if anchor in violations else ""
+        title = (anchor.paper_title or "").replace("|", "/")[:60]
+        lines.append(
+            f"| {flag} | {anchor.dataset_count} | {anchor.total_attributed} | "
+            f"{anchor.context_classified} | `{anchor.anchor}` | {title} |"
+        )
+    return "\n".join(lines)
+
+
+def run_audit(
+    citations_dir: Path,
+    max_datasets_per_anchor: int = 5,
+    top: int = 20,
+    report_json: Path | None = None,
+    report_md: Path | None = None,
+) -> AttributionReport:
+    """Load the corpus, build the report, write optional artifacts, log summary."""
+    if not citations_dir.exists():
+        raise FileNotFoundError(f"Citations directory not found: {citations_dir}")
+
+    records = load_corpus(citations_dir)
+    report = build_report(records, max_datasets_per_anchor=max_datasets_per_anchor)
+
+    print(format_text(report, top=top))
+
+    if report_json is not None:
+        report_json.parent.mkdir(parents=True, exist_ok=True)
+        report_json.write_text(json.dumps(report.to_dict(), indent=2), encoding="utf-8")
+        logger.info("Wrote JSON report to %s", report_json)
+    if report_md is not None:
+        report_md.parent.mkdir(parents=True, exist_ok=True)
+        report_md.write_text(format_markdown(report, top=top), encoding="utf-8")
+        logger.info("Wrote Markdown report to %s", report_md)
+
+    return report

--- a/src/dataset_citations/cli/audit_attribution.py
+++ b/src/dataset_citations/cli/audit_attribution.py
@@ -1,0 +1,81 @@
+"""CLI: cross-dataset citation attribution audit.
+
+Surfaces the inflation caused by shared umbrella / methods anchors leaking
+their citers onto every dataset that lists them. Run report-only in CI to keep
+the true number visible; pass ``--fail-on-violation`` to use it as a deploy
+guard once the anchor-judgment backfill is complete.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from pathlib import Path
+
+from ..analysis.attribution_audit import run_audit
+
+logger = logging.getLogger(__name__)
+
+
+def main() -> None:
+    """Main CLI entry point."""
+    parser = argparse.ArgumentParser(
+        description="Audit cross-dataset citation attribution (umbrella-anchor leakage)",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument(
+        "--citations-dir",
+        type=Path,
+        default=Path("citations/json_opencite"),
+        help="Directory containing schema-v2 citation JSON files",
+    )
+    parser.add_argument(
+        "--max-datasets-per-anchor",
+        type=int,
+        default=5,
+        help="An anchor attributed across more datasets than this is a violation",
+    )
+    parser.add_argument(
+        "--top",
+        type=int,
+        default=20,
+        help="How many anchors to list in the console / markdown report",
+    )
+    parser.add_argument(
+        "--report-json", type=Path, help="Write the full report as JSON to this path"
+    )
+    parser.add_argument(
+        "--report-md", type=Path, help="Write a markdown report to this path"
+    )
+    parser.add_argument(
+        "--fail-on-violation",
+        action="store_true",
+        help="Exit non-zero if any anchor exceeds the spread threshold",
+    )
+    parser.add_argument("--verbose", action="store_true", help="Enable debug logging")
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    )
+
+    report = run_audit(
+        citations_dir=args.citations_dir,
+        max_datasets_per_anchor=args.max_datasets_per_anchor,
+        top=args.top,
+        report_json=args.report_json,
+        report_md=args.report_md,
+    )
+
+    if args.fail_on_violation and report.violations:
+        logger.error(
+            "%d anchor(s) exceed the spread threshold; failing.",
+            len(report.violations),
+        )
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_attribution_audit.py
+++ b/tests/test_attribution_audit.py
@@ -1,0 +1,160 @@
+"""Real-fixture tests for the cross-dataset attribution audit.
+
+Reproduces the umbrella-anchor inflation: a shared anchor (MNE-BIDS-like DOI)
+listed in several datasets attributes its citers to every one of them, while a
+per-dataset data-paper anchor contributes unique citers. No mocks: records are
+real schema-v2 shapes and the IO path writes/reads real JSON files.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from dataset_citations.analysis.attribution_audit import (
+    build_report,
+    load_corpus,
+    run_audit,
+)
+
+UMBRELLA = "10.21105/joss.01896"
+
+
+def _cite(doi: str, source_doi: str) -> dict:
+    return {
+        "title": f"Paper {doi}",
+        "doi": doi,
+        "pmid": None,
+        "openalex_id": None,
+        "source_doi": source_doi,
+        "source_relation": "References",
+        "cited_by": 1,
+    }
+
+
+def _record(dataset_id: str, citations: list[dict], context: list[dict] | None = None):
+    return {
+        "dataset_id": dataset_id,
+        "num_citations": len(citations),
+        "citation_details": citations,
+        "metadata": {"schema_version": "2.0", "context_anchors": context or []},
+    }
+
+
+def _three_sharing_datasets() -> list[dict]:
+    # Each dataset shares the umbrella anchor's citers p1/p2 and has one
+    # unique citer via its own data-paper anchor. ds003 uses an UPPERCASE
+    # umbrella DOI to exercise case-insensitive anchor keying.
+    return [
+        _record(
+            "ds001",
+            [
+                _cite("10.x/p1", UMBRELLA),
+                _cite("10.x/p2", UMBRELLA),
+                _cite("10.x/p3", "10.1/data1"),
+            ],
+        ),
+        _record(
+            "ds002",
+            [
+                _cite("10.x/p1", UMBRELLA),
+                _cite("10.x/p2", UMBRELLA),
+                _cite("10.x/p4", "10.1/data2"),
+            ],
+        ),
+        _record(
+            "ds003",
+            [
+                _cite("10.x/p1", "10.21105/JOSS.01896"),
+                _cite("10.x/p2", "10.21105/JOSS.01896"),
+                _cite("10.x/p5", "10.1/data3"),
+            ],
+        ),
+    ]
+
+
+def test_summed_vs_unique_counts():
+    report = build_report(_three_sharing_datasets(), max_datasets_per_anchor=2)
+    assert report.summed_citations == 9
+    # p1..p5 distinct -> 5 unique despite 9 summed rows
+    assert report.unique_citations == 5
+    assert round(report.inflation_ratio, 2) == 1.80
+
+
+def test_umbrella_anchor_flagged_as_violation():
+    report = build_report(_three_sharing_datasets(), max_datasets_per_anchor=2)
+    by_anchor = {a.anchor: a for a in report.anchor_spreads}
+    # uppercase ds003 merges into the same normalized anchor key
+    assert by_anchor[UMBRELLA].dataset_count == 3
+    assert by_anchor[UMBRELLA].total_attributed == 6
+    violation_anchors = {a.anchor for a in report.violations}
+    assert UMBRELLA in violation_anchors
+    # the per-dataset data anchors stay below threshold
+    assert "10.1/data1" not in violation_anchors
+
+
+def test_estimated_true_total_drops_violation_rows():
+    report = build_report(_three_sharing_datasets(), max_datasets_per_anchor=2)
+    # only the 3 data-paper citers (p3/p4/p5) survive
+    assert report.estimated_true_total == 3
+    assert report.per_dataset["ds001"] == {"summed": 3, "cleaned": 1}
+
+
+def test_context_anchors_excluded_and_paren_normalized():
+    records = _three_sharing_datasets()
+    # ds004 buckets the umbrella into context with a trailing-paren identifier;
+    # it must NOT raise the anchor's fetched spread and must normalize to the
+    # same key, incrementing context_classified.
+    records.append(
+        _record(
+            "ds004",
+            [_cite("10.x/p6", "10.1/data4")],
+            context=[
+                {
+                    "anchor_identifier": "10.21105/joss.01896)",
+                    "anchor_identifier_type": "doi",
+                    "classification": "umbrella",
+                    "paper_title": "MNE-BIDS",
+                }
+            ],
+        )
+    )
+    report = build_report(records, max_datasets_per_anchor=2)
+    by_anchor = {a.anchor: a for a in report.anchor_spreads}
+    # spread stays 3 (ds004 did not fetch the umbrella's citers)
+    assert by_anchor[UMBRELLA].dataset_count == 3
+    assert by_anchor[UMBRELLA].context_classified == 1
+    assert by_anchor[UMBRELLA].paper_title == "MNE-BIDS"
+
+
+def test_no_violation_when_threshold_high():
+    report = build_report(_three_sharing_datasets(), max_datasets_per_anchor=5)
+    assert report.violations == []
+    # nothing dropped, so cleaned == summed everywhere
+    assert report.estimated_true_total == report.summed_citations
+
+
+def test_run_audit_reads_files_and_writes_json(tmp_path: Path):
+    citations_dir = tmp_path / "json_opencite"
+    citations_dir.mkdir()
+    for rec in _three_sharing_datasets():
+        (citations_dir / f"{rec['dataset_id']}_citations.json").write_text(
+            json.dumps(rec), encoding="utf-8"
+        )
+    # a non-citation json must be ignored by the glob
+    (citations_dir / "notes.json").write_text("{}", encoding="utf-8")
+
+    assert len(load_corpus(citations_dir)) == 3
+
+    report_json = tmp_path / "report.json"
+    report = run_audit(
+        citations_dir=citations_dir,
+        max_datasets_per_anchor=2,
+        report_json=report_json,
+    )
+    assert report.summed_citations == 9
+    assert report.unique_citations == 5
+
+    written = json.loads(report_json.read_text(encoding="utf-8"))
+    assert written["summed_citations"] == 9
+    assert written["n_violations"] == 1


### PR DESCRIPTION
Closes #111.

## What

Adds `dataset-citations-audit-attribution` (`analysis/attribution_audit.py` + `cli/audit_attribution.py`) — a corpus-wide audit that detects the umbrella-anchor inflation and reports the true citation count.

## Real-corpus output (today's `citations/json_opencite/`)

```
Files:             592
Summed citations:  17394
Unique citations:  7573      <- the real number
Inflation ratio:   2.30x
Est. true total:   9320 (after dropping 9 over-spread anchors)
Violations:        9 anchors exceed > 5 datasets/anchor
   #ds   attr  ctx  anchor
 !  25   2500    0  10.21105/joss.01896            (MNE-BIDS)
 !  24   2139    0  10.1038/s41597-019-0104-8      (EEG-BIDS)
 !  12   1189    6  10.1038/sdata.2017.181         (HBN; already bucketed in 6)
 !  12    877    6  10.1038/sdata.2017.40          (HBN; already bucketed in 6)
 ...
```

The `ctx` column shows anchor judgment already buckets the HBN papers out in the 6 judged datasets; the leak persists only where judgment never ran (epic #76 backfill incomplete, 10/592 datasets).

## How it works

- Citing-paper identity is DOI-first (then OpenAlex / PMID / normalized title), matching the pipeline's dedup intent, so `unique_citations` reflects a correctly-deduped corpus.
- Anchor identity uses `normalize_doi` (strips the trailing-paren artifact), so `10.1038/sdata.2017.181)` and uppercase variants collapse correctly.
- `context_anchors` (judged-out anchors) are excluded from the leak count and surfaced in the `ctx` column.
- `--fail-on-violation` is available for use as a deploy guard once the backfill is complete; wired into `test.yml` as **report-only** (`continue-on-error`) for now so it can't block while the corpus is still inflated.

## Tested

- `tests/test_attribution_audit.py`: 6 real-fixture tests (no mocks) covering summed-vs-unique counting, umbrella violation detection, case/paren anchor normalization, context-anchor exclusion, estimated-true-total, threshold behavior, and the file-IO + JSON-report path. All pass.
- `ruff format --check` + `ruff check` + `ty check` clean on the full tree.