### PR TITLE
fix(ops): default anchor-judgment model gemma4:31b -> gemma4:e4b

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,7 +59,7 @@ echo "GITHUB_TOKEN=..."  > .env
 # workstation-local `ollama serve` (see scripts/probe_anchor_judgment.py
 # docstring for the canonical workflow).
 # export OLLAMA_BASE_URL=http://localhost:21434   # tunneled to hallu:11434
-# export OLLAMA_MODEL=gemma4:31b                  # tracks _DEFAULT_MODEL
+# export OLLAMA_MODEL=gemma4:e4b                  # tracks _DEFAULT_MODEL (31b OOMs on shared hallu)
 ```
 
 ## Development Workflow
@@ -138,7 +138,7 @@ uv run dataset-citations-score-confidence --citations-dir citations/json_opencit
 1. **Discovery**: Prefer `https://api.nemar.org/datasets` (D1 catalog, no auth, ~40KB for the full list of 594 datasets) for both nm-* and on-* (NEMAR-imported OpenNeuro) IDs. One request gives every dataset's `dataset_id`, `doi`, `concept_doi`, `source`, `source_id`, `github_repo`, and modality/task/author metadata. Legacy ds-* IDs not yet in the catalog still come from GitHub via `cli/discover.py`.
 2. **DOI extraction**: For nm-* / on-* — fetch `https://data.nemar.org/<id>/metadata.json` (the same neuroschema doc the worker generates from `.nemar/metadata.json` + D1 enrichment) and parse `related_identifiers[]` via `sources/nemar_metadata.py`. Confirmed shape: `{ identifier, identifier_type, relation_type }` with DataCite relation values. For legacy ds-* — fall back to `dataset_description.json` via `sources/bids_metadata.py`. The dataset's **own** DOI (from the catalog `doi` field) is also a citation anchor with `relation_type = References`. Relation types we consume: `References`, `IsDerivedFrom`, `IsIdenticalTo`, `IsVersionOf`.
 3. **Anchor judgment + citation fetching** (epic #76):
-   - **3a. Anchor judgment**: `dataset-citations-judge-anchors` classifies each anchor DOI as `data_paper` / `umbrella` / `methodology` / `related_work` / `irrelevant` via an Ollama-served Gemma checkpoint (default `gemma4:31b` on hallu, swappable via `OLLAMA_MODEL`). Writes per-dataset sidecars to `citations/anchor_judgments/<id>.json`. Aborts with exit code 2 if the Ollama daemon is unreachable.
+   - **3a. Anchor judgment**: `dataset-citations-judge-anchors` classifies each anchor DOI as `data_paper` / `umbrella` / `methodology` / `related_work` / `irrelevant` via an Ollama-served Gemma checkpoint (default `gemma4:e4b` on hallu, swappable via `OLLAMA_MODEL`; `gemma4:31b` discriminates better but OOMs on the shared host). Writes per-dataset sidecars to `citations/anchor_judgments/<id>.json`. Aborts with exit code 2 if the Ollama daemon is unreachable.
    - **3b. Pipeline bucketing + citation fetching**: `core/opencite_pipeline.py` reads the sidecar via `quality/anchor_judgment_io.py` and buckets anchors by classification: `data_paper` -> kept for the opencite fetch; everything else -> recorded in `metadata.context_anchors[]` as context only. Anchors not present in the sidecar (or with no sidecar at all) fall through to "fetch all" so the pipeline stays usable while the backfill is in progress; a per-dataset WARN logs the gap count. `backends/opencite_backend.py` (sync facade over opencite) then queries OpenAlex / Semantic Scholar / PubMed for the surviving `data_paper` anchors. Concurrency throttled by `OPENCITE_MAX_CONCURRENCY` (CI sets to 1, see PR #50).
 4. **Processing**: `core/opencite_pipeline.py` deduplicates across anchors and produces schema-v2 citation JSON.
 5. **Quality scoring**: sentence-transformer similarity between dataset metadata and citation abstract. Runs on hallu's RTX 4090 via `scripts/hallu_cron_pipeline.sh` (epic #76).

--- a/scripts/hallu_cron_pipeline.sh
+++ b/scripts/hallu_cron_pipeline.sh
@@ -83,6 +83,12 @@ uv run dataset-citations-retrieve-metadata \
   exit 2
 }
 
+# Pin the anchor-judgment model. gemma4:e4b (9.6GB) is used instead of the
+# larger gemma4:31b (19GB) because hallu is a shared host and 31B OOMs /
+# blocks other GPU jobs. Honors an explicit OLLAMA_MODEL override for a
+# dedicated host. Keep in sync with llm_client._DEFAULT_MODEL.
+export OLLAMA_MODEL="${OLLAMA_MODEL:-gemma4:e4b}"
+
 # 3. Preflight: Ollama must be reachable for anchor adjudication. If the
 # daemon is down, abort cleanly instead of producing a citation update
 # with stale judgments. Exit 2 mirrors the contract documented for

--- a/src/dataset_citations/quality/llm_client.py
+++ b/src/dataset_citations/quality/llm_client.py
@@ -71,11 +71,18 @@ _ENV_TIMEOUT = "OLLAMA_TIMEOUT_SECONDS"
 
 _DEFAULT_BASE_URL = "http://localhost:11434"
 # Single source of truth for the deployed model. Bump this one constant
-# (and re-run the probe) when a new checkpoint is pulled on hallu. 31B
-# is the smallest checkpoint that handles the methodology-vs-data_paper
-# discrimination correctly on the acceptance-gate probe; 26B confused a
-# Brainstorm-tools anchor for a data paper.
-_DEFAULT_MODEL = "gemma4:31b"
+# (and re-run scripts/probe_anchor_judgment.py) when the pulled model changes.
+#
+# Trade-off (2026-06-13): the larger 31B checkpoint discriminates
+# methodology-vs-data_paper best (26B once confused a Brainstorm-tools anchor
+# for a data paper), but 31B (19GB) OOMs / blocks other GPU jobs on the shared
+# hallu host, so it is not a viable steady-state default. gemma4:e4b (9.6GB)
+# is the resource-fit choice that still emits clean JSON under format=json
+# (qwen3.5:9b does not). Net guardrail against any weaker-judge umbrella
+# leakage: the cross-dataset attribution audit (dataset-citations-audit-attribution)
+# flags anchors fanned across many datasets regardless of judgment quality.
+# Override with OLLAMA_MODEL=gemma4:31b on a dedicated host.
+_DEFAULT_MODEL = "gemma4:e4b"
 # Per-judgment timeout: most calls return in 3-10s, but cold loads + long
 # prompts on the 26B checkpoint have been observed at ~150s. 300s gives
 # headroom without hanging the probe forever on a stuck request.


### PR DESCRIPTION
Closes #120.

## Why

hallu is a shared GPU host; `gemma4:31b` (19GB) OOMs / blocks other jobs, so it is not a viable steady-state default. Tested on hallu:
- `qwen3.5:9b` - **unusable**: returns empty/non-JSON even under the client's `format: json` (reasoning model); all probe anchors error.
- `gemma4:e4b` (9.6GB) - emits clean JSON, parses under `format: json`, same format as the working 31B. Fits alongside other jobs.

## Change

- `llm_client.py`: `_DEFAULT_MODEL = 'gemma4:e4b'`, with an honest comment on the quality/resource trade-off.
- `hallu_cron_pipeline.sh`: pin `export OLLAMA_MODEL=${OLLAMA_MODEL:-gemma4:e4b}` so the nightly never loads 31B even if the code default drifts.
- AGENTS.md references updated.

## Quality caveat (honest)

The prior comment noted larger checkpoints discriminate methodology-vs-data_paper better (a 26B once mislabeled a Brainstorm-tools anchor). e4b is much smaller, so per-dataset misjudgments are possible. Mitigation: the cross-dataset attribution audit (#112) flags any anchor fanned across many datasets regardless of judge quality, catching umbrella leakage. `OLLAMA_MODEL=gemma4:31b` still overrides on a dedicated host.

## Tested

- Default resolves to `gemma4:e4b` (verified); `bash -n` + ruff clean.
- `test_quality_llm_client.py` + `test_pipeline_anchor_judgment.py` green (no test hardcodes the default; the pipeline echo-tests pass their own model string).