### PR TITLE
fix(ops): throttle GitHub client to avoid secondary rate-limit stalls

### DIFF
--- a/src/dataset_citations/quality/dataset_metadata.py
+++ b/src/dataset_citations/quality/dataset_metadata.py
@@ -29,8 +29,9 @@ import re
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 
-from github import Github
 from github.GithubException import GithubException
+
+from dataset_citations.utils.github_client import build_github
 
 logger = logging.getLogger(__name__)
 
@@ -72,10 +73,8 @@ class DatasetMetadataRetriever:
         """
         # `timeout` caps how long PyGithub will wait on a single HTTP call
         # before raising; without it a CLOSE_WAIT socket can hang forever.
-        if github_token:
-            self.github = Github(github_token, timeout=_GITHUB_TIMEOUT_SECONDS)
-        else:
-            self.github = Github(timeout=_GITHUB_TIMEOUT_SECONDS)
+        # build_github also spaces requests to stay under the secondary limit.
+        self.github = build_github(github_token, timeout=_GITHUB_TIMEOUT_SECONDS)
 
     def get_dataset_metadata(self, dataset_id: str) -> Dict[str, Any]:
         """

--- a/src/dataset_citations/sources/bids_metadata.py
+++ b/src/dataset_citations/sources/bids_metadata.py
@@ -14,7 +14,6 @@ import json
 import logging
 from typing import Any
 
