### PR TITLE
feat(web): headline high-confidence citations, exclude BIDS/methods anchors

### DIFF
--- a/web/src/lib/data.ts
+++ b/web/src/lib/data.ts
@@ -291,6 +291,10 @@ export function loadAll(): LoadedData {
     lowConfidenceTotal += lowConf.length;
     if (counted.length > 0) {
       datasetsWithCitations += 1;
+    }
+    // Generate a page for any dataset with citations (high- OR low-confidence),
+    // so every low-confidence citation is actually surfaced per dataset.
+    if (counted.length > 0 || lowConf.length > 0) {
       counted.sort((a, b) => b.citedBy - a.citedBy);
       lowConf.sort((a, b) => b.citedBy - a.citedBy);
       datasets.push({

--- a/web/src/lib/data.ts
+++ b/web/src/lib/data.ts
@@ -4,19 +4,47 @@
  * Reads the schema-v2 citation JSON committed to this repo
  * (citations/json_opencite/) plus dataset names from datasets/, and exposes a
  * typed contract the pages render. Runs in node during `astro build`; nothing
- * here ships to the client. Phases P2+P3 of epic #127.
+ * here ships to the client. Epic #127.
+ *
+ * Counting policy (issue #138): the HEADLINE counts only HIGH-CONFIDENCE
+ * citations (confidence_score >= HIGH_CONF) and EXCLUDES BIDS / methods /
+ * umbrella anchor papers (a citation pulled in via a method/standards paper is
+ * not a citation OF the dataset). Methods anchors are detected as a source DOI
+ * that is over-spread across many datasets, plus a curated denylist of canonical
+ * BIDS/methods papers. Low-confidence citations are not counted but are kept so
+ * the per-dataset view can surface them ("also N low-confidence").
  */
 import { existsSync, readFileSync, readdirSync } from "node:fs";
 import { dirname, join } from "node:path";
 
-// Opt-in to build an empty dashboard when no data is present. Off by default so
-// a misconfigured build fails loudly instead of shipping zero-stat pages.
 const ALLOW_EMPTY = process.env.CITATIONS_ALLOW_EMPTY === "1";
 const EMPTY_HINT =
   "Run the hallu pipeline (or check out a tree with citations/json_opencite/), " +
   "or set CITATIONS_ALLOW_EMPTY=1 to intentionally build an empty dashboard.";
 
-/** Walk up from the build CWD to locate a repo-relative data dir. */
+const HIGH_CONF = 0.4;
+// A source anchor attributed across more datasets than this is treated as a
+// methods/umbrella paper (its citers are not citations of any one dataset).
+const METHODS_SPREAD = 5;
+
+// Curated canonical BIDS / methods / standards / umbrella anchor DOIs (normalized:
+// lowercase, no "doi:" prefix). Excluded even if not over-spread. The over-spread
+// heuristic catches the rest. The principled long-term fix is anchor judgment on
+// the un-judged ds-* datasets (#131); this is the build-local stand-in.
+const METHODS_DENYLIST = new Set<string>([
+  "10.21105/joss.01896", // MNE-BIDS
+  "10.1038/s41597-019-0104-8", // EEG-BIDS
+  "10.1038/s41597-019-0105-7", // iEEG-BIDS
+  "10.1038/sdata.2018.110", // MEG-BIDS
+  "10.1038/sdata.2016.44", // BIDS (original)
+  "10.1038/s41592-018-0235-4", // fMRIPrep
+  "10.3389/fnins.2013.00267", // MNE-Python
+  "10.1016/j.jneumeth.2003.10.009", // EEGLAB
+  "10.1155/2011/156869", // FieldTrip
+  "10.1038/sdata.2017.181", // HBN (umbrella)
+  "10.1038/sdata.2017.40", // HBN resource (umbrella)
+]);
+
 function findRepoDir(sub: string): string | null {
   let dir = process.cwd();
   for (let depth = 0; depth < 8; depth++) {
@@ -49,16 +77,25 @@ export interface Citation {
 
 export interface DatasetDetail {
   id: string;
-  name: string;
+  /** High-confidence, non-methods citations — the counted set. */
   numCitations: number;
+  name: string;
   citations: Citation[];
+  /** Low-confidence citations (kept for the detail view, not counted). */
+  lowConfCitations: Citation[];
+  /** Count of method/standards references excluded from the dataset's citations. */
+  methodsExcluded: number;
 }
 
 export interface Overview {
   datasetCount: number;
   datasetsWithCitations: number;
+  /** Summed high-confidence, non-methods citations across datasets. */
   totalCitations: number;
+  /** Unique high-confidence, non-methods citing papers (the headline). */
   uniqueCitations: number;
+  /** Summed low-confidence citations (surfaced as a secondary figure). */
+  lowConfidenceTotal: number;
 }
 
 export interface LoadedData {
@@ -75,25 +112,28 @@ interface RawCitation {
   doi?: string | null;
   pmid?: string | null;
   openalex_id?: string | null;
+  source_doi?: string | null;
   cited_by?: number | null;
   confidence_scoring?: { confidence_score?: number | null } | null;
 }
 
-interface RawFile {
-  dataset_id?: string;
-  num_citations?: number;
-  citation_details?: RawCitation[];
+interface RawEntry {
+  id: string;
+  details: RawCitation[];
+}
+
+function normalizeDoi(doi: string): string {
+  return doi
+    .trim()
+    .toLowerCase()
+    .replace(/^doi:/, "")
+    .replace(/[.,;:]+$/, "");
 }
 
 /** DOI-first identity for a citing paper (matches the attribution audit's dedup). */
 function citingKey(c: RawCitation): string {
-  const doi = c.doi;
-  if (doi) {
-    return `doi:${doi
-      .trim()
-      .toLowerCase()
-      .replace(/^doi:/, "")
-      .replace(/[.,;:]+$/, "")}`;
+  if (c.doi) {
+    return `doi:${normalizeDoi(c.doi)}`;
   }
   if (c.openalex_id) {
     return `openalex:${c.openalex_id.trim().toLowerCase()}`;
@@ -102,6 +142,11 @@ function citingKey(c: RawCitation): string {
     return `pmid:${String(c.pmid).trim()}`;
   }
   return `title:${(c.title ?? "").trim().toLowerCase().replace(/\s+/g, " ")}`;
+}
+
+function isHighConf(c: RawCitation): boolean {
+  const conf = c.confidence_scoring?.confidence_score;
+  return typeof conf === "number" && conf >= HIGH_CONF;
 }
 
 function toCitation(c: RawCitation): Citation {
@@ -135,9 +180,63 @@ function readDatasetName(id: string): string {
   }
 }
 
+function readEntries(): RawEntry[] | null {
+  if (!citationsDir) {
+    return null;
+  }
+  const files = readdirSync(citationsDir).filter((f) => f.endsWith("_citations.json"));
+  if (files.length === 0) {
+    return null;
+  }
+  const entries: RawEntry[] = [];
+  for (const fileName of files) {
+    try {
+      const raw = JSON.parse(readFileSync(join(citationsDir, fileName), "utf-8")) as {
+        dataset_id?: string;
+        citation_details?: RawCitation[];
+      };
+      entries.push({
+        id: raw.dataset_id || fileName.replace("_citations.json", ""),
+        details: raw.citation_details ?? [],
+      });
+    } catch (err) {
+      console.warn(`[data] skipping ${fileName}: ${err instanceof Error ? err.message : err}`);
+    }
+  }
+  return entries;
+}
+
+/** Source DOIs attributed across more than METHODS_SPREAD datasets, unioned with
+ * the curated denylist — the methods/umbrella anchors whose citers we exclude. */
+function methodsAnchors(entries: RawEntry[]): Set<string> {
+  const spread = new Map<string, Set<string>>();
+  for (const { id, details } of entries) {
+    for (const c of details) {
+      if (!c.source_doi) {
+        continue;
+      }
+      const key = normalizeDoi(c.source_doi);
+      const set = spread.get(key) ?? new Set<string>();
+      set.add(id);
+      spread.set(key, set);
+    }
+  }
+  const methods = new Set<string>(METHODS_DENYLIST);
+  for (const [anchor, datasets] of spread) {
+    if (datasets.size > METHODS_SPREAD) {
+      methods.add(anchor);
+    }
+  }
+  return methods;
+}
+
+function isMethodsCitation(c: RawCitation, methods: Set<string>): boolean {
+  return c.source_doi ? methods.has(normalizeDoi(c.source_doi)) : false;
+}
+
 let cache: LoadedData | null = null;
 
-/** Load the full dataset + overview once (memoized across page builds). */
+/** Load + classify the full corpus once (memoized across page builds). */
 export function loadAll(): LoadedData {
   if (cache) {
     return cache;
@@ -148,65 +247,71 @@ export function loadAll(): LoadedData {
       datasetsWithCitations: 0,
       totalCitations: 0,
       uniqueCitations: 0,
+      lowConfidenceTotal: 0,
     },
     datasets: [],
   };
 
-  if (!citationsDir) {
+  const entries = readEntries();
+  if (!entries) {
     if (ALLOW_EMPTY) {
-      console.warn(`[data] citations/json_opencite/ not found; building empty. ${EMPTY_HINT}`);
+      console.warn(`[data] no citation data found; building empty. ${EMPTY_HINT}`);
       cache = empty;
       return cache;
     }
-    throw new Error(`[data] Cannot locate citations/json_opencite/. ${EMPTY_HINT}`);
+    throw new Error(`[data] Cannot load citations/json_opencite/. ${EMPTY_HINT}`);
   }
 
-  const files = readdirSync(citationsDir).filter((f) => f.endsWith("_citations.json"));
-  if (files.length === 0) {
-    if (ALLOW_EMPTY) {
-      console.warn(`[data] ${citationsDir} has no *_citations.json; building empty.`);
-      cache = empty;
-      return cache;
-    }
-    throw new Error(`[data] ${citationsDir} has no *_citations.json files. ${EMPTY_HINT}`);
-  }
-
+  const methods = methodsAnchors(entries);
+  const uniqueHighConf = new Set<string>();
   let totalCitations = 0;
+  let lowConfidenceTotal = 0;
   let datasetsWithCitations = 0;
-  const unique = new Set<string>();
   const datasets: DatasetDetail[] = [];
 
-  for (const fileName of files) {
-    let raw: RawFile;
-    try {
-      raw = JSON.parse(readFileSync(join(citationsDir, fileName), "utf-8")) as RawFile;
-    } catch (err) {
-      console.warn(`[data] skipping ${fileName}: ${err instanceof Error ? err.message : err}`);
-      continue;
-    }
-    const id = raw.dataset_id || fileName.replace("_citations.json", "");
-    const details = raw.citation_details ?? [];
-    const num = raw.num_citations ?? details.length;
-    totalCitations += num;
+  for (const { id, details } of entries) {
+    const counted: Citation[] = [];
+    const lowConf: Citation[] = [];
+    let methodsExcluded = 0;
+
     for (const c of details) {
-      unique.add(citingKey(c));
+      if (isMethodsCitation(c, methods)) {
+        methodsExcluded += 1;
+        continue;
+      }
+      if (isHighConf(c)) {
+        counted.push(toCitation(c));
+        uniqueHighConf.add(citingKey(c));
+      } else {
+        lowConf.push(toCitation(c));
+      }
     }
-    // Count + render only datasets with renderable citation_details (a file can
-    // carry num_citations > 0 with empty details after a partial fetch).
-    if (details.length > 0) {
+
+    totalCitations += counted.length;
+    lowConfidenceTotal += lowConf.length;
+    if (counted.length > 0) {
       datasetsWithCitations += 1;
-      const citations = details.map(toCitation).sort((a, b) => b.citedBy - a.citedBy);
-      datasets.push({ id, name: readDatasetName(id), numCitations: num, citations });
+      counted.sort((a, b) => b.citedBy - a.citedBy);
+      lowConf.sort((a, b) => b.citedBy - a.citedBy);
+      datasets.push({
+        id,
+        name: readDatasetName(id),
+        numCitations: counted.length,
+        citations: counted,
+        lowConfCitations: lowConf,
+        methodsExcluded,
+      });
     }
   }
 
   datasets.sort((a, b) => b.numCitations - a.numCitations);
   cache = {
     overview: {
-      datasetCount: files.length,
+      datasetCount: entries.length,
       datasetsWithCitations,
       totalCitations,
-      uniqueCitations: unique.size,
+      uniqueCitations: uniqueHighConf.size,
+      lowConfidenceTotal,
     },
     datasets,
   };

--- a/web/src/pages/dataset/[id].astro
+++ b/web/src/pages/dataset/[id].astro
@@ -27,9 +27,17 @@ const base = import.meta.env.BASE_URL.replace(/\/$/, "");
     )}
   </p>
 
-  <ol class="cites" role="list">
-    {dataset.citations.map((citation) => <CitationItem citation={citation} />)}
-  </ol>
+  {
+    dataset.citations.length > 0 ? (
+      <ol class="cites" role="list">
+        {dataset.citations.map((citation) => (
+          <CitationItem citation={citation} />
+        ))}
+      </ol>
+    ) : (
+      <p class="empty">No high-confidence citations yet for this dataset.</p>
+    )
+  }
 
   {
     dataset.lowConfCitations.length > 0 && (
@@ -69,6 +77,10 @@ const base = import.meta.env.BASE_URL.replace(/\/$/, "");
     list-style: none;
     margin-top: var(--space-6);
     border-top: 1px solid var(--color-border);
+  }
+  .empty {
+    margin-top: var(--space-6);
+    color: var(--color-fg-muted);
   }
   .lowconf {
     margin-top: var(--space-8);

--- a/web/src/pages/dataset/[id].astro
+++ b/web/src/pages/dataset/[id].astro
@@ -21,12 +21,30 @@ const base = import.meta.env.BASE_URL.replace(/\/$/, "");
   <p class="back"><a href={`${base}/`}>← All datasets</a></p>
   <h1 class="ds-title">{dataset.name}</h1>
   <p class="ds-sub">
-    <span class="ds-sub__id">{dataset.id}</span> · {fmt(dataset.numCitations)} citations
+    <span class="ds-sub__id">{dataset.id}</span> · {fmt(dataset.numCitations)} high-confidence citations
+    {dataset.methodsExcluded > 0 && (
+      <span class="ds-sub__excl">· {fmt(dataset.methodsExcluded)} method/standards refs excluded</span>
+    )}
   </p>
 
   <ol class="cites" role="list">
     {dataset.citations.map((citation) => <CitationItem citation={citation} />)}
   </ol>
+
+  {
+    dataset.lowConfCitations.length > 0 && (
+      <details class="lowconf">
+        <summary>
+          {fmt(dataset.lowConfCitations.length)} lower-confidence citations (not counted)
+        </summary>
+        <ol class="cites" role="list">
+          {dataset.lowConfCitations.map((citation) => (
+            <CitationItem citation={citation} />
+          ))}
+        </ol>
+      </details>
+    )
+  }
 </Base>
 
 <style>
@@ -44,9 +62,27 @@ const base = import.meta.env.BASE_URL.replace(/\/$/, "");
   .ds-sub__id {
     font-family: var(--font-mono);
   }
+  .ds-sub__excl {
+    color: var(--color-fg-subtle);
+  }
   .cites {
     list-style: none;
     margin-top: var(--space-6);
     border-top: 1px solid var(--color-border);
+  }
+  .lowconf {
+    margin-top: var(--space-8);
+  }
+  .lowconf summary {
+    cursor: pointer;
+    font-weight: var(--fw-medium);
+    color: var(--color-fg-muted);
+    padding: var(--space-2) 0;
+  }
+  .lowconf summary:hover {
+    color: var(--color-fg);
+  }
+  .lowconf .cites {
+    margin-top: var(--space-2);
   }
 </style>

--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -23,11 +23,16 @@ const datasetLink = (id: string) => `${base}/dataset/${id}`;
     <StatCard value={fmt(overview.datasetCount)} label="Datasets tracked" />
     <StatCard
       value={fmt(overview.uniqueCitations)}
-      label="Unique citing papers"
-      hint={`${fmt(overview.totalCitations)} total attributions`}
+      label="High-confidence citing papers"
+      hint={`${fmt(overview.totalCitations)} attributions across datasets`}
     />
     <StatCard value={fmt(overview.datasetsWithCitations)} label="Datasets with citations" />
   </section>
+  <p class="stats-note">
+    Counts include only high-confidence citations and exclude BIDS / methods /
+    standards reference papers. {fmt(overview.lowConfidenceTotal)} lower-confidence
+    citations are kept and shown per dataset.
+  </p>
 
   <section class="browse">
     <h2>Most-cited datasets</h2>
@@ -60,6 +65,12 @@ const datasetLink = (id: string) => `${base}/dataset/${id}`;
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
     gap: var(--space-5);
+  }
+  .stats-note {
+    margin-top: var(--space-3);
+    max-width: var(--max-width-prose);
+    font-size: var(--fs-sm);
+    color: var(--color-fg-subtle);
   }
   .browse {
     margin-top: var(--space-12);

--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -26,7 +26,10 @@ const datasetLink = (id: string) => `${base}/dataset/${id}`;
       label="High-confidence citing papers"
       hint={`${fmt(overview.totalCitations)} attributions across datasets`}
     />
-    <StatCard value={fmt(overview.datasetsWithCitations)} label="Datasets with citations" />
+    <StatCard
+      value={fmt(overview.datasetsWithCitations)}
+      label="Datasets with high-confidence citations"
+    />
   </section>
   <p class="stats-note">
     Counts include only high-confidence citations and exclude BIDS / methods /


### PR DESCRIPTION
Closes #138. Per maintainer: report **only high-confidence** citations and **exclude BIDS/methods/umbrella anchor papers**; keep low-confidence visible in the per-dataset detail.

## Counting policy (web/src/lib/data.ts)
- **Methods/umbrella anchors** = a `source_doi` over-spread across > 5 datasets ∪ a curated BIDS/methods denylist (MNE-BIDS, EEG-BIDS, iEEG/MEG-BIDS, BIDS spec, fMRIPrep, MNE-Python, EEGLAB, FieldTrip, HBN). A citation pulled in via such an anchor is **not** a citation of the dataset → excluded.
- **Counted = high-confidence (score >= 0.4) AND not methods.** This is the headline.
- Low-confidence citations are kept (not counted) and shown per dataset.

## Result (vs the old 'all' count)
| | Old headline | New headline |
|---|---|---|
| Unique citing papers | 9,003 (all) | **5,990 (high-confidence, methods excluded)** |
| Low-confidence | (counted in 9,003) | 4,003, surfaced per dataset, not in headline |

## UI
- index: 'High-confidence citing papers' KPI + a note that BIDS/methods are excluded and N low-confidence are kept.
- dataset/[id]: counted citations + a '… method/standards refs excluded' note + a collapsible 'N lower-confidence citations (not counted)'.

## Verified
`bun run build` green (193 pages); `biome check` clean; `astro check` 0/0/0.

The over-spread+denylist heuristic is the build-local stand-in for anchor judgment on the un-judged ds-* datasets (#131); as those are judged, the methods exclusion becomes exact.