### PR TITLE
fix(analysis): temporal high-confidence series + stale year cap

### DIFF
--- a/src/dataset_citations/analysis/generate_temporal.py
+++ b/src/dataset_citations/analysis/generate_temporal.py
@@ -1,21 +1,48 @@
 #!/usr/bin/env python
 """Generate temporal analysis data from citation JSON files."""
 
+import argparse
 import csv
 import json
 import sys
 from collections import defaultdict
+from datetime import datetime, timezone
 from pathlib import Path
 
+# Default confidence threshold; matches the dashboard's high-confidence filter
+# (dashboard/components/network_data.py and charts.py).
+DEFAULT_CONFIDENCE_THRESHOLD = 0.4
+MIN_YEAR = 2000
 
-def generate_temporal(citations_dir: Path, output_dir: Path):
-    """Generate temporal analysis data from citation data."""
 
-    # Initialize data structures
-    yearly_citations = defaultdict(int)
-    yearly_datasets = defaultdict(set)
+def _confidence_score(citation: dict) -> float:
+    """Per-citation confidence, tolerant of a missing/None scoring block."""
+    scoring = citation.get("confidence_scoring") or {}
+    return scoring.get("confidence_score") or 0.0
 
-    # Process all citation files
+
+def generate_temporal(
+    citations_dir: Path,
+    output_dir: Path,
+    confidence_threshold: float = DEFAULT_CONFIDENCE_THRESHOLD,
+    max_year: int | None = None,
+):
+    """Generate temporal analysis data from citation data.
+
+    Emits per-year ``total_citations`` (all citations) and
+    ``high_confidence_citations`` (confidence_score >= ``confidence_threshold``).
+    The high-confidence series is what the dashboard growth chart consumes;
+    without it the timeline rendered flat at zero.
+    """
+    if max_year is None:
+        # Allow next-year preprints; the previous hardcoded `< 2025` silently
+        # dropped every 2025+ citation.
+        max_year = datetime.now(timezone.utc).year + 1
+
+    yearly_citations: dict[int, int] = defaultdict(int)
+    yearly_high_conf: dict[int, int] = defaultdict(int)
+    yearly_datasets: dict[int, set[str]] = defaultdict(set)
+
     for json_file in citations_dir.glob("*.json"):
         dataset_id = json_file.stem.replace("_citations", "")
 
@@ -25,17 +52,24 @@ def generate_temporal(citations_dir: Path, output_dir: Path):
 
             for citation in citations:
                 year = citation.get("year", 0)
-                if year and 2000 < year < 2025:
-                    yearly_citations[year] += 1
-                    yearly_datasets[year].add(dataset_id)
+                if not year or not (MIN_YEAR < year <= max_year):
+                    continue
+                yearly_citations[year] += 1
+                yearly_datasets[year].add(dataset_id)
+                if _confidence_score(citation) >= confidence_threshold:
+                    yearly_high_conf[year] += 1
 
-    # Prepare output directory
     output_dir.mkdir(parents=True, exist_ok=True)
 
-    # Save temporal summary
     with open(output_dir / "temporal_summary.csv", "w", newline="") as f:
         writer = csv.DictWriter(
-            f, fieldnames=["year", "total_citations", "unique_datasets"]
+            f,
+            fieldnames=[
+                "year",
+                "total_citations",
+                "high_confidence_citations",
+                "unique_datasets",
+            ],
         )
         writer.writeheader()
         for year in sorted(yearly_citations.keys()):
@@ -43,14 +77,16 @@ def generate_temporal(citations_dir: Path, output_dir: Path):
                 {
                     "year": year,
                     "total_citations": yearly_citations[year],
+                    "high_confidence_citations": yearly_high_conf[year],
                     "unique_datasets": len(yearly_datasets[year]),
                 }
             )
 
-    # Save as JSON too
     temporal_data = {
         "yearly_citations": dict(yearly_citations),
+        "yearly_high_confidence_citations": dict(yearly_high_conf),
         "yearly_datasets": {str(k): len(v) for k, v in yearly_datasets.items()},
+        "confidence_threshold": confidence_threshold,
     }
 
     with open(output_dir / "temporal_analysis.json", "w") as f:
