### PR TITLE
feat(web): Astro P5+P6 — themes + temporal views + nav

### DIFF
--- a/web/src/layouts/Base.astro
+++ b/web/src/layouts/Base.astro
@@ -9,6 +9,15 @@ interface Props {
 const { title, description = "Citation tracking for NEMAR and OpenNeuro neuroscience datasets." } =
   Astro.props;
 const homeUrl = "https://nemar.org";
+
+const base = import.meta.env.BASE_URL.replace(/\/$/, "");
+const here = Astro.url.pathname.replace(/\/$/, "");
+const navItems: Array<[string, string]> = [
+  ["Overview", `${base}`],
+  ["Maps", `${base}/maps`],
+  ["Themes", `${base}/themes`],
+  ["Trends", `${base}/trends`],
+];
 ---
 
 <!doctype html>
@@ -36,6 +45,15 @@ const homeUrl = "https://nemar.org";
     <header class="site-header">
       <div class="container site-header__inner">
         <a class="site-header__brand" href={homeUrl}>NEMAR <span>Citations</span></a>
+        <nav class="site-nav" aria-label="Dashboard sections">
+          {
+            navItems.map(([label, href]) => (
+              <a href={href} class="site-nav__link" aria-current={here === href ? "page" : undefined}>
+                {label}
+              </a>
+            ))
+          }
+        </nav>
         <button id="theme-toggle" type="button" aria-label="Toggle light/dark theme">◐</button>
       </div>
     </header>
@@ -100,6 +118,29 @@ const homeUrl = "https://nemar.org";
       }
       .site-header__brand span {
         color: var(--brand-teal);
+      }
+      .site-nav {
+        display: flex;
+        gap: var(--space-1);
+        margin-inline-start: auto;
+        margin-inline-end: var(--space-3);
+        flex-wrap: wrap;
+      }
+      .site-nav__link {
+        padding: var(--space-2) var(--space-3);
+        border-radius: var(--radius-md);
+        font-size: var(--fs-sm);
+        font-weight: var(--fw-medium);
+        color: var(--color-fg-muted);
+      }
+      .site-nav__link:hover {
+        background: var(--color-bg-subtle);
+        color: var(--color-fg);
+        text-decoration: none;
+      }
+      .site-nav__link[aria-current="page"] {
+        color: var(--brand-teal);
+        background: var(--color-bg-subtle);
       }
       #theme-toggle {
         font-size: var(--fs-xl);

--- a/web/src/lib/data.ts
+++ b/web/src/lib/data.ts
@@ -15,7 +15,9 @@
  * the per-dataset view can surface them ("also N low-confidence").
  */
 import { existsSync, readFileSync, readdirSync } from "node:fs";
-import { dirname, join } from "node:path";
+import { join } from "node:path";
+
+import { findRepoPath } from "./repo";
 
 const ALLOW_EMPTY = process.env.CITATIONS_ALLOW_EMPTY === "1";
 const EMPTY_HINT =
@@ -45,24 +47,8 @@ const METHODS_DENYLIST = new Set<string>([
   "10.1038/sdata.2017.40", // HBN resource (umbrella)
 ]);
 
