### PR TITLE
Astro polish: footer tagline + real theme wordclouds

### DIFF
--- a/web/.gitignore
+++ b/web/.gitignore
@@ -3,3 +3,6 @@ dist/
 .astro/
 .wrangler/
 .DS_Store
+
+# Generated at build by scripts/copy-theme-assets.mjs (source: dashboard_data/themes/)
+public/themes/

--- a/web/package.json
+++ b/web/package.json
@@ -12,7 +12,7 @@
     "build": "bun run copy-assets && astro build",
     "preview": "astro preview",
     "check": "astro check",
-    "lint": "biome check src",
+    "lint": "biome check src scripts",
     "format": "biome format --write src"
   },
   "dependencies": {

--- a/web/package.json
+++ b/web/package.json
@@ -7,8 +7,9 @@
     "node": ">=22.12.0"
   },
   "scripts": {
-    "dev": "astro dev",
-    "build": "astro build",
+    "copy-assets": "bun scripts/copy-theme-assets.mjs",
+    "dev": "bun run copy-assets && astro dev",
+    "build": "bun run copy-assets && astro build",
     "preview": "astro preview",
     "check": "astro check",
     "lint": "biome check src",

--- a/web/scripts/copy-theme-assets.mjs
+++ b/web/scripts/copy-theme-assets.mjs
@@ -2,11 +2,19 @@
 // dashboard_data/themes/ into web/public/themes/ so Astro serves them as static
 // assets. Run before `astro build` / `astro dev`. Idempotent; warns (does not
 // fail) if the source is absent so a code-only build still works.
+//
+// Paths are resolved from this file's own location (not process.cwd()) so the
+// destination is always web/public/themes/ regardless of where the script is
+// invoked from.
 import { copyFileSync, existsSync, mkdirSync, readdirSync } from "node:fs";
 import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const webRoot = dirname(scriptDir); // scripts/ -> web/
 
 function findRepoDir(rel) {
-  let dir = process.cwd();
+  let dir = webRoot;
   for (let depth = 0; depth < 8; depth++) {
     const candidate = join(dir, rel);
     if (existsSync(candidate)) {
@@ -22,7 +30,7 @@ function findRepoDir(rel) {
 }
 
 const src = findRepoDir(join("dashboard_data", "themes"));
-const dest = join(process.cwd(), "public", "themes");
+const dest = join(webRoot, "public", "themes");
 
 if (!src) {
   console.warn("[copy-theme-assets] dashboard_data/themes not found; skipping wordcloud copy.");

--- a/web/scripts/copy-theme-assets.mjs
+++ b/web/scripts/copy-theme-assets.mjs
@@ -1,0 +1,39 @@
+// Copy the Python-generated theme wordcloud PNGs from the repo's
+// dashboard_data/themes/ into web/public/themes/ so Astro serves them as static
+// assets. Run before `astro build` / `astro dev`. Idempotent; warns (does not
+// fail) if the source is absent so a code-only build still works.
+import { copyFileSync, existsSync, mkdirSync, readdirSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+function findRepoDir(rel) {
+  let dir = process.cwd();
+  for (let depth = 0; depth < 8; depth++) {
+    const candidate = join(dir, rel);
+    if (existsSync(candidate)) {
+      return candidate;
+    }
+    const parent = dirname(dir);
+    if (parent === dir) {
+      break;
+    }
+    dir = parent;
+  }
+  return null;
+}
+
+const src = findRepoDir(join("dashboard_data", "themes"));
+const dest = join(process.cwd(), "public", "themes");
+
+if (!src) {
+  console.warn("[copy-theme-assets] dashboard_data/themes not found; skipping wordcloud copy.");
+} else {
+  mkdirSync(dest, { recursive: true });
+  let n = 0;
+  for (const file of readdirSync(src)) {
+    if (file.endsWith(".png")) {
+      copyFileSync(join(src, file), join(dest, file));
+      n += 1;
+    }
+  }
+  console.log(`[copy-theme-assets] copied ${n} wordcloud PNG(s) to public/themes/`);
+}

--- a/web/src/layouts/Base.astro
+++ b/web/src/layouts/Base.astro
@@ -64,7 +64,7 @@ const navItems: Array<[string, string]> = [
 
     <footer class="site-footer">
       <div class="container">
-        NEMAR citation dashboard · data from OpenNeuro and NEMAR ·
+        NEMAR is an open-access data, tools, and compute resource for FAIR neuroscience ·
         <a href={homeUrl}>nemar.org</a>
       </div>
     </footer>

--- a/web/src/lib/themes.ts
+++ b/web/src/lib/themes.ts
@@ -1,7 +1,7 @@
 /** Build-time loader for research themes (dashboard_data/themes/
  * comprehensive_theme_analysis.json). Empty-safe. */
-import { readFileSync } from "node:fs";
-import { join } from "node:path";
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
 import { findRepoPath } from "./repo";
 
 export interface Theme {
@@ -9,6 +9,9 @@ export interface Theme {
   name: string;
   size: number;
   topWords: string[];
+  /** Public path to the matplotlib wordcloud PNG (copied into public/themes/
+   * by scripts/copy-theme-assets.mjs), or null when the source PNG is absent. */
+  wordcloud: string | null;
 }
 
 interface RawTheme {
@@ -23,14 +26,20 @@ export function loadThemes(): Theme[] {
   if (!path) {
     return [];
   }
+  const themesDir = dirname(path);
   try {
     const data = JSON.parse(readFileSync(path, "utf-8")) as { themes?: RawTheme[] };
-    return (data.themes ?? []).map((t) => ({
-      id: t.id ?? 0,
-      name: t.name?.trim() || "Theme",
-      size: t.size ?? 0,
-      topWords: t.top_words ?? [],
-    }));
+    return (data.themes ?? []).map((t) => {
+      const id = t.id ?? 0;
+      const png = `theme_${id}_wordcloud.png`;
+      return {
+        id,
+        name: t.name?.trim() || "Theme",
+        size: t.size ?? 0,
+        topWords: t.top_words ?? [],
+        wordcloud: existsSync(join(themesDir, png)) ? png : null,
+      };
+    });
   } catch (err) {
     console.warn(
       `[themes] failed to parse theme analysis: ${err instanceof Error ? err.message : err}`,

--- a/web/src/pages/themes.astro
+++ b/web/src/pages/themes.astro
@@ -1,10 +1,12 @@
 ---
 import Base from "../layouts/Base.astro";
-import { loadThemes } from "../lib/themes";
+import { type Theme, loadThemes } from "../lib/themes";
 
 const themes = loadThemes();
 const fmt = (n: number) => n.toLocaleString("en-US");
 const base = import.meta.env.BASE_URL.replace(/\/$/, "");
+const altText = (t: Theme) =>
+  `Word cloud for the ${t.name} theme. Most frequent terms: ${t.topWords.slice(0, 8).join(", ")}.`;
 ---
 
 <Base title="Research themes — NEMAR Citations">
@@ -26,7 +28,7 @@ const base = import.meta.env.BASE_URL.replace(/\/$/, "");
               <p class="theme__size">{fmt(t.size)} citations</p>
             </header>
             {t.wordcloud ? (
-              <figure class="theme__cloud-fig">
+              <div class="theme__cloud-fig">
                 <img
                   class="theme__cloud-img"
                   src={`${base}/themes/${t.wordcloud}`}
@@ -34,9 +36,9 @@ const base = import.meta.env.BASE_URL.replace(/\/$/, "");
                   height="400"
                   loading="lazy"
                   decoding="async"
-                  alt={`Word cloud for the ${t.name} theme. Most frequent terms: ${t.topWords.slice(0, 8).join(", ")}.`}
+                  alt={altText(t)}
                 />
-              </figure>
+              </div>
             ) : (
               <ul class="cloud" role="list">
                 {t.topWords.map((w, i) => (

--- a/web/src/pages/themes.astro
+++ b/web/src/pages/themes.astro
@@ -4,6 +4,7 @@ import { loadThemes } from "../lib/themes";
 
 const themes = loadThemes();
 const fmt = (n: number) => n.toLocaleString("en-US");
+const base = import.meta.env.BASE_URL.replace(/\/$/, "");
 ---
 
 <Base title="Research themes — NEMAR Citations">
@@ -20,13 +21,29 @@ const fmt = (n: number) => n.toLocaleString("en-US");
       <div class="themes">
         {themes.map((t) => (
           <article class="theme">
-            <h2 class="theme__name">{t.name}</h2>
-            <p class="theme__size">{fmt(t.size)} citations</p>
-            <ul class="cloud" role="list">
-              {t.topWords.map((w, i) => (
-                <li style={`font-size: ${Math.max(0.8, 1.35 - i * 0.06)}rem`}>{w}</li>
-              ))}
-            </ul>
+            <header class="theme__head">
+              <h2 class="theme__name">{t.name}</h2>
+              <p class="theme__size">{fmt(t.size)} citations</p>
+            </header>
+            {t.wordcloud ? (
+              <figure class="theme__cloud-fig">
+                <img
+                  class="theme__cloud-img"
+                  src={`${base}/themes/${t.wordcloud}`}
+                  width="800"
+                  height="400"
+                  loading="lazy"
+                  decoding="async"
+                  alt={`Word cloud for the ${t.name} theme. Most frequent terms: ${t.topWords.slice(0, 8).join(", ")}.`}
+                />
+              </figure>
+            ) : (
+              <ul class="cloud" role="list">
+                {t.topWords.map((w, i) => (
+                  <li style={`font-size: ${Math.max(0.8, 1.35 - i * 0.06)}rem`}>{w}</li>
+                ))}
+              </ul>
+            )}
           </article>
         ))}
       </div>
@@ -56,14 +73,32 @@ const fmt = (n: number) => n.toLocaleString("en-US");
     padding: var(--space-5);
     background: var(--color-bg-elevated);
   }
+  .theme__head {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: var(--space-3);
+  }
   .theme__name {
     font-size: var(--fs-xl);
   }
   .theme__size {
-    margin-top: var(--space-1);
+    flex: none;
     font-size: var(--fs-sm);
     color: var(--brand-teal);
     font-weight: var(--fw-semibold);
+    white-space: nowrap;
+  }
+  .theme__cloud-fig {
+    margin: var(--space-4) 0 0;
+  }
+  .theme__cloud-img {
+    display: block;
+    width: 100%;
+    height: auto;
+    border-radius: var(--radius-md);
+    border: 1px solid var(--color-border);
+    background: #fff;
   }
   .cloud {
     list-style: none;


### PR DESCRIPTION
Closes #146.

Two maintainer-reported polish items on the live dashboard.

## Footer tagline
Footer now reads **"NEMAR is an open-access data, tools, and compute resource for FAIR neuroscience"** instead of the previous data-source line.

## Real theme wordclouds
The Python theme pipeline already generates matplotlib wordcloud PNGs (`dashboard_data/themes/theme_N_wordcloud.png`), but the Astro themes page only rendered a CSS tag cloud. This surfaces the real images:

- `web/scripts/copy-theme-assets.mjs` copies the PNGs into `web/public/themes/` at build (chained into `dev`/`build` via the `copy-assets` script; runs with bun, warns-not-fails if the source is absent).
- `lib/themes.ts` resolves + existence-checks each theme's PNG and exposes a `wordcloud` field.
- `themes.astro` renders the image (with descriptive alt text from the top terms) and falls back to the text tag cloud when a PNG is missing.
- `web/public/themes/` is gitignored (generated from the committed `dashboard_data/themes/`).

## Verification
- [x] `bun run build` succeeds; `dist/themes/theme_0..3_wordcloud.png` present; footer string in `dist/index.html`
- [x] `bun run lint` (biome) clean
- [x] `bun run check` (astro/types) 0 errors

This is the first of several follow-ups addressing the dashboard feature-parity feedback (interactive maps, multi-chart trends, and a cites-dataset-vs-data-paper flag are separate PRs).