-from github import Github
 from github.GithubException import GithubException
 
 from dataset_citations.sources.doi import (
@@ -31,6 +30,7 @@ from dataset_citations.sources.models import (
     IdentifierType,
     RelationType,
 )
+from dataset_citations.utils.github_client import build_github
 
 logger = logging.getLogger(__name__)
 
@@ -46,7 +46,7 @@ class BidsMetadataSource:
     returns DOI/PMID/arXiv references suitable for opencite lookup."""
 
     def __init__(self, github_token: str | None = None) -> None:
-        self.github = Github(github_token) if github_token else Github()
+        self.github = build_github(github_token)
 
     def get_doi_references(
         self, dataset_id: str, org: str = "OpenNeuroDatasets"

--- a/src/dataset_citations/sources/nemar_metadata.py
+++ b/src/dataset_citations/sources/nemar_metadata.py
@@ -21,7 +21,6 @@ import logging
 from typing import Any, cast, get_args
 
 import requests
-from github import Github
 from github.GithubException import GithubException
 
 from dataset_citations.sources.doi import (
@@ -36,6 +35,7 @@ from dataset_citations.sources.models import (
     FetchSuccess,
     RelationType,
 )
+from dataset_citations.utils.github_client import build_github
 
 logger = logging.getLogger(__name__)
 
@@ -63,7 +63,7 @@ class NemarMetadataSource:
         data_api_base: str = DEFAULT_DATA_API_BASE,
         data_api_timeout: float = DEFAULT_DATA_API_TIMEOUT,
     ) -> None:
-        self.github = Github(github_token) if github_token else Github()
+        self.github = build_github(github_token)
         self.prefer_data_api = prefer_data_api
         self.data_api_base = data_api_base.rstrip("/")
         self.data_api_timeout = data_api_timeout

--- a/src/dataset_citations/utils/github_client.py
+++ b/src/dataset_citations/utils/github_client.py
@@ -1,0 +1,43 @@
+"""Shared PyGithub client builder with request spacing.
+
+A full citation re-fetch loops `get_repo` + `get_contents` over hundreds of
+legacy ds-* datasets to extract DOI anchors. Unspaced, that burst trips
+GitHub's *secondary* (abuse) rate limit even though the primary 5000/hr budget
+is nearly untouched, and PyGithub then backs off for the full primary-reset
+window (~59 min) on a single request, stalling the whole pipeline.
+
+Spacing requests a minimum interval apart keeps the burst under the secondary
+limit. The interval is configurable via ``GITHUB_SECONDS_BETWEEN_REQUESTS``
+(default 1.0s ~= 60 req/min) so a dedicated host can speed it up or a throttled
+one can slow it down without code changes.
+"""
+
+from __future__ import annotations
+
+import os
+
+from github import Auth, Github
+
+_ENV_SPACING = "GITHUB_SECONDS_BETWEEN_REQUESTS"
+_DEFAULT_SPACING = 1.0
+
+
+def github_request_spacing() -> float:
+    """Minimum seconds between GitHub requests (env-configurable, >= 0)."""
+    raw = os.getenv(_ENV_SPACING)
+    if raw is None:
+        return _DEFAULT_SPACING
+    try:
+        value = float(raw)
+    except ValueError:
+        return _DEFAULT_SPACING
+    return value if value >= 0 else _DEFAULT_SPACING
+
+
+def build_github(token: str | None = None, *, timeout: int | None = None) -> Github:
+    """Return a PyGithub client throttled to stay under the secondary limit."""
+    auth = Auth.Token(token) if token else None
+    spacing = github_request_spacing()
+    if timeout is None:
+        return Github(auth=auth, seconds_between_requests=spacing)
+    return Github(auth=auth, seconds_between_requests=spacing, timeout=timeout)

--- a/tests/test_github_client.py
+++ b/tests/test_github_client.py
@@ -1,0 +1,48 @@
+"""Tests for the throttled GitHub client builder (#124).
+
+Env resolution is exercised with real os.environ manipulation (monkeypatch is
+env plumbing, not a service mock), and build_github constructs a real PyGithub
+client (no network happens at construction time).
+"""
+
+from __future__ import annotations
+
+from dataset_citations.utils.github_client import (
+    _DEFAULT_SPACING,
+    build_github,
+    github_request_spacing,
+)
+
+_ENV = "GITHUB_SECONDS_BETWEEN_REQUESTS"
+
+
+def test_default_spacing(monkeypatch):
+    monkeypatch.delenv(_ENV, raising=False)
+    assert github_request_spacing() == _DEFAULT_SPACING
+
+
+def test_env_override(monkeypatch):
+    monkeypatch.setenv(_ENV, "2.5")
+    assert github_request_spacing() == 2.5
+
+
+def test_invalid_env_falls_back(monkeypatch):
+    monkeypatch.setenv(_ENV, "not-a-number")
+    assert github_request_spacing() == _DEFAULT_SPACING
+
+
+def test_negative_env_falls_back(monkeypatch):
+    monkeypatch.setenv(_ENV, "-3")
+    assert github_request_spacing() == _DEFAULT_SPACING
+
+
+def test_build_github_constructs_without_token(monkeypatch):
+    monkeypatch.setenv(_ENV, "1.0")
+    client = build_github()
+    assert client is not None
+
+
+def test_build_github_constructs_with_token_and_timeout(monkeypatch):
+    monkeypatch.setenv(_ENV, "1.0")
+    client = build_github("fake-token-not-used-offline", timeout=30)
+    assert client is not None


### PR DESCRIPTION
Closes #124. Unblocks the full citation re-fetch (and protects the nightly cron) from GitHub's secondary rate limit.

## What

New `utils/github_client.py::build_github()` builds the PyGithub client with `seconds_between_requests` (default 1.0s, env `GITHUB_SECONDS_BETWEEN_REQUESTS`) so the per-dataset `get_repo`/`get_contents` burst during ds-* DOI extraction stays under the secondary limit. Uses `Auth.Token` and keeps the existing `timeout`. Wired into `bids_metadata`, `nemar_metadata`, `quality/dataset_metadata`.

## Why

During the supervised regeneration, the `update --max-age-days 0` re-fetch tripped GitHub's secondary limit (primary had 4686/5000 remaining) and PyGithub backed off ~59 min on a single request, stalling the pipeline. Spacing requests fixes it at the source.

## Tested

`tests/test_github_client.py`: 6 real tests (env resolution + real client construction, no service mocks). ruff + ty clean on the helper; the three sources construct throttled clients.