### PR TITLE
Per-citation flag: cites dataset vs cites data paper

### DIFF
--- a/web/src/components/CitationItem.astro
+++ b/web/src/components/CitationItem.astro
@@ -11,7 +11,11 @@ const meta = [citation.authors, citation.year ? String(citation.year) : "", cita
   .filter((part) => part)
   .join(" · ");
 const prov = citation.provenance;
-const provTitle = prov.anchorTitle ? `Found via: ${prov.anchorTitle}` : prov.label;
+const provTitle = prov.anchorTitle
+  ? `Found via: ${prov.anchorTitle}`
+  : prov.kind === "dataset"
+    ? "This paper cited the dataset DOI directly"
+    : prov.label;
 ---
 
 <li class="cite">

--- a/web/src/components/CitationItem.astro
+++ b/web/src/components/CitationItem.astro
@@ -10,6 +10,8 @@ const href = citation.url || (citation.doi ? `https://doi.org/${citation.doi}` :
 const meta = [citation.authors, citation.year ? String(citation.year) : "", citation.venue]
   .filter((part) => part)
   .join(" · ");
+const prov = citation.provenance;
+const provTitle = prov.anchorTitle ? `Found via: ${prov.anchorTitle}` : prov.label;
 ---
 
 <li class="cite">
@@ -23,11 +25,12 @@ const meta = [citation.authors, citation.year ? String(citation.year) : "", cita
     )
   }
   {meta && <p class="cite__meta">{meta}</p>}
-  {
-    citation.citedBy > 0 && (
+  <p class="cite__tags">
+    <span class={`cite__flag cite__flag--${prov.kind}`} title={provTitle}>{prov.label}</span>
+    {citation.citedBy > 0 && (
       <span class="cite__by">{citation.citedBy.toLocaleString("en-US")} citations</span>
-    )
-  }
+    )}
+  </p>
 </li>
 
 <style>
@@ -47,9 +50,35 @@ const meta = [citation.authors, citation.year ? String(citation.year) : "", cita
     font-size: var(--fs-sm);
     color: var(--color-fg-muted);
   }
-  .cite__by {
+  .cite__tags {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: var(--space-2) var(--space-3);
+    margin-top: var(--space-2);
+  }
+  .cite__flag {
     display: inline-block;
-    margin-top: var(--space-1);
+    font-size: var(--fs-xs);
+    font-weight: var(--fw-medium);
+    padding: 2px var(--space-2);
+    border-radius: var(--radius-sm, 4px);
+    border: 1px solid transparent;
+    cursor: help;
+  }
+  /* Cites a publication (data paper): the common case today. */
+  .cite__flag--paper {
+    color: var(--color-fg-muted);
+    background: var(--color-bg-subtle);
+    border-color: var(--color-border);
+  }
+  /* Cites the dataset's own DOI: highlighted (rare today, grows over time). */
+  .cite__flag--dataset {
+    color: var(--brand-teal);
+    background: color-mix(in srgb, var(--brand-teal) 12%, transparent);
+    border-color: color-mix(in srgb, var(--brand-teal) 35%, transparent);
+  }
+  .cite__by {
     font-size: var(--fs-xs);
     color: var(--color-fg-subtle);
   }

--- a/web/src/lib/data.ts
+++ b/web/src/lib/data.ts
@@ -49,6 +49,26 @@ const METHODS_DENYLIST = new Set<string>([
 
 const citationsDir = findRepoPath(join("citations", "json_opencite"));
 const datasetsDir = findRepoPath("datasets");
+const anchorJudgmentsDir = findRepoPath(join("citations", "anchor_judgments"));
+
+// OpenNeuro / NEMAR dataset DOIs (the dataset's own record, not a publication).
+// Citations whose source anchor matches this are "cites dataset"; everything
+// else is a publication ("cites data paper"). ~0 today; grows as the managed
+// mirror gives datasets robust DOIs that accrue direct citations.
+const DATASET_DOI_RE = /^10\.18112\/openneuro/;
+
+/** Where a citation was found: did the citing paper cite the dataset's own DOI,
+ * or a publication (data paper) describing it? Derived by joining the citation's
+ * source anchor DOI against the anchor-judgment sidecars. */
+export interface CitationProvenance {
+  /** "dataset" = source anchor is the dataset's own OpenNeuro/NEMAR DOI;
+   * "paper" = source anchor is a publication. */
+  kind: "dataset" | "paper";
+  /** Badge text, e.g. "Cites dataset" / "Cites data paper" / "Cites paper". */
+  label: string;
+  /** Title of the cited anchor paper (provenance), when known from the sidecar. */
+  anchorTitle: string | null;
+}
 
 export interface Citation {
   title: string;
@@ -59,6 +79,7 @@ export interface Citation {
   doi: string | null;
   citedBy: number;
   confidence: number | null;
+  provenance: CitationProvenance;
 }
 
 export interface DatasetDetail {
@@ -120,9 +141,13 @@ interface RawCitation {
   pmid?: string | null;
   openalex_id?: string | null;
   source_doi?: string | null;
+  source_relation?: string | null;
   cited_by?: number | null;
   confidence_scoring?: { confidence_score?: number | null } | null;
 }
+
+/** anchor DOI (normalized) -> its judged classification + paper title. */
+type AnchorMap = Map<string, { classification: string; title: string | null }>;
 
 interface RawEntry {
   id: string;
@@ -156,7 +181,19 @@ function isHighConf(c: RawCitation): boolean {
   return typeof conf === "number" && conf >= HIGH_CONF;
 }
 
-function toCitation(c: RawCitation): Citation {
+/** Classify where a citation was found from its source anchor DOI + the
+ * dataset's anchor-judgment sidecar. */
+function provenanceOf(c: RawCitation, anchors: AnchorMap): CitationProvenance {
+  const sd = c.source_doi ? normalizeDoi(c.source_doi) : null;
+  if (sd && DATASET_DOI_RE.test(sd)) {
+    return { kind: "dataset", label: "Cites dataset", anchorTitle: null };
+  }
+  const info = sd ? anchors.get(sd) : undefined;
+  const label = info?.classification === "data_paper" ? "Cites data paper" : "Cites paper";
+  return { kind: "paper", label, anchorTitle: info?.title ?? null };
+}
+
+function toCitation(c: RawCitation, anchors: AnchorMap): Citation {
   return {
     title: c.title?.trim() || "Untitled",
     authors: c.author?.trim() || "",
@@ -166,7 +203,43 @@ function toCitation(c: RawCitation): Citation {
     doi: c.doi?.trim() || null,
     citedBy: typeof c.cited_by === "number" ? c.cited_by : 0,
     confidence: c.confidence_scoring?.confidence_score ?? null,
+    provenance: provenanceOf(c, anchors),
   };
+}
+
+/** Read a dataset's anchor-judgment sidecar into a DOI -> {classification,title}
+ * map. Returns an empty map when the sidecar is missing or unreadable. */
+function readAnchorMap(id: string): AnchorMap {
+  const map: AnchorMap = new Map();
+  if (!anchorJudgmentsDir) {
+    return map;
+  }
+  const path = join(anchorJudgmentsDir, `${id}.json`);
+  if (!existsSync(path)) {
+    return map;
+  }
+  try {
+    const data = JSON.parse(readFileSync(path, "utf-8")) as {
+      judgments?: Array<{
+        anchor_identifier?: string | null;
+        classification?: string | null;
+        paper_title?: string | null;
+      }>;
+    };
+    for (const j of data.judgments ?? []) {
+      if (j.anchor_identifier) {
+        map.set(normalizeDoi(j.anchor_identifier), {
+          classification: j.classification ?? "",
+          title: j.paper_title?.trim() || null,
+        });
+      }
+    }
+  } catch (err) {
+    console.warn(
+      `[data] skipping anchor sidecar ${id}: ${err instanceof Error ? err.message : err}`,
+    );
+  }
+  return map;
 }
 
 function readDatasetName(id: string): string {
@@ -283,6 +356,7 @@ export function loadAll(): LoadedData {
     const counted: Citation[] = [];
     const lowConf: Citation[] = [];
     let methodsExcluded = 0;
+    const anchors = readAnchorMap(id);
 
     for (const c of details) {
       if (isMethodsCitation(c, methods)) {
@@ -290,7 +364,7 @@ export function loadAll(): LoadedData {
         continue;
       }
       if (isHighConf(c)) {
-        const cit = toCitation(c);
+        const cit = toCitation(c, anchors);
         counted.push(cit);
         const key = citingKey(c);
         if (!uniqueHighConf.has(key)) {
@@ -298,7 +372,7 @@ export function loadAll(): LoadedData {
           firstYearByKey.set(key, cit.year);
         }
       } else {
-        lowConf.push(toCitation(c));
+        lowConf.push(toCitation(c, anchors));
       }
     }
 

--- a/web/src/lib/data.ts
+++ b/web/src/lib/data.ts
@@ -51,11 +51,14 @@ const citationsDir = findRepoPath(join("citations", "json_opencite"));
 const datasetsDir = findRepoPath("datasets");
 const anchorJudgmentsDir = findRepoPath(join("citations", "anchor_judgments"));
 
-// OpenNeuro / NEMAR dataset DOIs (the dataset's own record, not a publication).
-// Citations whose source anchor matches this are "cites dataset"; everything
-// else is a publication ("cites data paper"). ~0 today; grows as the managed
-// mirror gives datasets robust DOIs that accrue direct citations.
-const DATASET_DOI_RE = /^10\.18112\/openneuro/;
+// OpenNeuro dataset DOIs (10.18112/openneuro.*), the dataset's own record rather
+// than a publication. The trailing dot matches the canonical Python detector
+// (src/dataset_citations/sources/doi.py) and avoids matching other registrants
+// under the same prefix. NEMAR nm-* DOIs use a different prefix (TBD); extend
+// this once it is confirmed. Citations whose source anchor matches this are
+// "cites dataset"; everything else is a publication. ~0 today; grows as the
+// managed mirror gives datasets robust DOIs that accrue direct citations.
+const DATASET_DOI_RE = /^10\.18112\/openneuro\./;
 
 /** Where a citation was found: did the citing paper cite the dataset's own DOI,
  * or a publication (data paper) describing it? Derived by joining the citation's

--- a/web/src/pages/dataset/[id].astro
+++ b/web/src/pages/dataset/[id].astro
@@ -17,7 +17,7 @@ const fmt = (n: number) => n.toLocaleString("en-US");
 const base = import.meta.env.BASE_URL.replace(/\/$/, "");
 ---
 
-<Base title={`${dataset.name} — citations`}>
+<Base title={`${dataset.name} · citations`}>
   <p class="back"><a href={`${base}/`}>← All datasets</a></p>
   <h1 class="ds-title">{dataset.name}</h1>
   <p class="ds-sub">


### PR DESCRIPTION
Closes #152.

Adds the missing per-citation provenance flag on the dataset page.

## Data reality (informs the design)
Across the 5,990 counted citations, ~all arrive through a `data_paper` anchor (5,372 data_paper + related_work); **zero** through a dataset's own DOI today (the corpus was built from data-paper anchors; OpenNeuro/NEMAR dataset DOIs yielded ~0 citations in OpenAlex/S2/PubMed). So the flag reads "Cites data paper" on ~all rows now; the "Cites dataset" side activates automatically as the managed mirror gives datasets robust DOIs that accrue direct citations.

## What changed
- **`lib/data.ts`**: join each citation's `source_doi` against the complete `citations/anchor_judgments/<id>.json` sidecars. Per-citation `provenance`: `kind` = `dataset` (source anchor is an OpenNeuro/NEMAR dataset DOI) else `paper`; `label` = "Cites data paper" when the anchor is judged `data_paper`, else "Cites paper"; `anchorTitle` = the cited paper's title.
- **`CitationItem.astro`**: small badge per row, with the cited paper's title as a `Found via: ...` tooltip; the `Cites dataset` case is visually highlighted.
- Removed the dataset page-title em-dash.

## Verification (Puppeteer, 1920x1080)
- [x] Badge renders on every citation; tooltip shows the actual data-paper title
- [x] Label distribution across all pages: 8,882 "Cites data paper", 2,724 "Cites paper", 0 "Cites dataset" (as expected today)
- [x] `bun run build` / `lint` / `check` (0 errors)