-function findRepoDir(sub: string): string | null {
-  let dir = process.cwd();
-  for (let depth = 0; depth < 8; depth++) {
-    const candidate = join(dir, sub);
-    if (existsSync(candidate)) {
-      return candidate;
-    }
-    const parent = dirname(dir);
-    if (parent === dir) {
-      break;
-    }
-    dir = parent;
-  }
-  return null;
-}
-
-const citationsDir = findRepoDir(join("citations", "json_opencite"));
-const datasetsDir = findRepoDir("datasets");
+const citationsDir = findRepoPath(join("citations", "json_opencite"));
+const datasetsDir = findRepoPath("datasets");
 
 export interface Citation {
   title: string;

--- a/web/src/lib/maps.ts
+++ b/web/src/lib/maps.ts
@@ -6,8 +6,10 @@
  * Maps are an enhancement: a missing file degrades to an empty map, it does not
  * fail the build.
  */
-import { existsSync, readFileSync } from "node:fs";
-import { dirname, join } from "node:path";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { findRepoPath } from "./repo";
 
 export interface DatasetPoint {
   id: string;
@@ -29,25 +31,9 @@ export interface UmapPoints {
   citations: CitationPoint[];
 }
 
-function findFile(rel: string): string | null {
-  let dir = process.cwd();
-  for (let depth = 0; depth < 8; depth++) {
-    const candidate = join(dir, rel);
-    if (existsSync(candidate)) {
-      return candidate;
-    }
-    const parent = dirname(dir);
-    if (parent === dir) {
-      break;
-    }
-    dir = parent;
-  }
-  return null;
-}
-
 export function loadUmapPoints(): UmapPoints {
   const empty: UmapPoints = { datasets: [], citations: [] };
-  const path = findFile(join("dashboard_data", "umap_points.json"));
+  const path = findRepoPath(join("dashboard_data", "umap_points.json"));
   if (!path) {
     return empty;
   }

--- a/web/src/lib/repo.ts
+++ b/web/src/lib/repo.ts
@@ -1,0 +1,21 @@
+/** Walk up from the build working directory to find a repo-relative path.
+ * Shared by the build-time data loaders; `import.meta.url` is unreliable under
+ * Vite and the data lives outside the Astro project root (web/). */
+import { existsSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+export function findRepoPath(rel: string): string | null {
+  let dir = process.cwd();
+  for (let depth = 0; depth < 8; depth++) {
+    const candidate = join(dir, rel);
+    if (existsSync(candidate)) {
+      return candidate;
+    }
+    const parent = dirname(dir);
+    if (parent === dir) {
+      break;
+    }
+    dir = parent;
+  }
+  return null;
+}

--- a/web/src/lib/temporal.ts
+++ b/web/src/lib/temporal.ts
@@ -30,6 +30,10 @@ export function loadTemporal(): YearPoint[] {
     const ti = col("total_citations");
     const hi = col("high_confidence_citations");
     const di = col("unique_datasets");
+    if (yi < 0 || ti < 0) {
+      console.warn(`[temporal] CSV missing required columns; header=${header.join(",")}`);
+      return [];
+    }
 
     const rows = lines
       .slice(1)

--- a/web/src/lib/temporal.ts
+++ b/web/src/lib/temporal.ts
@@ -1,0 +1,59 @@
+/** Build-time loader for the temporal series (dashboard_data/temporal/
+ * temporal_summary.csv: year, total_citations, high_confidence_citations,
+ * unique_datasets). Returns rows sorted by year with a cumulative
+ * high-confidence total. Empty-safe. */
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { findRepoPath } from "./repo";
+
+export interface YearPoint {
+  year: number;
+  total: number;
+  highConf: number;
+  datasets: number;
+  cumulativeHighConf: number;
+}
+
+export function loadTemporal(): YearPoint[] {
+  const path = findRepoPath(join("dashboard_data", "temporal", "temporal_summary.csv"));
+  if (!path) {
+    return [];
+  }
+  try {
+    const lines = readFileSync(path, "utf-8").trim().split("\n");
+    if (lines.length < 2) {
+      return [];
+    }
+    const header = lines[0].split(",").map((h) => h.trim());
+    const col = (name: string) => header.indexOf(name);
+    const yi = col("year");
+    const ti = col("total_citations");
+    const hi = col("high_confidence_citations");
+    const di = col("unique_datasets");
+
+    const rows = lines
+      .slice(1)
+      .map((line) => {
+        const c = line.split(",");
+        return {
+          year: Number(c[yi]),
+          total: Number(c[ti]) || 0,
+          highConf: hi >= 0 ? Number(c[hi]) || 0 : 0,
+          datasets: di >= 0 ? Number(c[di]) || 0 : 0,
+        };
+      })
+      .filter((r) => Number.isFinite(r.year) && r.year > 0)
+      .sort((a, b) => a.year - b.year);
+
+    let cumulative = 0;
+    return rows.map((r) => {
+      cumulative += r.highConf;
+      return { ...r, cumulativeHighConf: cumulative };
+    });
+  } catch (err) {
+    console.warn(
+      `[temporal] failed to parse temporal CSV: ${err instanceof Error ? err.message : err}`,
+    );
+    return [];
+  }
+}

--- a/web/src/lib/themes.ts
+++ b/web/src/lib/themes.ts
@@ -1,0 +1,40 @@
+/** Build-time loader for research themes (dashboard_data/themes/
+ * comprehensive_theme_analysis.json). Empty-safe. */
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { findRepoPath } from "./repo";
+
+export interface Theme {
+  id: number;
+  name: string;
+  size: number;
+  topWords: string[];
+}
+
+interface RawTheme {
+  id?: number;
+  name?: string;
+  size?: number;
+  top_words?: string[];
+}
+
+export function loadThemes(): Theme[] {
+  const path = findRepoPath(join("dashboard_data", "themes", "comprehensive_theme_analysis.json"));
+  if (!path) {
+    return [];
+  }
+  try {
+    const data = JSON.parse(readFileSync(path, "utf-8")) as { themes?: RawTheme[] };
+    return (data.themes ?? []).map((t) => ({
+      id: t.id ?? 0,
+      name: t.name?.trim() || "Theme",
+      size: t.size ?? 0,
+      topWords: t.top_words ?? [],
+    }));
+  } catch (err) {
+    console.warn(
+      `[themes] failed to parse theme analysis: ${err instanceof Error ? err.message : err}`,
+    );
+    return [];
+  }
+}

--- a/web/src/pages/themes.astro
+++ b/web/src/pages/themes.astro
@@ -1,0 +1,83 @@
+---
+import Base from "../layouts/Base.astro";
+import { loadThemes } from "../lib/themes";
+
+const themes = loadThemes();
+const fmt = (n: number) => n.toLocaleString("en-US");
+---
+
+<Base title="Research themes — NEMAR Citations">
+  <h1>Research themes</h1>
+  <p class="sub">
+    Citing papers clustered by semantic similarity; each theme's most distinctive
+    terms are shown largest.
+  </p>
+
+  {
+    themes.length === 0 ? (
+      <p class="empty">No theme data available yet.</p>
+    ) : (
+      <div class="themes">
+        {themes.map((t) => (
+          <article class="theme">
+            <h2 class="theme__name">{t.name}</h2>
+            <p class="theme__size">{fmt(t.size)} citations</p>
+            <ul class="cloud" role="list">
+              {t.topWords.map((w, i) => (
+                <li style={`font-size: ${Math.max(0.8, 1.35 - i * 0.06)}rem`}>{w}</li>
+              ))}
+            </ul>
+          </article>
+        ))}
+      </div>
+    )
+  }
+</Base>
+
+<style>
+  .sub {
+    margin-top: var(--space-2);
+    max-width: var(--max-width-prose);
+    color: var(--color-fg-muted);
+  }
+  .empty {
+    margin-top: var(--space-8);
+    color: var(--color-fg-subtle);
+  }
+  .themes {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: var(--space-5);
+    margin-top: var(--space-6);
+  }
+  .theme {
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-lg);
+    padding: var(--space-5);
+    background: var(--color-bg-elevated);
+  }
+  .theme__name {
+    font-size: var(--fs-xl);
+  }
+  .theme__size {
+    margin-top: var(--space-1);
+    font-size: var(--fs-sm);
+    color: var(--brand-teal);
+    font-weight: var(--fw-semibold);
+  }
+  .cloud {
+    list-style: none;
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-2) var(--space-3);
+    margin-top: var(--space-4);
+    line-height: var(--lh-snug);
+  }
+  .cloud li {
+    color: var(--color-fg-muted);
+  }
+  .cloud li:first-child {
+    color: var(--color-fg);
+    font-weight: var(--fw-semibold);
+  }
+</style>

--- a/web/src/pages/trends.astro
+++ b/web/src/pages/trends.astro
@@ -1,0 +1,85 @@
+---
+import Base from "../layouts/Base.astro";
+import { loadTemporal } from "../lib/temporal";
+
+const points = loadTemporal();
+const fmt = (n: number) => n.toLocaleString("en-US");
+
+const W = 820;
+const H = 380;
+const PAD = 48;
+const years = points.map((p) => p.year);
+const minYear = years.length ? Math.min(...years) : 0;
+const maxYear = years.length ? Math.max(...years) : 1;
+const maxCum = points.length ? Math.max(...points.map((p) => p.cumulativeHighConf)) : 1;
+const sx = (yr: number) =>
+  PAD + (maxYear === minYear ? 0.5 : (yr - minYear) / (maxYear - minYear)) * (W - 2 * PAD);
+const sy = (c: number) => H - PAD - (maxCum === 0 ? 0 : c / maxCum) * (H - 2 * PAD);
+const linePath = points
+  .map((p, i) => `${i ? "L" : "M"}${sx(p.year).toFixed(1)},${sy(p.cumulativeHighConf).toFixed(1)}`)
+  .join(" ");
+const latest = points.length ? points[points.length - 1].cumulativeHighConf : 0;
+---
+
+<Base title="Citation trends — NEMAR Citations">
+  <h1>Citation growth</h1>
+  <p class="sub">
+    Cumulative high-confidence citations by year — {fmt(latest)} to date across tracked datasets.
+  </p>
+
+  {
+    points.length === 0 ? (
+      <p class="empty">No temporal data available yet.</p>
+    ) : (
+      <div class="chart">
+        <svg viewBox={`0 0 ${W} ${H}`} role="img" aria-label="Cumulative high-confidence citations by year">
+          <path d={linePath} class="line" />
+          {points.map((p) => (
+            <circle cx={sx(p.year)} cy={sy(p.cumulativeHighConf)} r="3" class="pt">
+              <title>{`${p.year}: ${fmt(p.cumulativeHighConf)} cumulative`}</title>
+            </circle>
+          ))}
+          <text x={sx(minYear)} y={H - 16} class="ax">{minYear}</text>
+          <text x={sx(maxYear)} y={H - 16} class="ax" text-anchor="end">{maxYear}</text>
+          <text x={PAD} y={sy(maxCum) - 6} class="ax">{fmt(maxCum)}</text>
+        </svg>
+      </div>
+    )
+  }
+</Base>
+
+<style>
+  .sub {
+    margin-top: var(--space-2);
+    max-width: var(--max-width-prose);
+    color: var(--color-fg-muted);
+  }
+  .empty {
+    margin-top: var(--space-8);
+    color: var(--color-fg-subtle);
+  }
+  .chart {
+    margin-top: var(--space-6);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-lg);
+    padding: var(--space-4);
+    background: var(--color-bg-elevated);
+  }
+  svg {
+    width: 100%;
+    height: auto;
+    display: block;
+  }
+  .line {
+    fill: none;
+    stroke: var(--brand-teal);
+    stroke-width: 2.5;
+  }
+  .pt {
+    fill: var(--brand-teal);
+  }
+  .ax {
+    fill: var(--color-fg-subtle);
+    font-size: 12px;
+  }
+</style>


### PR DESCRIPTION
Phases 5+6 of epic #127 (closes #142). Brings the Astro app to feature parity ahead of the cutover.

## What
- **Themes** (`/themes`): cards from `dashboard_data/themes/comprehensive_theme_analysis.json`, each theme's top terms as a CSS-sized tag cloud (text-based; drops the old PNG wordclouds).
- **Trends** (`/trends`): cumulative high-confidence citation growth from `dashboard_data/temporal/temporal_summary.csv` (the #117-fixed `high_confidence_citations` column) as a pure-SVG line with year/peak axis labels and per-point tooltips.
- **Nav** in Base: Overview / Maps / Themes / Trends with `aria-current` active state.
- Shared `lib/repo.ts` (`findRepoPath`) for the build-time loaders; both loaders are empty-safe with warn-on-parse-failure.

## Verified
`bun run build` green; themes renders 4 cards (Core EEG, …), trends renders the growth line, nav highlights the active page. `biome check` clean; `astro check` 0/0/0.

After this, the Astro app has overview + browse + per-dataset + maps + themes + trends — full parity. Next: **P8 cutover** (point deploy-dashboard.yml at the Astro build → fully live).