### PR TITLE
fix(ops): relax deploy gate — *similarities*.csv is a warning, not a hard fail

### DIFF
--- a/.github/workflows/deploy-dashboard.yml
+++ b/.github/workflows/deploy-dashboard.yml
@@ -71,15 +71,16 @@ jobs:
               echo "OK: $dir ($count files)"
             fi
           done
-          # UMAP outputs (phase 3, #99) live FLAT in dashboard_data/ as
-          # *similarities*.csv so the aggregator's non-recursive glob picks
-          # them up. Missing CSVs would render an empty Citation Similarities
-          # panel without otherwise breaking the build; catch that here.
+          # UMAP similarity exports were intended to live FLAT in dashboard_data/
+          # as *similarities*.csv, but no current producer writes them
+          # (analyze-umap emits a .pkl projection, not a CSV). The Citation
+          # Similarities panel degrades to empty when absent, and the surface is
+          # being replaced by the Astro rebuild (#127), so a missing CSV is a
+          # WARNING, not a hard failure (#132). The themes/network/temporal/
+          # embeddings checks above remain hard requirements.
           sim_count=$(find dashboard_data -maxdepth 1 -name "*similarities*.csv" -type f 2>/dev/null | wc -l | tr -d ' ')
           if [ "$sim_count" -eq 0 ]; then
-            echo "::error::No *similarities*.csv files at dashboard_data/ top level"
-            echo "::error::Phase 3 of epic #96 expects hallu's analyze-umap step to write them flat there"
-            missing=1
+            echo "::warning::No dashboard_data/*similarities*.csv (no producer yet, #132); Citation Similarities panel will be empty. Continuing."
           else
             echo "OK: dashboard_data/*similarities*.csv ($sim_count files)"
           fi


### PR DESCRIPTION
Closes #132. Unblocks deploying the accurate regenerated data (PR #130).

## Problem
`deploy-dashboard.yml` fail-fast verify hard-required `dashboard_data/*similarities*.csv`, but **no code produces that file** — `analyze-umap` writes an `embeddings/analysis/.../*.pkl` projection, never a similarities CSV. So the gate could never pass and every deploy fail-fasted (confirmed against the fresh regen).

## Change
The similarities check is now a `::warning::` that continues, instead of `exit 1`. The hard requirements for `dashboard_data/{themes,network,temporal}` and `embeddings/` (which DO have producers and are present) are unchanged.

## Rationale
The Citation Similarities panel degrades to empty when the CSV is absent (the aggregator's glob just returns []), and that panel is already broken (#116, fabricated-by-index) and being replaced by the Astro rebuild (#127). So a missing CSV must not block shipping accurate citation counts.

## Tested
YAML parses; the other (real) input checks stay hard. After this + PR #130 merge, `deploy-dashboard.yml` deploys the accurate data instead of fail-fasting.