### PR TITLE
fix(ops): analyze-umap --embedding-type both (Dataset Map was empty)

### DIFF
--- a/scripts/hallu_cron_pipeline.sh
+++ b/scripts/hallu_cron_pipeline.sh
@@ -194,7 +194,7 @@ echo "--- analyze-umap ---"
 uv run dataset-citations-analyze-umap \
   --embeddings-dir embeddings \
   --output-dir dashboard_data \
-  --embedding-type citations || {
+  --embedding-type both || {
   echo "ERROR: dataset-citations-analyze-umap failed; aborting before commit." >&2
   exit 2
 }

--- a/scripts/hallu_rerun.sh
+++ b/scripts/hallu_rerun.sh
@@ -156,7 +156,7 @@ umap_analysis() {
   run uv run dataset-citations-analyze-umap \
     --embeddings-dir embeddings \
     --output-dir dashboard_data \
-    --embedding-type citations || {
+    --embedding-type both || {
     echo "ERROR: dataset-citations-analyze-umap failed; aborting." >&2
     exit 2
   }


### PR DESCRIPTION
Closes #136. The cron + rerun ran `generate-embeddings --embedding-type both` but `analyze-umap --embedding-type citations`, so no dataset UMAP coordinates were produced and the dashboard **Dataset Map rendered empty**. Changed both `analyze-umap` calls to `--embedding-type both`.

Verified on hallu: `analyze-umap --embedding-type both` produces `both_umap_2d_*.pkl` (602 datasets + 6,383 citations). `bash -n` clean; preflight tests pass.

Note: the old Python dashboard's maps are also subject to #116 (the Citation Map's node titles/counts are fabricated-by-index); the correct rebuild is Astro P4 (#127). This fix ensures the dataset UMAP exists, which Astro P4 also needs.