@@ -59,9 +95,7 @@ def generate_temporal(citations_dir: Path, output_dir: Path):
     print(f"Generated temporal analysis data: {len(yearly_citations)} years of data")
 
 
-if __name__ == "__main__":
-    import argparse
-
+def main() -> None:
     parser = argparse.ArgumentParser(description="Generate temporal analysis data")
     parser.add_argument(
         "--citations-dir",
@@ -75,6 +109,12 @@ if __name__ == "__main__":
         default=Path("dashboard_data/temporal"),
         help="Output directory for temporal analysis",
     )
+    parser.add_argument(
+        "--confidence-threshold",
+        type=float,
+        default=DEFAULT_CONFIDENCE_THRESHOLD,
+        help="Minimum confidence score for the high_confidence_citations series",
+    )
 
     args = parser.parse_args()
 
@@ -82,4 +122,12 @@ if __name__ == "__main__":
         print(f"Error: Citations directory {args.citations_dir} not found")
         sys.exit(1)
 
-    generate_temporal(args.citations_dir, args.output_dir)
+    generate_temporal(
+        args.citations_dir,
+        args.output_dir,
+        confidence_threshold=args.confidence_threshold,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_generate_temporal.py
+++ b/tests/test_generate_temporal.py
@@ -1,0 +1,145 @@
+"""Real-fixture tests for the temporal analysis generator.
+
+Covers the two bugs in issue #115: the missing ``high_confidence_citations``
+series (which left the dashboard growth chart flat) and the stale ``< 2025``
+year cap (which dropped 2025/2026 citations). No mocks: real citation JSON
+files are written to a tmp dir and the real CSV/JSON outputs are read back.
+"""
+
+from __future__ import annotations
+
+import csv
+import json
+from pathlib import Path
+
+from dataset_citations.analysis.generate_temporal import generate_temporal
+
+
+def _cite(year, score=None):
+    cit = {"year": year, "title": f"paper {year}/{score}"}
+    if score is not None:
+        cit["confidence_scoring"] = {"confidence_score": score}
+    return cit
+
+
+def _write_corpus(citations_dir: Path) -> None:
+    citations_dir.mkdir(parents=True, exist_ok=True)
+    (citations_dir / "ds_a_citations.json").write_text(
+        json.dumps(
+            {
+                "dataset_id": "ds_a",
+                "citation_details": [
+                    _cite(2022, 0.8),  # high
+                    _cite(2022, 0.2),  # low
+                    _cite(1998, 0.9),  # excluded: before MIN_YEAR
+                ],
+            }
+        )
+    )
+    (citations_dir / "ds_b_citations.json").write_text(
+        json.dumps(
+            {
+                "dataset_id": "ds_b",
+                "citation_details": [
+                    _cite(2026, 0.5),  # high, recent year (was dropped by < 2025)
+                    _cite(2022, None),  # no scoring block -> low
+                    {"year": 2022, "confidence_scoring": None},  # None block -> low
+                    _cite(0),  # excluded: no year
+                ],
+            }
+        )
+    )
+
+
+def _read_summary(output_dir: Path) -> dict[int, dict]:
+    rows = {}
+    with open(output_dir / "temporal_summary.csv") as f:
+        for row in csv.DictReader(f):
+            rows[int(row["year"])] = row
+    return rows
+
+
+def test_high_confidence_column_present_and_correct(tmp_path: Path):
+    citations_dir = tmp_path / "json_opencite"
+    output_dir = tmp_path / "temporal"
+    _write_corpus(citations_dir)
+
+    generate_temporal(
+        citations_dir, output_dir, confidence_threshold=0.4, max_year=2027
+    )
+
+    rows = _read_summary(output_dir)
+    assert "high_confidence_citations" in rows[2022]
+    # 2022: 4 total (0.8, 0.2, missing, None), 1 high-confidence (0.8), 2 datasets
+    assert int(rows[2022]["total_citations"]) == 4
+    assert int(rows[2022]["high_confidence_citations"]) == 1
+    assert int(rows[2022]["unique_datasets"]) == 2
+
+
+def test_recent_years_are_not_dropped(tmp_path: Path):
+    citations_dir = tmp_path / "json_opencite"
+    output_dir = tmp_path / "temporal"
+    _write_corpus(citations_dir)
+
+    generate_temporal(
+        citations_dir, output_dir, confidence_threshold=0.4, max_year=2027
+    )
+
+    rows = _read_summary(output_dir)
+    # 2026 used to be dropped by the hardcoded `< 2025` cap
+    assert 2026 in rows
+    assert int(rows[2026]["total_citations"]) == 1
+    assert int(rows[2026]["high_confidence_citations"]) == 1
+    # pre-2000 and yearless citations are excluded
+    assert 1998 not in rows
+    assert 0 not in rows
+
+
+def test_json_output_carries_high_confidence(tmp_path: Path):
+    citations_dir = tmp_path / "json_opencite"
+    output_dir = tmp_path / "temporal"
+    _write_corpus(citations_dir)
+
+    generate_temporal(
+        citations_dir, output_dir, confidence_threshold=0.4, max_year=2027
+    )
+
+    payload = json.loads((output_dir / "temporal_analysis.json").read_text())
+    assert payload["yearly_high_confidence_citations"]["2022"] == 1
+    assert payload["yearly_high_confidence_citations"]["2026"] == 1
+    assert payload["confidence_threshold"] == 0.4
+
+
+def test_threshold_is_respected(tmp_path: Path):
+    citations_dir = tmp_path / "json_opencite"
+    output_dir = tmp_path / "temporal"
+    _write_corpus(citations_dir)
+
+    # With a 0.1 threshold the 0.2 and 0.5 citations also count as high.
+    generate_temporal(
+        citations_dir, output_dir, confidence_threshold=0.1, max_year=2027
+    )
+
+    rows = _read_summary(output_dir)
+    # 2022: 0.8 and 0.2 clear 0.1; missing/None stay 0.0 -> 2 high
+    assert int(rows[2022]["high_confidence_citations"]) == 2
+
+
+def test_default_max_year_excludes_far_future(tmp_path: Path):
+    citations_dir = tmp_path / "json_opencite"
+    output_dir = tmp_path / "temporal"
+    citations_dir.mkdir(parents=True)
+    (citations_dir / "ds_c_citations.json").write_text(
+        json.dumps(
+            {
+                "dataset_id": "ds_c",
+                "citation_details": [_cite(2023, 0.9), _cite(3000, 0.9)],
+            }
+        )
+    )
+
+    generate_temporal(citations_dir, output_dir)  # default max_year = now+1
+
+    rows = _read_summary(output_dir)
+    assert 2023 in rows
+    assert 3000 not in rows


### PR DESCRIPTION
Closes #115. Partially addresses the dashboard correctness tracking issue #116 (data-layer half).

## What

`analysis/generate_temporal.py` now:
- Emits a per-year **`high_confidence_citations`** column in `temporal_summary.csv` and `yearly_high_confidence_citations` in `temporal_analysis.json`, computed from `citation_details[].confidence_scoring.confidence_score >= threshold` (default 0.4). The dashboard growth chart (`charts.py:_generate_growth_chart`) reads exactly this column; it was always absent, so the timeline rendered flat at y=0.
- Replaces the hardcoded `year < 2025` cap with `<= current_year + 1` (configurable via `max_year`), so 2025/2026 citations are no longer dropped. It is 2026.
- Adds a `--confidence-threshold` flag; tolerates a missing/None `confidence_scoring` block.

This is the data-layer half of the dashboard correctness bugs (#116); it feeds both the current dashboard and the future Astro dashboard and runs in the hallu analysis pipeline. The rendering-layer bugs (by-index citation map, hardcoded modality, KPI source-of-truth) stay tracked in #116 for the Astro rebuild.

## Tested

- `tests/test_generate_temporal.py`: 5 real-fixture tests (no mocks) covering the high-confidence column, threshold behavior, recent-year inclusion, pre-2000/yearless exclusion, JSON output, and the default future-year cap. All pass.
- ruff format/check + ty clean.

Note: the `high_confidence_citations` series only becomes non-zero once `confidence_scoring` is populated by the score-confidence step on hallu; the fix is the correct contract regardless.