### PR TITLE
Redirect removed /trends to the overview

### DIFF
--- a/web/astro.config.mjs
+++ b/web/astro.config.mjs
@@ -10,4 +10,11 @@ export default defineConfig({
   base: "/citations",
   output: "static",
   trailingSlash: "ignore",
+  // /trends was folded into the overview (#159); keep the previously-public URL
+  // working by redirecting old links to the overview instead of 404ing.
+  // Destination is an absolute path (base is not auto-prepended), so target
+  // /citations/ explicitly.
+  redirects: {
+    "/trends": "/citations/",
+  },
 });


### PR DESCRIPTION
Closes #160.

`/trends` was folded into the overview (#159); the origin now 404s for it. This adds an Astro `redirects` entry so the previously-public `/trends` URL redirects to `/citations/` (the overview) instead of 404ing for old bookmarks/search-engine links.

- Astro does not prepend `base` to the redirect destination, so the target is the explicit absolute `/citations/` (verified: built `dist/trends/index.html` has `url=/citations/`; local preview confirms).

## Caveat (separate from this PR)
A stale Cloudflare edge copy of the OLD `/trends` (cached under an old 7-day `s-maxage`) will keep serving the old content until the cache TTL expires or the zone cache is purged. The origin is already correct (cache-busted `/trends` returns 404, and after this lands, the redirect). An instant fix needs a Cloudflare "Purge Everything" on the nemar.org zone.

## Verification
- [x] `bun run build` -> `dist/trends/index.html` redirects to `/citations/`
- [x] `bun run lint` / `check` clean; local preview redirect confirmed
