### PR TITLE
fix(ops): sync hallu_rerun.sh with cron analysis stages (themes/network/temporal)

### DIFF
--- a/scripts/hallu_rerun.sh
+++ b/scripts/hallu_rerun.sh
@@ -10,6 +10,7 @@
 #   scripts/hallu_rerun.sh --score-only      # just step 4 (GPU scoring)
 #   scripts/hallu_rerun.sh --embeddings-only # just step 5a (GPU embeddings)
 #   scripts/hallu_rerun.sh --umap-only       # just step 5b (UMAP on embeddings)
+#   scripts/hallu_rerun.sh --analysis-only   # just step 6 (themes + network + temporal)
 #   scripts/hallu_rerun.sh --dry-run         # print the steps that would run
 #
 # Assumes:
@@ -35,6 +36,7 @@ for arg in "$@"; do
     --score-only) MODE="score" ;;
     --embeddings-only) MODE="embeddings" ;;
     --umap-only) MODE="umap" ;;
+    --analysis-only) MODE="analysis" ;;
     --dry-run) DRY_RUN=1 ;;
     -h|--help)
       sed -n '2,18p' "$0"
@@ -157,6 +159,41 @@ umap_analysis() {
   }
 }
 
+# Step 6: theme / network / temporal analyses -> dashboard_data/{themes,network,
+# temporal}/. PR #108 added these to the cron but not here, so manual recovery
+# could not satisfy deploy-dashboard.yml's verify (it hard-requires the three
+# dirs be non-empty). Mirror the cron exactly: same CLIs, mkdir, and explicit
+# `|| exit 2` guard (the helper runs under `set -uo pipefail`, no -e).
+themes_analysis() {
+  mkdir -p dashboard_data/themes
+  run uv run python -m dataset_citations.analysis.generate_themes \
+    --citations-dir citations/json_opencite \
+    --output-dir dashboard_data/themes || {
+    echo "ERROR: generate-themes failed; aborting." >&2
+    exit 2
+  }
+}
+
+network_analysis() {
+  mkdir -p dashboard_data/network
+  run uv run python -m dataset_citations.analysis.generate_network \
+    --citations-dir citations/json_opencite \
+    --output-dir dashboard_data/network || {
+    echo "ERROR: generate-network failed; aborting." >&2
+    exit 2
+  }
+}
+
+temporal_analysis() {
+  mkdir -p dashboard_data/temporal
+  run uv run python -m dataset_citations.analysis.generate_temporal \
+    --citations-dir citations/json_opencite \
+    --output-dir dashboard_data/temporal || {
+    echo "ERROR: generate-temporal failed; aborting." >&2
+    exit 2
+  }
+}
+
 case "$MODE" in
   judge)
     # judge-only needs the dataset list AND fresh dataset descriptions
@@ -201,6 +238,14 @@ case "$MODE" in
     # the analyze-umap CLI logs a clear error if the directory is missing.
     umap_analysis
     ;;
+  analysis)
+    # Theme/network/temporal only; reads citations/json_opencite and writes
+    # the three dashboard_data/ subdirs deploy-dashboard.yml verifies. No
+    # GitHub / opencite / Ollama traffic.
+    themes_analysis
+    network_analysis
+    temporal_analysis
+    ;;
   full)
     discover
     retrieve_metadata
@@ -209,5 +254,8 @@ case "$MODE" in
     score_confidence
     embeddings
     umap_analysis
+    themes_analysis
+    network_analysis
+    temporal_analysis
     ;;
 esac

--- a/tests/test_hallu_cron_preflight.py
+++ b/tests/test_hallu_cron_preflight.py
@@ -198,3 +198,61 @@ def test_rerun_script_supports_umap_only_flag() -> None:
         "umap_analysis must run after score_confidence in the rerun helper's "
         "full mode (matches cron ordering)."
     )
+
+
+# The theme/network/temporal analyses produced by the cron and required by
+# deploy-dashboard.yml's verify step. PR #108 added them to the cron only; the
+# tests below keep the rerun helper in sync so manual recovery can satisfy the
+# deploy gate (issue #113).
+_ANALYSIS_MODULES = (
+    "dataset_citations.analysis.generate_themes",
+    "dataset_citations.analysis.generate_network",
+    "dataset_citations.analysis.generate_temporal",
+)
+
+
+def test_cron_script_wires_analysis_stages() -> None:
+    """Catch accidental removal of the themes/network/temporal stages."""
+    text = CRON_SCRIPT.read_text()
+    for module in _ANALYSIS_MODULES:
+        assert module in text, f"{module} missing from hallu_cron_pipeline.sh"
+
+
+def test_rerun_full_mode_matches_cron_analysis_stages() -> None:
+    """Every analysis stage in the cron must also be in the rerun helper.
+
+    Otherwise an operator recovering via scripts/hallu_rerun.sh produces an
+    incomplete dashboard_data/ tree and deploy-dashboard.yml's verify fails.
+    """
+    rerun = RERUN_SCRIPT.read_text()
+    for module in _ANALYSIS_MODULES:
+        assert module in rerun, (
+            f"{module} is in the cron but missing from hallu_rerun.sh; "
+            "manual recovery would not satisfy deploy-dashboard.yml's verify"
+        )
+
+
+def test_rerun_script_supports_analysis_only_flag() -> None:
+    """The --analysis-only flag must run the three analysis stages (issue #113)."""
+    text = RERUN_SCRIPT.read_text()
+    assert "--analysis-only" in text
+    assert 'MODE="analysis"' in text, (
+        "rerun helper must map --analysis-only to analysis mode"
+    )
+
+
+def test_rerun_full_mode_runs_analysis_after_umap() -> None:
+    """Full mode must run the analysis stages after UMAP, matching cron order."""
+    text = RERUN_SCRIPT.read_text()
+    full_block_start = text.index("  full)")
+    full_block = text[full_block_start : full_block_start + 600]
+    for fn in (
+        "umap_analysis",
+        "themes_analysis",
+        "network_analysis",
+        "temporal_analysis",
+    ):
+        assert fn in full_block, f"{fn} missing from rerun full mode"
+    assert full_block.index("umap_analysis") < full_block.index("themes_analysis"), (
+        "analysis stages must run after umap_analysis in the rerun helper's full mode"
+    )


### PR DESCRIPTION
Closes #113.

## What

PR #108 added the themes/network/temporal analysis stages to `hallu_cron_pipeline.sh` but not to `hallu_rerun.sh`, so manual recovery (`scripts/hallu_rerun.sh`) produced an incomplete `dashboard_data/` tree and could not satisfy `deploy-dashboard.yml`'s fail-fast verify (which hard-requires non-empty `dashboard_data/{themes,network,temporal}`).

- Adds `themes_analysis` / `network_analysis` / `temporal_analysis` functions mirroring the cron exactly (same CLIs, `mkdir -p`, `|| exit 2` guards).
- Runs them in `full` mode after `umap_analysis`; adds an `--analysis-only` flag.
- Adds 4 preflight tests, including a **stage-parity** test asserting every `dataset_citations.analysis.generate_*` module in the cron is also in the rerun helper, so this drift cannot recur.

## Tested

- `bash -n` clean on both scripts.
- `--dry-run` (full + --analysis-only) prints the three stages with correct paths.
- `tests/test_hallu_cron_preflight.py`: 13 passed.
- ruff format/check clean.