### PR TITLE
fix(ops): one dataset's metadata failure no longer aborts the nightly cron

### DIFF
--- a/scripts/hallu_cron_pipeline.sh
+++ b/scripts/hallu_cron_pipeline.sh
@@ -78,7 +78,8 @@ echo "--- retrieve-metadata ---"
 uv run dataset-citations-retrieve-metadata \
   --citations-dir citations/json_opencite \
   --output-dir datasets \
-  --skip-existing || {
+  --skip-existing \
+  --max-failures 10 || {
   echo "ERROR: dataset-citations-retrieve-metadata failed; aborting." >&2
   exit 2
 }

--- a/scripts/hallu_rerun.sh
+++ b/scripts/hallu_rerun.sh
@@ -79,9 +79,12 @@ discover() {
 }
 
 retrieve_metadata() {
+  # --max-failures mirrors the cron: a few dead/undecodable repos must not
+  # abort a manual recovery run (issue #118).
   run uv run dataset-citations-retrieve-metadata \
     --citations-dir citations/json_opencite \
-    --output-dir datasets
+    --output-dir datasets \
+    --max-failures 10
 }
 
 preflight_ollama() {

--- a/src/dataset_citations/cli/retrieve_metadata.py
+++ b/src/dataset_citations/cli/retrieve_metadata.py
@@ -23,6 +23,20 @@ from ..quality.dataset_metadata import DatasetMetadataRetriever, save_dataset_me
 logger = logging.getLogger(__name__)
 
 
+def resolve_exit_code(
+    successful: int, skipped: int, failed: int, max_failures: int
+) -> int:
+    """Return the CLI exit code from the per-dataset retrieval tally.
+
+    retrieve-metadata is a best-effort refresh; a few dead, renamed, or
+    undecodable repos (e.g. ds002001's >1MB dataset_description.json) should
+    not abort the whole nightly pipeline. Exit non-zero only when the failure
+    count exceeds ``max_failures``. Default ``max_failures=0`` preserves the
+    original strict behavior; the hallu cron opts into tolerance (issue #118).
+    """
+    return 1 if failed > max_failures else 0
+
+
 def get_dataset_ids_from_citations_dir(citations_dir: str) -> List[str]:
     """Extract dataset IDs from citation JSON files."""
     dataset_ids = []
@@ -87,6 +101,17 @@ Examples:
         "--skip-existing",
         action="store_true",
         help="Skip datasets that already have metadata files",
+    )
+
+    parser.add_argument(
+        "--max-failures",
+        type=int,
+        default=0,
+        help=(
+            "Tolerate up to this many per-dataset retrieval failures before "
+            "exiting non-zero (default 0 = strict). The nightly cron passes a "
+            "small value so one dead/undecodable repo cannot abort the pipeline."
+        ),
     )
 
     parser.add_argument(
@@ -172,11 +197,19 @@ Examples:
     logger.info(f"  Failed: {failed}")
     logger.info(f"  Total processed: {len(dataset_ids)}")
 
-    if failed > 0:
-        logger.warning(f"{failed} datasets had retrieval failures")
-        return 1
+    exit_code = resolve_exit_code(successful, skipped, failed, args.max_failures)
+    if failed > args.max_failures:
+        logger.warning(
+            f"{failed} datasets had retrieval failures "
+            f"(> --max-failures={args.max_failures}); failing."
+        )
+    elif failed > 0:
+        logger.warning(
+            f"{failed} datasets had retrieval failures "
+            f"(within --max-failures={args.max_failures}); continuing."
+        )
 
-    return 0
+    return exit_code
 
 
 if __name__ == "__main__":

--- a/src/dataset_citations/quality/dataset_metadata.py
+++ b/src/dataset_citations/quality/dataset_metadata.py
@@ -162,10 +162,14 @@ class DatasetMetadataRetriever:
         except GithubException as e:
             logger.warning(f"dataset_description.json not found for {dataset_id}: {e}")
             return None
-        except json.JSONDecodeError as e:
-            logger.error(
-                f"Invalid JSON in dataset_description.json for {dataset_id}: {e}"
-            )
+        except (AssertionError, ValueError) as e:
+            # PyGithub's ContentFile.decoded_content raises
+            # AssertionError("unsupported encoding: None") for files it cannot
+            # base64-decode (e.g. a >1MB blob returned with encoding=none, as on
+            # ds002001). ValueError covers json.JSONDecodeError and
+            # UnicodeDecodeError. Treat the description as unavailable rather than
+            # letting one undecodable file abort the whole dataset retrieval.
+            logger.warning(f"dataset_description.json unreadable for {dataset_id}: {e}")
             return None
 
     def _get_readme_content(self, repo, dataset_id: str) -> Optional[str]:
@@ -179,8 +183,12 @@ class DatasetMetadataRetriever:
                 logger.info(f"Retrieved {readme_file} for {dataset_id}")
                 return readme_text
 
-            except GithubException:
-                continue  # Try next README file
+            except (GithubException, AssertionError, ValueError) as e:
+                # AssertionError/ValueError: PyGithub cannot decode an oversized
+                # or odd-encoding README; skip it instead of crashing the
+                # dataset retrieval. Try the next candidate filename.
+                logger.debug(f"{readme_file} unreadable for {dataset_id}: {e}")
+                continue
 
         logger.warning(f"No README file found for {dataset_id}")
         return None

--- a/tests/test_retrieve_metadata_resilience.py
+++ b/tests/test_retrieve_metadata_resilience.py
@@ -1,0 +1,60 @@
+"""Tests for nightly metadata-retrieval resilience (issue #118).
+
+The unit tests exercise the pure exit-code policy with real integers (no
+mocks). The integration test hits the real GitHub repo whose oversized file
+(``ds002001``) used to crash the whole nightly cron; it is gated behind
+RUN_INTEGRATION_TESTS so the fast suite stays offline.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from dataset_citations.cli.retrieve_metadata import resolve_exit_code
+
+
+def test_no_failures_is_success():
+    assert resolve_exit_code(successful=10, skipped=0, failed=0, max_failures=0) == 0
+
+
+def test_single_failure_is_fatal_under_strict_default():
+    # The exact ds002001 cron case: 0 new, 592 cached, 1 failed, strict.
+    assert resolve_exit_code(successful=0, skipped=592, failed=1, max_failures=0) == 1
+
+
+def test_single_failure_tolerated_when_cron_opts_in():
+    # The fix: the cron passes --max-failures 10, so 1 failure no longer aborts.
+    assert resolve_exit_code(successful=0, skipped=592, failed=1, max_failures=10) == 0
+
+
+def test_failures_exceeding_threshold_still_fail():
+    assert resolve_exit_code(successful=0, skipped=580, failed=13, max_failures=10) == 1
+
+
+def test_threshold_is_inclusive():
+    assert resolve_exit_code(successful=0, skipped=0, failed=10, max_failures=10) == 0
+    assert resolve_exit_code(successful=0, skipped=0, failed=11, max_failures=10) == 1
+
+
+@pytest.mark.skipif(
+    not os.getenv("RUN_INTEGRATION_TESTS") or not os.getenv("GITHUB_TOKEN"),
+    reason="needs network + GITHUB_TOKEN",
+)
+def test_undecodable_file_does_not_crash_dataset_retrieval():
+    """ds002001 has a file PyGithub cannot decode; retrieval must not raise.
+
+    Before the fix this raised AssertionError('unsupported encoding: None')
+    out of get_dataset_metadata, counting the dataset as failed and (under the
+    strict default) aborting the nightly cron.
+    """
+    from dataset_citations.quality.dataset_metadata import DatasetMetadataRetriever
+
+    retriever = DatasetMetadataRetriever(os.getenv("GITHUB_TOKEN"))
+    metadata = retriever.get_dataset_metadata("ds002001")
+
+    # The repo is found, so the dataset is usable even though the oversized
+    # file could not be decoded; the CLI counts this as successful, not failed.
+    assert metadata["retrieval_status"]["repository"] == "success"
+    assert metadata["github_info"]["exists"] is True


### PR DESCRIPTION
Closes #118. **This is the fix that restores the daily hallu pipeline.**

## Root cause (diagnosed live on hallu)

The nightly cron runs daily (`0 3 * * *`) but has aborted at `retrieve-metadata` every night since May 22:

```
ERROR - Error retrieving metadata for ds002001: unsupported encoding: None
INFO  - Successful: 0  Skipped: 592  Failed: 1  Total: 593
ERROR: dataset-citations-retrieve-metadata failed; aborting.  (rc=2)
```

`ds002001`'s `dataset_description.json` makes PyGithub's `decoded_content` raise `AssertionError('unsupported encoding: None')` (an undecodable / >1MB blob). `_get_dataset_description` only caught `GithubException`, so it propagated, the dataset counted as `failed`, `retrieve_metadata.py` returned 1 on `failed > 0`, and the cron's `|| exit 2` guard killed the entire pipeline before judge-anchors / fetch / score / commit ever ran.

## Fix (defense-in-depth)

1. **`quality/dataset_metadata.py`** - `_get_dataset_description` / `_get_readme_content` now also catch `AssertionError`/`ValueError` around `decoded_content.decode()`, so one undecodable file makes that component `None` instead of crashing the dataset (the repo is still found -> counts as successful).
2. **`cli/retrieve_metadata.py`** - new `--max-failures N` (default 0 = unchanged strict behavior) with a pure, tested `resolve_exit_code()`; exits non-zero only when `failed > max_failures`.
3. **`hallu_cron_pipeline.sh` + `hallu_rerun.sh`** - pass `--max-failures 10` so a handful of dead/renamed/undecodable repos can't block the nightly.

## Tested

- `tests/test_retrieve_metadata_resilience.py`: 5 pure `resolve_exit_code` unit tests (incl. the exact ds002001 case) + 1 real GitHub integration test on ds002001 gated behind RUN_INTEGRATION_TESTS. 5 passed, 1 skipped offline.
- `bash -n` clean on both scripts; ruff format/check clean. (Pre-existing unrelated `ty` note at dataset_metadata.py:122 is non-blocking and not touched.)

After merge, the next 03:00 UTC cron should complete end-to-end and open the first auto-update PR since #75.