### PR TITLE
ci: bump actions to node24 runtime

### DIFF
--- a/.github/workflows/deploy-dashboard.yml
+++ b/.github/workflows/deploy-dashboard.yml
@@ -27,7 +27,7 @@ jobs:
     name: Build and deploy dashboard
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up bun
         uses: oven-sh/setup-bun@v2
@@ -61,7 +61,7 @@ jobs:
           cp -r web/dist/. deploy/citations/
 
       - name: Deploy to Cloudflare Pages
-        uses: cloudflare/wrangler-action@v3
+        uses: cloudflare/wrangler-action@v4
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,10 +17,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
 
@@ -45,10 +45,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
           cache-dependency-glob: "pyproject.toml"
@@ -81,9 +81,9 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: matrix.python-version == '3.13'
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         with:
-          file: ./coverage.xml
+          files: ./coverage.xml
           flags: unittests
           name: codecov-umbrella
           fail_ci_if_error: false
@@ -95,10 +95,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
 
@@ -156,10 +156,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
 
@@ -181,7 +181,7 @@ jobs:
 
       - name: Upload test artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: test-outputs
           path: |
@@ -194,7 +194,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Run Trivy security scan
         uses: aquasecurity/trivy-action@master
@@ -206,7 +206,7 @@ jobs:
           severity: 'HIGH,CRITICAL'
 
       - name: Upload Trivy results
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         if: always()
         with:
           sarif_file: 'trivy-results.sarif'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -83,6 +83,10 @@ jobs:
         if: matrix.python-version == '3.13'
         uses: codecov/codecov-action@v5
         with:
+          # codecov v5 dropped tokenless uploads; without CODECOV_TOKEN the
+          # upload silently no-ops (fail_ci_if_error stays false so CI is not
+          # blocked). Add the CODECOV_TOKEN repo secret to restore delivery.
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.xml
           flags: unittests
           name: codecov-umbrella


### PR DESCRIPTION
Closes #155

## Summary

- actions/checkout@v4 (node20) -> @v5 (node24)
- astral-sh/setup-uv@v3 (node20) -> @v7 (node24; v4/v5/v6 all still node20)
- codecov/codecov-action@v4 (node20) -> @v5 (composite; no node dependency)
- actions/upload-artifact@v4 (node20) -> @v6 (node24)
- cloudflare/wrangler-action@v3 (node20) -> @v4 (node24)
- github/codeql-action/upload-sarif@v3 (node20) -> @v4 (node24)
- Also renames the codecov input `file` -> `files` (breaking rename in v5; caught by actionlint)

## Not changed

- oven-sh/setup-bun@v2 - already declares node24; no change needed
- aquasecurity/trivy-action@master - composite runner; not affected by node version deprecation

## Verification

Each bumped action verified by fetching its published `action.yml` `runs.using` field via `gh api repos/<owner>/<repo>/contents/action.yml?ref=<tag>`. Results:

| Action | Old | New | runs.using |
|---|---|---|---|
| actions/checkout | v4 | v5 | node24 |
| astral-sh/setup-uv | v3 | v7 | node24 |
| codecov/codecov-action | v4 | v5 | composite |
| actions/upload-artifact | v4 | v6 | node24 |
| cloudflare/wrangler-action | v3 | v4 | node24 |
| github/codeql-action/upload-sarif | v3 | v4 | node24 |

actionlint run (after fixing the codecov input rename): no errors.

## Test plan

- [x] actionlint passes with zero findings on both workflow files
- [x] Each action's `action.yml` `runs.using` confirmed node24 via gh api
- [ ] CI green on this PR (automated)