### PR TITLE
fix: rewrite citation JSON only on real change (#165)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,11 @@ logs/
 # Per-anchor opencite checkpoints (transient resume state for citation fetches)
 citations/.checkpoints/
 
+# Per-dataset last-fetched cache for the update freshness gate (issue #165).
+# Kept out of git so the gate has a timestamp that advances every run without
+# churning the committed citation JSON diffs.
+citations/.fetch_state.json
+
 # Analysis results are now included for sharing and reproducibility
 # (Note: Results can be regenerated using CLI commands documented in README files)
 

--- a/src/dataset_citations/cli/update.py
+++ b/src/dataset_citations/cli/update.py
@@ -21,6 +21,7 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 from dataset_citations.backends import OpenCiteBackend
+from dataset_citations.core.citation_utils import strip_volatile_timestamps
 from dataset_citations.core.opencite_pipeline import (
     fetch_dataset_citations_via_opencite,
 )
@@ -34,41 +35,85 @@ logging.basicConfig(
 logger = logging.getLogger(__name__)
 
 
-def _is_fresh_success(filepath: str, max_age_seconds: int) -> bool:
-    """Return True if `filepath` is a successful, recent citation JSON.
+# Statuses that indicate a genuine API failure rather than a stable outcome.
+# A file carrying one of these should be re-fetched on the next run (retry);
+# any other status (success, partial, no_doi_references, no_data_paper_anchor,
+# unsupported_prefix:*) is stable and safe to skip within the freshness window.
+_API_FAILURE_STATUSES = frozenset(
+    {"rate_limit", "auth", "network", "not_found", "parse", "other"}
+)
 
-    Used by run_opencite_backend to skip datasets that were already
-    successfully fetched within the freshness window (typically the
-    weekly cron cadence). A JSON that doesn't parse, doesn't have a
-    success fetch_status, or has a stale date_last_updated triggers
-    a re-fetch.
+# Per-output-dir cache of the last time each dataset was fetched. Kept OUT of
+# the committed citation JSON (and gitignored) so the freshness gate has a
+# timestamp that advances every run without churning the diff. `date_last_updated`
+# inside the citation JSON now means "last content change" (issue #165), so it
+# can no longer double as the freshness signal.
+_FETCH_STATE_FILENAME = ".fetch_state.json"
 
-    Robust against missing fields and unparseable timestamps: any
-    failure to determine freshness returns False (refetch).
-    """
+
+def _read_json_or_none(filepath: str) -> dict | None:
+    """Load JSON from `filepath`, returning None on any read/parse failure."""
     if not os.path.isfile(filepath):
-        return False
+        return None
     try:
         with open(filepath, encoding="utf-8") as f:
-            payload = json.load(f)
+            data = json.load(f)
     except (OSError, json.JSONDecodeError):
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def _has_stable_status(filepath: str) -> bool:
+    """Return True if the on-disk citation JSON has a non-transient status.
+
+    A missing/unparseable file, or one whose `metadata.fetch_status` is a
+    transient API failure, returns False so the dataset is re-fetched.
+    """
+    payload = _read_json_or_none(filepath)
+    if payload is None:
         return False
     metadata = payload.get("metadata")
     if not isinstance(metadata, dict):
         return False
-    if metadata.get("fetch_status") != "success":
-        return False
-    raw_date = payload.get("date_last_updated")
-    if not isinstance(raw_date, str):
+    status = metadata.get("fetch_status")
+    return isinstance(status, str) and status not in _API_FAILURE_STATUSES
+
+
+def _checked_within(
+    dataset_id: str, fetch_state: dict[str, str], max_age_seconds: int
+) -> bool:
+    """Return True if `dataset_id` was fetched within `max_age_seconds`.
+
+    Reads the last-checked timestamp from the fetch-state cache. Any missing
+    entry or unparseable timestamp returns False (re-fetch).
+    """
+    raw = fetch_state.get(dataset_id)
+    if not isinstance(raw, str):
         return False
     try:
-        fetched_at = datetime.fromisoformat(raw_date)
+        checked_at = datetime.fromisoformat(raw)
     except ValueError:
         return False
-    if fetched_at.tzinfo is None:
-        fetched_at = fetched_at.replace(tzinfo=timezone.utc)
-    age = datetime.now(timezone.utc) - fetched_at
-    return age <= timedelta(seconds=max_age_seconds)
+    if checked_at.tzinfo is None:
+        checked_at = checked_at.replace(tzinfo=timezone.utc)
+    return datetime.now(timezone.utc) - checked_at <= timedelta(seconds=max_age_seconds)
+
+
+def _load_fetch_state(path: str) -> dict[str, str]:
+    """Load the {dataset_id: last_checked_iso} cache; empty dict if absent."""
+    data = _read_json_or_none(path)
+    if data is None:
+        return {}
+    return {k: v for k, v in data.items() if isinstance(v, str)}
+
+
+def _save_fetch_state(path: str, state: dict[str, str]) -> None:
+    """Persist the fetch-state cache. Best-effort: log and continue on failure."""
+    try:
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(state, f, indent=2, sort_keys=True)
+    except OSError as e:
+        logger.warning("Could not write fetch-state cache %s: %s", path, e)
 
 
 def _load_catalog_doi_map(
@@ -145,29 +190,31 @@ def run_opencite_backend(args: argparse.Namespace) -> None:
         len(catalog_dois),
     )
 
-    # Statuses that indicate a genuine API failure rather than legitimately
-    # absent DOIs. If every dataset stubs out with one of these, we should
-    # exit non-zero so automation (cron / CI) can detect a fully-degraded
-    # run instead of silently producing a PR full of empty JSONs.
-    api_failure_statuses = {
-        "rate_limit",
-        "auth",
-        "network",
-        "not_found",
-        "parse",
-        "other",
-    }
+    # A run where every processed dataset stubs out with an _API_FAILURE_STATUSES
+    # value (and nothing was written) exits non-zero below, so automation can
+    # detect a fully-degraded run instead of silently shipping empty JSONs.
     max_age_seconds = args.max_age_days * 86400 if args.max_age_days > 0 else None
+    fetch_state_path = os.path.join(args.output_dir, _FETCH_STATE_FILENAME)
+    fetch_state = _load_fetch_state(fetch_state_path)
     successes = 0
     stub_only = 0
     write_failures = 0
     api_failures = 0
     skipped_fresh = 0
+    unchanged = 0
     for dataset_id in dataset_ids:
         filepath = os.path.join(json_dir, f"{dataset_id}_citations.json")
-        if max_age_seconds is not None and _is_fresh_success(filepath, max_age_seconds):
+        # Freshness gate: skip a re-fetch when the on-disk result is stable
+        # (not a transient API failure) AND we checked it within the window.
+        # The last-checked signal comes from the gitignored fetch-state cache,
+        # NOT date_last_updated, which now only advances on real content change.
+        if (
+            max_age_seconds is not None
+            and _has_stable_status(filepath)
+            and _checked_within(dataset_id, fetch_state, max_age_seconds)
+        ):
             logger.info(
-                "%s: skipping (existing JSON is fresh-success within %d days)",
+                "%s: skipping (checked within %d days, stable status)",
                 dataset_id,
                 args.max_age_days,
             )
@@ -179,29 +226,51 @@ def run_opencite_backend(args: argparse.Namespace) -> None:
             catalog_doi=catalog_dois.get(dataset_id),
             use_checkpoint=True,
         )
-        try:
-            with open(filepath, "w", encoding="utf-8") as f:
-                json.dump(payload, f, indent=2, ensure_ascii=False)
-        except OSError as e:
-            logger.error("Failed to write %s: %s", filepath, e)
-            write_failures += 1
-            continue
+        # Content-idempotent write. The opencite payload never carries the
+        # confidence_scoring block (the separate score step adds it), so we
+        # carry the existing block onto a comparison copy to avoid a spurious
+        # "changed" verdict every run. When nothing changed, leave the file
+        # (and its scores + timestamps) byte-for-byte untouched. When citations
+        # DID change, write the fresh payload WITHOUT the now-stale scores so
+        # the score step re-scores it (its --skip-existing skips files that
+        # already have confidence_scoring). See issue #165.
+        existing = _read_json_or_none(filepath)
+        compare = payload
+        if existing is not None and "confidence_scoring" in existing:
+            compare = {**payload, "confidence_scoring": existing["confidence_scoring"]}
+        if existing is not None and strip_volatile_timestamps(
+            existing
+        ) == strip_volatile_timestamps(compare):
+            unchanged += 1
+        else:
+            try:
+                with open(filepath, "w", encoding="utf-8") as f:
+                    json.dump(payload, f, indent=2, ensure_ascii=False)
+            except OSError as e:
+                logger.error("Failed to write %s: %s", filepath, e)
+                write_failures += 1
+                continue
+        # Record the fetch attempt so the freshness gate can skip it next run.
+        fetch_state[dataset_id] = datetime.now(timezone.utc).isoformat()
         if payload["num_citations"] > 0:
             successes += 1
         else:
             stub_only += 1
             status = payload.get("metadata", {}).get("fetch_status", "empty")
-            if status in api_failure_statuses:
+            if status in _API_FAILURE_STATUSES:
                 api_failures += 1
             logger.info("%s: 0 citations (status=%s)", dataset_id, status)
 
+    _save_fetch_state(fetch_state_path, fetch_state)
     logger.info(
         "opencite run complete: %d with citations, %d empty/stub "
-        "(%d API-failure), %d write failures, %d skipped (fresh), %d total.",
+        "(%d API-failure), %d write failures, %d unchanged, %d skipped (fresh), "
+        "%d total.",
         successes,
         stub_only,
         api_failures,
         write_failures,
+        unchanged,
         skipped_fresh,
         len(dataset_ids),
     )

--- a/src/dataset_citations/cli/update.py
+++ b/src/dataset_citations/cli/update.py
@@ -52,13 +52,21 @@ _FETCH_STATE_FILENAME = ".fetch_state.json"
 
 
 def _read_json_or_none(filepath: str) -> dict | None:
-    """Load JSON from `filepath`, returning None on any read/parse failure."""
+    """Load JSON from `filepath`, returning None on any read/parse failure.
+
+    A missing file returns None silently (an expected case for both new
+    datasets and an absent fetch-state cache). A file that EXISTS but cannot
+    be read/parsed is logged at WARNING: a corrupt citation JSON would
+    otherwise be silently treated as absent and re-fetched every run with no
+    trace in the cron log.
+    """
     if not os.path.isfile(filepath):
         return None
     try:
         with open(filepath, encoding="utf-8") as f:
             data = json.load(f)
-    except (OSError, json.JSONDecodeError):
+    except (OSError, json.JSONDecodeError) as e:
+        logger.warning("Could not read %s (%s); treating as absent", filepath, e)
         return None
     return data if isinstance(data, dict) else None
 
@@ -104,16 +112,28 @@ def _load_fetch_state(path: str) -> dict[str, str]:
     data = _read_json_or_none(path)
     if data is None:
         return {}
-    return {k: v for k, v in data.items() if isinstance(v, str)}
+    valid = {k: v for k, v in data.items() if isinstance(v, str)}
+    dropped = len(data) - len(valid)
+    if dropped:
+        logger.warning(
+            "fetch-state %s: dropped %d entries with non-string values", path, dropped
+        )
+    return valid
 
 
 def _save_fetch_state(path: str, state: dict[str, str]) -> None:
-    """Persist the fetch-state cache. Best-effort: log and continue on failure."""
+    """Persist the fetch-state cache. Best-effort: log and continue on failure.
+
+    Logged at ERROR (not WARNING): a failed save means the next run starts
+    from a cold cache and re-fetches every dataset, and the same disk/perms
+    condition likely failed the citation writes too, so this should be
+    visible in the cron log.
+    """
     try:
         with open(path, "w", encoding="utf-8") as f:
             json.dump(state, f, indent=2, sort_keys=True)
     except OSError as e:
-        logger.warning("Could not write fetch-state cache %s: %s", path, e)
+        logger.error("Could not write fetch-state cache %s: %s", path, e)
 
 
 def _load_catalog_doi_map(
@@ -331,10 +351,11 @@ def main():
         type=int,
         default=7,
         help=(
-            "Skip datasets whose existing JSON has fetch_status=success and "
-            "date_last_updated within this many days (default: 7, matching "
-            "the weekly cron cadence). Set to 0 to force re-fetch every "
-            "dataset on every invocation."
+            "Skip a re-fetch when the existing JSON has a stable (non-transient) "
+            "fetch_status AND the dataset was last fetched within this many days, "
+            "per the gitignored .fetch_state.json cache (default: 7, matching the "
+            "weekly cron cadence). Set to 0 to force re-fetch every dataset on "
+            "every invocation."
         ),
     )
 

--- a/src/dataset_citations/core/citation_utils.py
+++ b/src/dataset_citations/core/citation_utils.py
@@ -13,6 +13,7 @@ GitHub: https://github.com/neuromechanist
 Email: shirazi@ieee.org
 """
 
+import copy
 import json
 import logging
 import os
@@ -25,6 +26,37 @@ logger = logging.getLogger(__name__)
 
 DiscoveryBackend = Literal["scholarly", "opencite"]
 SCHEMA_VERSION_V2 = "2.0"
+
+# Timestamp fields that advance on every pipeline run regardless of whether the
+# citation content changed. They are excluded from content-equality checks so a
+# re-fetch / re-score that produced identical data does not rewrite the file and
+# churn the nightly git diff (issue #165).
+_VOLATILE_TIMESTAMP_PATHS: tuple[tuple[str, ...], ...] = (
+    ("date_last_updated",),
+    ("metadata", "fetch_date"),
+    ("confidence_scoring", "scoring_date"),
+)
+
+
+def strip_volatile_timestamps(payload: Dict[str, Any]) -> Dict[str, Any]:
+    """Return a deep copy of ``payload`` with per-run timestamp fields removed.
+
+    The result is only ever used to compare two citation payloads for
+    substantive equality; it is never written to disk. Removing
+    ``date_last_updated``, ``metadata.fetch_date`` and
+    ``confidence_scoring.scoring_date`` lets the update step detect when a
+    re-fetch produced identical content and leave the file (and its timestamps)
+    untouched, so ``date_last_updated`` advances only on a real change
+    (issue #165).
+    """
+    clone = copy.deepcopy(payload)
+    for *parents, leaf in _VOLATILE_TIMESTAMP_PATHS:
+        node: Any = clone
+        for key in parents:
+            node = node.get(key) if isinstance(node, dict) else None
+        if isinstance(node, dict):
+            node.pop(leaf, None)
+    return clone
 
 
 def create_citation_json_structure(

--- a/src/dataset_citations/quality/anchor_judgment.py
+++ b/src/dataset_citations/quality/anchor_judgment.py
@@ -339,7 +339,7 @@ def load_judgment_sidecar(path: str | Path) -> dict[str, Any]:
 def is_judgment_fresh(payload: dict[str, Any], *, max_age_days: int) -> bool:
     """Return True iff the sidecar's `judged_at` is within `max_age_days`.
 
-    Mirrors the freshness semantics from `cli/update.py::_is_fresh_success`
+    Mirrors the freshness semantics from `cli/update.py::_checked_within`
     (which currently uses `<=`; issue #80 tracks the off-by-one fix). We
     keep `<=` here so phase-2 freshness behaves identically to the existing
     citation freshness gate; once #80 lands, both gates should be updated

--- a/tests/test_citation_utils.py
+++ b/tests/test_citation_utils.py
@@ -321,5 +321,52 @@ class TestCitationUtils(unittest.TestCase):
         pass
 
 
+class TestStripVolatileTimestamps(unittest.TestCase):
+    """strip_volatile_timestamps underpins content-idempotent writes (issue #165)."""
+
+    def _payload(self, *, date: str, scoring: str) -> dict:
+        return {
+            "dataset_id": "ds000001",
+            "num_citations": 1,
+            "date_last_updated": date,
+            "metadata": {"fetch_date": date, "fetch_status": "success"},
+            "citation_details": [{"title": "A", "doi": "10.1/a"}],
+            "confidence_scoring": {"model_used": "m", "scoring_date": scoring},
+        }
+
+    def test_payloads_differing_only_in_timestamps_compare_equal(self):
+        a = self._payload(
+            date="2026-06-14T10:00:00+00:00", scoring="2026-06-15T01:00:00+00:00"
+        )
+        b = self._payload(
+            date="2026-06-18T10:00:00+00:00", scoring="2026-06-18T19:00:00+00:00"
+        )
+        self.assertEqual(
+            citation_utils.strip_volatile_timestamps(a),
+            citation_utils.strip_volatile_timestamps(b),
+        )
+
+    def test_substantive_change_compares_unequal(self):
+        a = self._payload(
+            date="2026-06-14T10:00:00+00:00", scoring="2026-06-15T01:00:00+00:00"
+        )
+        b = self._payload(
+            date="2026-06-14T10:00:00+00:00", scoring="2026-06-15T01:00:00+00:00"
+        )
+        b["num_citations"] = 2
+        self.assertNotEqual(
+            citation_utils.strip_volatile_timestamps(a),
+            citation_utils.strip_volatile_timestamps(b),
+        )
+
+    def test_does_not_mutate_input_and_tolerates_missing_keys(self):
+        original = {"dataset_id": "x", "date_last_updated": "2026-01-01T00:00:00+00:00"}
+        stripped = citation_utils.strip_volatile_timestamps(original)
+        # Input untouched (deep copy), volatile key removed in the result.
+        self.assertIn("date_last_updated", original)
+        self.assertNotIn("date_last_updated", stripped)
+        self.assertEqual(stripped, {"dataset_id": "x"})
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_cli_update_backend.py
+++ b/tests/test_cli_update_backend.py
@@ -263,6 +263,25 @@ class FreshnessGateTests(TestCase):
             self._write_json(path, {"metadata": {"fetch_status": "no_doi_references"}})
             self.assertTrue(_has_stable_status(str(path)))
 
+    def test_has_stable_status_true_for_partial(self) -> None:
+        # `partial` (some anchors errored, rest succeeded) is a stable outcome.
+        from dataset_citations.cli.update import _has_stable_status
+
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "nm000104_citations.json"
+            self._write_json(path, {"metadata": {"fetch_status": "partial"}})
+            self.assertTrue(_has_stable_status(str(path)))
+
+    def test_has_stable_status_true_for_no_data_paper_anchor(self) -> None:
+        from dataset_citations.cli.update import _has_stable_status
+
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "nm000104_citations.json"
+            self._write_json(
+                path, {"metadata": {"fetch_status": "no_data_paper_anchor"}}
+            )
+            self.assertTrue(_has_stable_status(str(path)))
+
     def test_has_stable_status_false_for_transient_failure(self) -> None:
         from dataset_citations.cli.update import _has_stable_status
 
@@ -322,6 +341,14 @@ class FreshnessGateTests(TestCase):
             self.assertEqual(
                 _load_fetch_state(path), {"ds1": "2026-06-18T00:00:00+00:00"}
             )
+
+    def test_load_fetch_state_returns_empty_on_corrupt_file(self) -> None:
+        from dataset_citations.cli.update import _load_fetch_state
+
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / ".fetch_state.json"
+            path.write_text("not json at all")
+            self.assertEqual(_load_fetch_state(str(path)), {})
 
 
 class IdempotentWriteTests(TestCase):
@@ -519,6 +546,112 @@ class IdempotentWriteTests(TestCase):
 
             # Stable status + checked within window -> no fetch at all.
             self.assertEqual(calls, [])
+
+    def test_fetch_state_written_to_disk_after_run(self) -> None:
+        with tempfile.TemporaryDirectory() as out_dir:
+            fetched = {
+                "dataset_id": "ds000006",
+                "num_citations": 0,
+                "date_last_updated": "2026-06-18T10:00:00+00:00",
+                "metadata": {
+                    "fetch_date": "2026-06-18T10:00:00+00:00",
+                    "fetch_status": "no_doi_references",
+                },
+                "citation_details": [],
+            }
+            self._run_with_stub(out_dir, "ds000006", fetched)
+            state_path = Path(out_dir) / ".fetch_state.json"
+            self.assertTrue(state_path.exists())
+            self.assertIn("ds000006", json.loads(state_path.read_text()))
+
+    def test_write_failure_does_not_update_fetch_state(self) -> None:
+        import os
+        import stat
+
+        from dataset_citations.cli import update as cli_module
+
+        with tempfile.TemporaryDirectory() as out_dir:
+            list_file = Path(out_dir) / "list.txt"
+            list_file.write_text("ds000007\n")
+            # Pre-create json_opencite read-only so the write fails (OSError).
+            json_dir = Path(out_dir) / "json_opencite"
+            json_dir.mkdir()
+            os.chmod(json_dir, stat.S_IRUSR | stat.S_IXUSR)
+
+            fetched = {
+                "dataset_id": "ds000007",
+                "num_citations": 1,
+                "date_last_updated": "2026-06-18T10:00:00+00:00",
+                "metadata": {
+                    "fetch_date": "2026-06-18T10:00:00+00:00",
+                    "fetch_status": "success",
+                },
+                "citation_details": [{"title": "A", "doi": "10.1/a"}],
+            }
+
+            def stub_pipeline(_did, **_):
+                return fetched
+
+            original = cli_module.fetch_dataset_citations_via_opencite
+            cli_module.fetch_dataset_citations_via_opencite = stub_pipeline  # type: ignore[assignment]
+            try:
+                # Single dataset, write fails -> exit 2; state saved before exit.
+                with self.assertRaises(SystemExit):
+                    cli_module.run_opencite_backend(_make_args(list_file, out_dir))
+            finally:
+                cli_module.fetch_dataset_citations_via_opencite = original  # type: ignore[assignment]
+                os.chmod(json_dir, stat.S_IRWXU)
+            state_path = Path(out_dir) / ".fetch_state.json"
+            on_disk = json.loads(state_path.read_text()) if state_path.exists() else {}
+            self.assertNotIn("ds000007", on_disk)
+
+    def test_transient_failure_forces_refetch_despite_fresh_state(self) -> None:
+        from datetime import datetime, timezone
+
+        from dataset_citations.cli import update as cli_module
+
+        with tempfile.TemporaryDirectory() as out_dir:
+            existing = {
+                "dataset_id": "ds000008",
+                "num_citations": 0,
+                "date_last_updated": "2026-06-18T10:00:00+00:00",
+                "metadata": {
+                    "fetch_date": "2026-06-18T10:00:00+00:00",
+                    # Transient failure: must NOT be skipped even if checked recently.
+                    "fetch_status": "rate_limit",
+                },
+                "citation_details": [],
+            }
+            self._seed(out_dir, "ds000008", existing)
+            (Path(out_dir) / ".fetch_state.json").write_text(
+                json.dumps({"ds000008": datetime.now(timezone.utc).isoformat()})
+            )
+            list_file = Path(out_dir) / "list.txt"
+            list_file.write_text("ds000008\n")
+
+            calls: list[str] = []
+
+            def stub_pipeline(did, **_):
+                calls.append(did)
+                return existing
+
+            original = cli_module.fetch_dataset_citations_via_opencite
+            cli_module.fetch_dataset_citations_via_opencite = stub_pipeline  # type: ignore[assignment]
+            try:
+                # Single all-rate-limit dataset is a degraded run -> exit 3.
+                # The fetch still happened (loop runs before the exit check),
+                # and exit-3 firing despite unchanged=1 confirms the unchanged
+                # path still flows through the api_failure accounting.
+                with self.assertRaises(SystemExit) as ctx:
+                    cli_module.run_opencite_backend(
+                        _make_args(list_file, out_dir, max_age_days=7)
+                    )
+                self.assertEqual(ctx.exception.code, 3)
+            finally:
+                cli_module.fetch_dataset_citations_via_opencite = original  # type: ignore[assignment]
+
+            # rate_limit is transient -> refetched despite a fresh cache entry.
+            self.assertEqual(calls, ["ds000008"])
 
 
 class CatalogDoiWiringTests(TestCase):

--- a/tests/test_cli_update_backend.py
+++ b/tests/test_cli_update_backend.py
@@ -23,6 +23,7 @@ def _make_args(
     out_dir: str,
     *,
     catalog_doi_map: dict[str, str] | None = None,
+    max_age_days: int = 0,
 ) -> argparse.Namespace:
     """Build the argparse.Namespace `run_opencite_backend` expects.
 
@@ -55,7 +56,7 @@ def _make_args(
         output_dir=out_dir,
         catalog_cache=cache_path,
         catalog_cache_max_age=3600,
-        max_age_days=0,
+        max_age_days=max_age_days,
     )
 
 
@@ -226,123 +227,298 @@ class RunOpenciteBackendTests(TestCase):
                 os.chmod(json_dir, stat.S_IRWXU)
 
 
-class IsFreshSuccessTests(TestCase):
-    """Direct tests for the `_is_fresh_success` helper. Pure file reader,
-    no network, real JSON fixtures on disk — no stubs of any kind.
+class FreshnessGateTests(TestCase):
+    """Direct tests for the decoupled freshness helpers (issue #165).
+
+    `_has_stable_status` reads the on-disk JSON; `_checked_within` reads the
+    fetch-state cache. Together they gate a re-fetch. Pure functions, real
+    fixtures on disk, no stubs.
     """
 
     def _write_json(self, path: Path, payload: dict) -> None:
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text(json.dumps(payload))
 
-    def test_returns_false_when_missing(self) -> None:
-        from dataset_citations.cli.update import _is_fresh_success
+    def test_has_stable_status_false_when_missing(self) -> None:
+        from dataset_citations.cli.update import _has_stable_status
 
         with tempfile.TemporaryDirectory() as tmp:
-            self.assertFalse(
-                _is_fresh_success(str(Path(tmp) / "absent.json"), 7 * 86400)
-            )
+            self.assertFalse(_has_stable_status(str(Path(tmp) / "absent.json")))
 
-    def test_returns_true_for_fresh_success(self) -> None:
-        from datetime import datetime, timezone
-
-        from dataset_citations.cli.update import _is_fresh_success
+    def test_has_stable_status_true_for_success(self) -> None:
+        from dataset_citations.cli.update import _has_stable_status
 
         with tempfile.TemporaryDirectory() as tmp:
             path = Path(tmp) / "nm000104_citations.json"
-            self._write_json(
-                path,
-                {
-                    "dataset_id": "nm000104",
-                    "num_citations": 5,
-                    "date_last_updated": datetime.now(timezone.utc).isoformat(),
-                    "metadata": {"fetch_status": "success"},
-                },
-            )
-            self.assertTrue(_is_fresh_success(str(path), 7 * 86400))
+            self._write_json(path, {"metadata": {"fetch_status": "success"}})
+            self.assertTrue(_has_stable_status(str(path)))
 
-    def test_returns_false_for_stale_success(self) -> None:
+    def test_has_stable_status_true_for_no_doi_references(self) -> None:
+        # The key fix: an empty dataset (no DOI refs) is a STABLE outcome, so it
+        # should be skippable within the window instead of refetched nightly.
+        from dataset_citations.cli.update import _has_stable_status
+
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "nm000104_citations.json"
+            self._write_json(path, {"metadata": {"fetch_status": "no_doi_references"}})
+            self.assertTrue(_has_stable_status(str(path)))
+
+    def test_has_stable_status_false_for_transient_failure(self) -> None:
+        from dataset_citations.cli.update import _has_stable_status
+
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "nm000104_citations.json"
+            self._write_json(path, {"metadata": {"fetch_status": "rate_limit"}})
+            self.assertFalse(_has_stable_status(str(path)))
+
+    def test_has_stable_status_false_for_malformed_or_headerless(self) -> None:
+        from dataset_citations.cli.update import _has_stable_status
+
+        with tempfile.TemporaryDirectory() as tmp:
+            broken = Path(tmp) / "broken.json"
+            broken.write_text("not json at all")
+            self.assertFalse(_has_stable_status(str(broken)))
+            headerless = Path(tmp) / "headerless.json"
+            self._write_json(headerless, {"dataset_id": "x", "num_citations": 0})
+            self.assertFalse(_has_stable_status(str(headerless)))
+
+    def test_checked_within_true_for_recent(self) -> None:
+        from datetime import datetime, timezone
+
+        from dataset_citations.cli.update import _checked_within
+
+        state = {"ds1": datetime.now(timezone.utc).isoformat()}
+        self.assertTrue(_checked_within("ds1", state, 7 * 86400))
+
+    def test_checked_within_false_for_stale(self) -> None:
         from datetime import datetime, timedelta, timezone
 
-        from dataset_citations.cli.update import _is_fresh_success
+        from dataset_citations.cli.update import _checked_within
 
-        with tempfile.TemporaryDirectory() as tmp:
-            path = Path(tmp) / "nm000104_citations.json"
-            stale = datetime.now(timezone.utc) - timedelta(days=30)
-            self._write_json(
-                path,
-                {
-                    "dataset_id": "nm000104",
-                    "date_last_updated": stale.isoformat(),
-                    "metadata": {"fetch_status": "success"},
-                },
-            )
-            self.assertFalse(_is_fresh_success(str(path), 7 * 86400))
+        stale = (datetime.now(timezone.utc) - timedelta(days=30)).isoformat()
+        self.assertFalse(_checked_within("ds1", {"ds1": stale}, 7 * 86400))
 
-    def test_returns_false_for_non_success_status(self) -> None:
+    def test_checked_within_false_for_missing_or_unparseable(self) -> None:
+        from dataset_citations.cli.update import _checked_within
+
+        self.assertFalse(_checked_within("ds1", {}, 7 * 86400))
+        self.assertFalse(_checked_within("ds1", {"ds1": "not-a-date"}, 7 * 86400))
+
+    def test_checked_within_treats_naive_timestamp_as_utc(self) -> None:
         from datetime import datetime, timezone
 
-        from dataset_citations.cli.update import _is_fresh_success
+        from dataset_citations.cli.update import _checked_within
+
+        naive_now = datetime.now(timezone.utc).replace(tzinfo=None).isoformat()
+        self.assertTrue(_checked_within("ds1", {"ds1": naive_now}, 7 * 86400))
+
+    def test_fetch_state_roundtrip(self) -> None:
+        from dataset_citations.cli.update import _load_fetch_state, _save_fetch_state
 
         with tempfile.TemporaryDirectory() as tmp:
-            path = Path(tmp) / "nm000104_citations.json"
-            self._write_json(
-                path,
-                {
-                    "dataset_id": "nm000104",
-                    "date_last_updated": datetime.now(timezone.utc).isoformat(),
-                    # Fresh but not a success: prior run hit rate_limit.
-                    "metadata": {"fetch_status": "rate_limit"},
-                },
+            path = str(Path(tmp) / ".fetch_state.json")
+            self.assertEqual(_load_fetch_state(path), {})  # absent -> empty
+            _save_fetch_state(path, {"ds1": "2026-06-18T00:00:00+00:00"})
+            self.assertEqual(
+                _load_fetch_state(path), {"ds1": "2026-06-18T00:00:00+00:00"}
             )
-            self.assertFalse(_is_fresh_success(str(path), 7 * 86400))
 
-    def test_returns_false_for_malformed_json(self) -> None:
-        from dataset_citations.cli.update import _is_fresh_success
 
-        with tempfile.TemporaryDirectory() as tmp:
-            path = Path(tmp) / "broken.json"
-            path.write_text("not json at all")
-            self.assertFalse(_is_fresh_success(str(path), 7 * 86400))
+class IdempotentWriteTests(TestCase):
+    """run_opencite_backend must not rewrite a citation file when only the
+    volatile timestamps differ, and must drop stale scores when content
+    genuinely changes so the score step re-scores (issue #165).
+    """
 
-    def test_returns_false_for_missing_metadata(self) -> None:
-        from dataset_citations.cli.update import _is_fresh_success
+    def _seed(self, out_dir: str, dataset_id: str, payload: dict) -> Path:
+        json_dir = Path(out_dir) / "json_opencite"
+        json_dir.mkdir(parents=True, exist_ok=True)
+        path = json_dir / f"{dataset_id}_citations.json"
+        path.write_text(json.dumps(payload, indent=2))
+        return path
 
-        with tempfile.TemporaryDirectory() as tmp:
-            path = Path(tmp) / "headerless.json"
-            self._write_json(path, {"dataset_id": "x", "num_citations": 0})
-            self.assertFalse(_is_fresh_success(str(path), 7 * 86400))
+    def _run_with_stub(self, out_dir: str, dataset_id: str, payload: dict) -> None:
+        from dataset_citations.cli import update as cli_module
 
-    def test_returns_false_for_unparseable_timestamp(self) -> None:
-        from dataset_citations.cli.update import _is_fresh_success
+        list_file = Path(out_dir) / "list.txt"
+        list_file.write_text(f"{dataset_id}\n")
 
-        with tempfile.TemporaryDirectory() as tmp:
-            path = Path(tmp) / "bad_date.json"
-            self._write_json(
-                path,
-                {
-                    "date_last_updated": "not-a-real-iso-string",
-                    "metadata": {"fetch_status": "success"},
+        def stub_pipeline(_did, **_):
+            return payload
+
+        original = cli_module.fetch_dataset_citations_via_opencite
+        cli_module.fetch_dataset_citations_via_opencite = stub_pipeline  # type: ignore[assignment]
+        try:
+            cli_module.run_opencite_backend(_make_args(list_file, out_dir))
+        finally:
+            cli_module.fetch_dataset_citations_via_opencite = original  # type: ignore[assignment]
+
+    def test_unchanged_content_does_not_rewrite_timestamps(self) -> None:
+        with tempfile.TemporaryDirectory() as out_dir:
+            existing = {
+                "dataset_id": "ds000001",
+                "num_citations": 0,
+                "date_last_updated": "2026-06-14T10:00:00+00:00",
+                "metadata": {
+                    "fetch_date": "2026-06-14T10:00:00+00:00",
+                    "fetch_status": "no_doi_references",
                 },
-            )
-            self.assertFalse(_is_fresh_success(str(path), 7 * 86400))
+                "citation_details": [],
+            }
+            path = self._seed(out_dir, "ds000001", existing)
+            # Same content, only the timestamps advance.
+            fetched = json.loads(json.dumps(existing))
+            fetched["date_last_updated"] = "2026-06-18T10:00:00+00:00"
+            fetched["metadata"]["fetch_date"] = "2026-06-18T10:00:00+00:00"
+            self._run_with_stub(out_dir, "ds000001", fetched)
+            on_disk = json.loads(path.read_text())
+            # File left untouched: old timestamp preserved.
+            self.assertEqual(on_disk["date_last_updated"], "2026-06-14T10:00:00+00:00")
 
-    def test_treats_naive_timestamp_as_utc(self) -> None:
+    def test_changed_content_rewrites_and_advances_timestamp(self) -> None:
+        with tempfile.TemporaryDirectory() as out_dir:
+            existing = {
+                "dataset_id": "ds000002",
+                "num_citations": 1,
+                "date_last_updated": "2026-06-14T10:00:00+00:00",
+                "metadata": {
+                    "fetch_date": "2026-06-14T10:00:00+00:00",
+                    "fetch_status": "success",
+                },
+                "citation_details": [{"title": "A", "doi": "10.1/a"}],
+            }
+            path = self._seed(out_dir, "ds000002", existing)
+            fetched = {
+                "dataset_id": "ds000002",
+                "num_citations": 2,
+                "date_last_updated": "2026-06-18T10:00:00+00:00",
+                "metadata": {
+                    "fetch_date": "2026-06-18T10:00:00+00:00",
+                    "fetch_status": "success",
+                },
+                "citation_details": [
+                    {"title": "A", "doi": "10.1/a"},
+                    {"title": "B", "doi": "10.1/b"},
+                ],
+            }
+            self._run_with_stub(out_dir, "ds000002", fetched)
+            on_disk = json.loads(path.read_text())
+            self.assertEqual(on_disk["num_citations"], 2)
+            self.assertEqual(on_disk["date_last_updated"], "2026-06-18T10:00:00+00:00")
+
+    def test_unchanged_preserves_existing_confidence_scoring(self) -> None:
+        with tempfile.TemporaryDirectory() as out_dir:
+            existing = {
+                "dataset_id": "ds000003",
+                "num_citations": 1,
+                "date_last_updated": "2026-06-14T10:00:00+00:00",
+                "metadata": {
+                    "fetch_date": "2026-06-14T10:00:00+00:00",
+                    "fetch_status": "success",
+                },
+                "citation_details": [{"title": "A", "doi": "10.1/a"}],
+                "confidence_scoring": {
+                    "model_used": "Qwen/Qwen3-Embedding-0.6B",
+                    "scoring_date": "2026-06-15T01:00:00+00:00",
+                },
+            }
+            path = self._seed(out_dir, "ds000003", existing)
+            # opencite payload never carries confidence_scoring.
+            fetched = {
+                "dataset_id": "ds000003",
+                "num_citations": 1,
+                "date_last_updated": "2026-06-18T10:00:00+00:00",
+                "metadata": {
+                    "fetch_date": "2026-06-18T10:00:00+00:00",
+                    "fetch_status": "success",
+                },
+                "citation_details": [{"title": "A", "doi": "10.1/a"}],
+            }
+            self._run_with_stub(out_dir, "ds000003", fetched)
+            on_disk = json.loads(path.read_text())
+            # Not rewritten -> score block (and its date) preserved.
+            self.assertIn("confidence_scoring", on_disk)
+            self.assertEqual(
+                on_disk["confidence_scoring"]["scoring_date"],
+                "2026-06-15T01:00:00+00:00",
+            )
+
+    def test_changed_content_drops_stale_confidence_scoring(self) -> None:
+        with tempfile.TemporaryDirectory() as out_dir:
+            existing = {
+                "dataset_id": "ds000004",
+                "num_citations": 1,
+                "date_last_updated": "2026-06-14T10:00:00+00:00",
+                "metadata": {
+                    "fetch_date": "2026-06-14T10:00:00+00:00",
+                    "fetch_status": "success",
+                },
+                "citation_details": [{"title": "A", "doi": "10.1/a"}],
+                "confidence_scoring": {
+                    "model_used": "Qwen/Qwen3-Embedding-0.6B",
+                    "scoring_date": "2026-06-15T01:00:00+00:00",
+                },
+            }
+            path = self._seed(out_dir, "ds000004", existing)
+            fetched = {
+                "dataset_id": "ds000004",
+                "num_citations": 2,
+                "date_last_updated": "2026-06-18T10:00:00+00:00",
+                "metadata": {
+                    "fetch_date": "2026-06-18T10:00:00+00:00",
+                    "fetch_status": "success",
+                },
+                "citation_details": [
+                    {"title": "A", "doi": "10.1/a"},
+                    {"title": "B", "doi": "10.1/b"},
+                ],
+            }
+            self._run_with_stub(out_dir, "ds000004", fetched)
+            on_disk = json.loads(path.read_text())
+            # Citations changed -> stale scores dropped so the score step re-scores.
+            self.assertNotIn("confidence_scoring", on_disk)
+
+    def test_fresh_stable_dataset_is_skipped(self) -> None:
         from datetime import datetime, timezone
 
-        from dataset_citations.cli.update import _is_fresh_success
+        from dataset_citations.cli import update as cli_module
 
-        with tempfile.TemporaryDirectory() as tmp:
-            path = Path(tmp) / "naive.json"
-            naive_now = datetime.now(timezone.utc).replace(tzinfo=None).isoformat()
-            self._write_json(
-                path,
-                {
-                    "date_last_updated": naive_now,
-                    "metadata": {"fetch_status": "success"},
+        with tempfile.TemporaryDirectory() as out_dir:
+            existing = {
+                "dataset_id": "ds000005",
+                "num_citations": 0,
+                "date_last_updated": "2026-01-01T00:00:00+00:00",
+                "metadata": {
+                    "fetch_date": "2026-01-01T00:00:00+00:00",
+                    "fetch_status": "no_doi_references",
                 },
+                "citation_details": [],
+            }
+            self._seed(out_dir, "ds000005", existing)
+            # Mark it as checked just now in the fetch-state cache.
+            (Path(out_dir) / ".fetch_state.json").write_text(
+                json.dumps({"ds000005": datetime.now(timezone.utc).isoformat()})
             )
-            self.assertTrue(_is_fresh_success(str(path), 7 * 86400))
+            list_file = Path(out_dir) / "list.txt"
+            list_file.write_text("ds000005\n")
+
+            calls: list[str] = []
+
+            def stub_pipeline(did, **_):
+                calls.append(did)
+                return existing
+
+            original = cli_module.fetch_dataset_citations_via_opencite
+            cli_module.fetch_dataset_citations_via_opencite = stub_pipeline  # type: ignore[assignment]
+            try:
+                cli_module.run_opencite_backend(
+                    _make_args(list_file, out_dir, max_age_days=7)
+                )
+            finally:
+                cli_module.fetch_dataset_citations_via_opencite = original  # type: ignore[assignment]
+
+            # Stable status + checked within window -> no fetch at all.
+            self.assertEqual(calls, [])
 
 
 class CatalogDoiWiringTests(TestCase):


### PR DESCRIPTION
Closes #165.

## Problem
Every nightly pipeline run rewrote large numbers of `citations/json_opencite/*.json` files even when no citations changed, advancing only `date_last_updated`, `metadata.fetch_date`, and `confidence_scoring.scoring_date`. This made the nightly diff meaningless, bloated history, and was the sole reason stacked auto-update PRs (e.g. the now-closed #164) conflicted with each other.

## Root causes
1. `cli/update.py::_is_fresh_success` only treated `fetch_status == "success"` as fresh, so zero-citation datasets (`no_doi_references`, `no_data_paper_anchor`) were refetched and rewritten every run.
2. Writes were unconditional: an identical re-fetch still rewrote the file with a new timestamp.
3. The update step dropped the `confidence_scoring` block (the opencite payload doesn't carry it); the score step then re-added it with a fresh `scoring_date` every run.

## Fix
- **`strip_volatile_timestamps()`** (`core/citation_utils.py`): compares two payloads ignoring `date_last_updated`, `metadata.fetch_date`, `confidence_scoring.scoring_date`.
- **`cli/update.py`**: write only when substantive content changed. The existing `confidence_scoring` block is carried onto the *comparison* copy (so an unchanged dataset isn't seen as changed), and is dropped only on a real change so the score step's `--skip-existing` re-scores exactly when citations actually changed. `date_last_updated` now means "last content change".
- **Freshness gate decoupled** onto a gitignored `citations/.fetch_state.json` last-checked cache. Without this, freezing `date_last_updated` would make the gate refetch everything nightly; the cache keeps the weekly cadence (and actually reduces fetches vs. before, since stable empty datasets stop refetching nightly). Stable statuses are now defined as "not a transient API failure".

## Tests (real data, no mocks)
- `strip_volatile_timestamps`: timestamp-only diffs compare equal; substantive diffs don't; input not mutated.
- New freshness helpers: stable-status detection (incl. `no_doi_references`), last-checked window, cache round-trip.
- `run_opencite_backend` end-to-end via monkeypatched real pipeline fn: unchanged content leaves the file untouched; changed content rewrites and advances the timestamp; `confidence_scoring` preserved on no-op and dropped on real change; fresh+stable dataset is skipped entirely.

302 passed, 26 skipped. `ruff format --check` + `ruff check` clean.

## Operational note
On the first nightly run after this merges, the fetch-state cache is empty so every dataset is fetched once (idempotent writes keep that diff clean); subsequent runs skip fresh ones. The cron's `git reset --hard` / `git clean` don't touch the gitignored cache, so it persists on hallu.
