### PR TITLE
feat: discover dataset accession-mention citations (#169 phase 2a)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,7 @@ Documentation = "https://github.com/nemarOrg/nemar-citations/blob/main/README.md
 dataset-citations-discover = "dataset_citations.cli.discover:main"
 dataset-citations-migrate = "dataset_citations.cli.migrate:main"
 dataset-citations-update = "dataset_citations.cli.update:main"
+dataset-citations-find-mentions = "dataset_citations.cli.find_mentions:main"
 dataset-citations-regenerate = "dataset_citations.cli.regenerate:main"
 dataset-citations-retrieve-metadata = "dataset_citations.cli.retrieve_metadata:main"
 dataset-citations-judge-anchors = "dataset_citations.cli.judge_anchors:main"

--- a/scripts/hallu_cron_pipeline.sh
+++ b/scripts/hallu_cron_pipeline.sh
@@ -138,6 +138,22 @@ OPENCITE_CONCURRENCY=4 \
   exit 2
 }
 
+# 3c. Accession-mention discovery (#169). People cite datasets by accession
+#     number in text (ds*/on*/nm*, plus the OpenNeuro ds- alias for on-*),
+#     not by DOI. Full-text search OpenAlex for those and fold the hits into
+#     citation_details tagged discovery_method=accession_mention ("cites
+#     dataset" bucket). Runs AFTER update (needs the anchor citation JSONs to
+#     merge into) and BEFORE score-confidence (which then ranks the merged
+#     citations; merge drops the stale confidence block when it adds new ones
+#     so --skip-existing re-scores). OpenAlex-only + idempotent writes, so it
+#     is cheap and non-churning. Guard with `|| exit 2` like the other steps.
+echo "--- find-mentions (openalex accession search) ---"
+uv run dataset-citations-find-mentions \
+  --citations-dir citations/json_opencite || {
+  echo "ERROR: dataset-citations-find-mentions failed; aborting before score." >&2
+  exit 2
+}
+
 # 4. Semantic confidence scoring on RTX 4090. --skip-existing is a small speedup
 #    for unchanged citation files. Same `|| exit 2` guard as the other GPU
 #    steps so a CUDA OOM aborts cleanly instead of feeding empty scores

--- a/scripts/hallu_cron_pipeline.sh
+++ b/scripts/hallu_cron_pipeline.sh
@@ -283,7 +283,7 @@ git commit -m "data: hallu nightly pipeline ($TS)
 
 GPU semantic scoring + embeddings on RTX 4090. Pipeline:
   catalog discover -> metadata -> judge-anchors -> opencite fetch
-  -> score-confidence -> generate-embeddings
+  -> find-mentions -> score-confidence -> generate-embeddings
 
 $(echo "$DIFFSTAT")"
 

--- a/src/dataset_citations/backends/accession_search.py
+++ b/src/dataset_citations/backends/accession_search.py
@@ -1,0 +1,164 @@
+"""Find papers that mention a dataset accession via OpenAlex full-text search.
+
+Datasets are cited by accession number in running text ("ds002718",
+"on005964", "nm000207"), not by DOI (OpenNeuro / NEMAR DOIs aren't indexed in
+OpenAlex). OpenAlex's `fulltext.search` filter surfaces those works. This
+backend reuses opencite's `OpenAlexClient` + `Config` (no new HTTP client) and
+maps each hit to the same citation-detail dict the opencite pipeline emits,
+tagged `discovery_method="accession_mention"`. Sync facade over the async
+client, mirroring `OpenCiteBackend`. Issue #169.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any
+
+import httpx
+from opencite.clients.openalex import OpenAlexClient
+from opencite.config import Config
+
+logger = logging.getLogger(__name__)
+
+
+def reconstruct_abstract(inverted: dict[str, list[int]] | None) -> str | None:
+    """Rebuild plain abstract text from OpenAlex's abstract_inverted_index."""
+    if not inverted:
+        return None
+    positions: list[tuple[int, str]] = []
+    for word, idxs in inverted.items():
+        for i in idxs:
+            positions.append((i, word))
+    if not positions:
+        return None
+    positions.sort()
+    return " ".join(word for _, word in positions)
+
+
+def _bare_doi(doi: str | None) -> str | None:
+    if not doi:
+        return None
+    stripped = (
+        doi.replace("https://doi.org/", "").replace("http://doi.org/", "").lower()
+    )
+    return stripped or None
+
+
+def _short_id(url_id: str | None) -> str | None:
+    if not url_id:
+        return None
+    return url_id.rsplit("/", 1)[-1] or None
+
+
+def work_to_citation(work: dict[str, Any], matched_accession: str) -> dict[str, Any]:
+    """Map a raw OpenAlex work JSON to a citation-detail dict.
+
+    Mirrors `opencite_pipeline._citing_work_to_dict` so accession-mention
+    citations are schema-compatible with anchor-based ones, plus the
+    `discovery_method` / `matched_accession` tags that mark the dataset bucket.
+    """
+    authors = [
+        a.get("author", {}).get("display_name")
+        for a in work.get("authorships", [])
+        if a.get("author", {}).get("display_name")
+    ]
+    source = (work.get("primary_location") or {}).get("source") or {}
+    pmid = (work.get("ids") or {}).get("pmid")
+    if pmid:
+        pmid = pmid.rsplit("/", 1)[-1]
+    doi = _bare_doi(work.get("doi"))
+    return {
+        "title": work.get("title"),
+        "author": ", ".join(authors) if authors else "n/a",
+        "venue": source.get("display_name") or "n/a",
+        "year": work.get("publication_year") or 0,
+        "url": f"https://doi.org/{doi}" if doi else (work.get("id") or ""),
+        "cited_by": work.get("cited_by_count") or 0,
+        "abstract": reconstruct_abstract(work.get("abstract_inverted_index")),
+        "doi": doi,
+        "pmid": pmid,
+        "openalex_id": _short_id(work.get("id")),
+        "source_doi": None,
+        "source_relation": None,
+        "discovery_backend": "openalex",
+        "discovery_method": "accession_mention",
+        "matched_accession": matched_accession,
+    }
+
+
+async def _search_term(
+    client: OpenAlexClient, term: str, max_results: int
+) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    cursor: str | None = "*"
+    per_page = min(max(max_results, 1), 100)
+    while cursor and len(out) < max_results:
+        resp = await client.get(
+            "works",
+            params={
+                "filter": f"fulltext.search:{term}",
+                "per-page": per_page,
+                "cursor": cursor,
+            },
+        )
+        data = resp.json()
+        for work in data.get("results", []):
+            out.append(work_to_citation(work, term))
+            if len(out) >= max_results:
+                break
+        cursor = (data.get("meta") or {}).get("next_cursor")
+    return out
+
+
+class AccessionSearchBackend:
+    """Sync facade: search OpenAlex full text for dataset accession mentions."""
+
+    def __init__(self, config: Config | None = None, *, max_results: int = 200) -> None:
+        self._config = config or Config.from_env()
+        self._max_results = max_results
+
+    def search(self, terms: list[str]) -> list[dict[str, Any]]:
+        """Return deduped citation dicts mentioning any of `terms`.
+
+        Dedup is by DOI, then OpenAlex id, then title (lowercased) so a paper
+        that mentions both the `on-` and `ds-` accession appears once. Results
+        are sorted by a stable key so repeated runs produce identical output
+        (content-idempotent writes depend on this). Per-term failures are
+        logged and skipped, never fatal.
+        """
+        if not terms:
+            return []
+        return asyncio.run(self._search_all(terms))
+
+    async def _search_all(self, terms: list[str]) -> list[dict[str, Any]]:
+        deduped: dict[str, dict[str, Any]] = {}
+        async with OpenAlexClient(self._config) as client:
+            assert isinstance(client, OpenAlexClient), (
+                "opencite changed OpenAlexClient.__aenter__ return type; "
+                f"got {type(client).__name__}"
+            )
+            for term in terms:
+                try:
+                    hits = await _search_term(client, term, self._max_results)
+                except (httpx.HTTPError, asyncio.TimeoutError, OSError) as e:
+                    logger.warning("accession search failed for %s: %s", term, e)
+                    continue
+                for citation in hits:
+                    key = (
+                        citation.get("doi")
+                        or citation.get("openalex_id")
+                        or (citation.get("title") or "")
+                    ).lower()
+                    if key and key not in deduped:
+                        deduped[key] = citation
+        return sorted(deduped.values(), key=_stable_key)
+
+
+def _stable_key(citation: dict[str, Any]) -> str:
+    return (
+        citation.get("doi")
+        or citation.get("openalex_id")
+        or citation.get("title")
+        or ""
+    ).lower()

--- a/src/dataset_citations/backends/accession_search.py
+++ b/src/dataset_citations/backends/accession_search.py
@@ -18,8 +18,14 @@ from typing import Any
 import httpx
 from opencite.clients.openalex import OpenAlexClient
 from opencite.config import Config
+from opencite.exceptions import OpenCiteError
 
 logger = logging.getLogger(__name__)
+
+# Safety bound on cursor pagination per term (50 * 100 = 5000 works). Accession
+# searches return far fewer, but this caps a pathological term and pairs with
+# the empty-page break below to make the loop always terminate.
+_MAX_PAGES = 50
 
 
 def reconstruct_abstract(inverted: dict[str, list[int]] | None) -> str | None:
@@ -87,28 +93,64 @@ def work_to_citation(work: dict[str, Any], matched_accession: str) -> dict[str, 
     }
 
 
-async def _search_term(
-    client: OpenAlexClient, term: str, max_results: int
-) -> list[dict[str, Any]]:
+async def _search_term(client: OpenAlexClient, term: str) -> list[dict[str, Any]]:
+    """Fully paginate OpenAlex `fulltext.search:term`, returning mapped hits.
+
+    Pagination is decoupled from any result cap so the full hit set is collected
+    deterministically; truncation happens after a stable sort in `search`. The
+    loop terminates on a falsy cursor, on an empty results page (OpenAlex index
+    lag can return `results: []` with `next_cursor` still set), or at the
+    `_MAX_PAGES` safety bound.
+    """
     out: list[dict[str, Any]] = []
     cursor: str | None = "*"
-    per_page = min(max(max_results, 1), 100)
-    while cursor and len(out) < max_results:
+    pages = 0
+    while cursor and pages < _MAX_PAGES:
         resp = await client.get(
             "works",
             params={
                 "filter": f"fulltext.search:{term}",
-                "per-page": per_page,
+                "per-page": 100,
                 "cursor": cursor,
             },
         )
         data = resp.json()
-        for work in data.get("results", []):
-            out.append(work_to_citation(work, term))
-            if len(out) >= max_results:
-                break
+        results = data.get("results", [])
+        if not results:
+            break
+        out.extend(work_to_citation(work, term) for work in results)
+        pages += 1
         cursor = (data.get("meta") or {}).get("next_cursor")
+    if pages >= _MAX_PAGES and cursor:
+        logger.warning(
+            "accession term %s hit the %d-page cap; results truncated", term, _MAX_PAGES
+        )
     return out
+
+
+def _stable_key(citation: dict[str, Any]) -> str:
+    """Dedup / sort key: DOI, else OpenAlex id, else title (stripped+lowercased)."""
+    for field in ("doi", "openalex_id", "title"):
+        value = citation.get(field)
+        if value:
+            return str(value).strip().lower()
+    return ""
+
+
+def dedup_citations(hit_lists: list[list[dict[str, Any]]]) -> list[dict[str, Any]]:
+    """Merge per-term hit lists into one deduped, stably-sorted list.
+
+    A paper that matches more than one accession term (e.g. an `on-` dataset's
+    `on*` and `ds*` ids) appears once. Pure function -> unit-testable without
+    network. The stable sort is what makes a later truncation deterministic.
+    """
+    deduped: dict[str, dict[str, Any]] = {}
+    for hits in hit_lists:
+        for citation in hits:
+            key = _stable_key(citation)
+            if key and key not in deduped:
+                deduped[key] = citation
+    return sorted(deduped.values(), key=_stable_key)
 
 
 class AccessionSearchBackend:
@@ -121,18 +163,20 @@ class AccessionSearchBackend:
     def search(self, terms: list[str]) -> list[dict[str, Any]]:
         """Return deduped citation dicts mentioning any of `terms`.
 
-        Dedup is by DOI, then OpenAlex id, then title (lowercased) so a paper
-        that mentions both the `on-` and `ds-` accession appears once. Results
-        are sorted by a stable key so repeated runs produce identical output
-        (content-idempotent writes depend on this). Per-term failures are
-        logged and skipped, never fatal.
+        Output is sorted by a stable key and truncated to `max_results` AFTER
+        the sort, so the kept subset is identical across runs even when a term
+        has more hits than the cap (content-idempotent writes depend on this).
+        Per-term failures are logged and skipped, never fatal.
         """
         if not terms:
             return []
-        return asyncio.run(self._search_all(terms))
+        deduped = asyncio.run(self._search_all(terms))
+        if self._max_results and len(deduped) > self._max_results:
+            return deduped[: self._max_results]
+        return deduped
 
     async def _search_all(self, terms: list[str]) -> list[dict[str, Any]]:
-        deduped: dict[str, dict[str, Any]] = {}
+        hit_lists: list[list[dict[str, Any]]] = []
         async with OpenAlexClient(self._config) as client:
             assert isinstance(client, OpenAlexClient), (
                 "opencite changed OpenAlexClient.__aenter__ return type; "
@@ -140,25 +184,12 @@ class AccessionSearchBackend:
             )
             for term in terms:
                 try:
-                    hits = await _search_term(client, term, self._max_results)
-                except (httpx.HTTPError, asyncio.TimeoutError, OSError) as e:
+                    hit_lists.append(await _search_term(client, term))
+                except (
+                    OpenCiteError,
+                    httpx.HTTPError,
+                    asyncio.TimeoutError,
+                    OSError,
+                ) as e:
                     logger.warning("accession search failed for %s: %s", term, e)
-                    continue
-                for citation in hits:
-                    key = (
-                        citation.get("doi")
-                        or citation.get("openalex_id")
-                        or (citation.get("title") or "")
-                    ).lower()
-                    if key and key not in deduped:
-                        deduped[key] = citation
-        return sorted(deduped.values(), key=_stable_key)
-
-
-def _stable_key(citation: dict[str, Any]) -> str:
-    return (
-        citation.get("doi")
-        or citation.get("openalex_id")
-        or citation.get("title")
-        or ""
-    ).lower()
+        return dedup_citations(hit_lists)

--- a/src/dataset_citations/cli/find_mentions.py
+++ b/src/dataset_citations/cli/find_mentions.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""Find dataset accession-mention citations via OpenAlex and merge them in.
+
+For each dataset that already has a citation JSON, full-text search OpenAlex
+for the dataset accession (`ds*`/`on*`/`nm*`, plus the OpenNeuro `ds-` alias
+carried in the catalog `source_id`) and fold the matching papers into
+`citation_details[]` tagged `discovery_method="accession_mention"`. This
+automates the old "search the accession by hand, keep high-confidence hits"
+workflow; the downstream score step ranks the merged citations. Issue #169.
+
+Runs after `dataset-citations-update` and before
+`dataset-citations-score-confidence` in the hallu cron.
+"""
+
+from __future__ import annotations
+
+import argparse
+import glob
+import json
+import logging
+import os
+from pathlib import Path
+
+from dataset_citations.backends.accession_search import AccessionSearchBackend
+from dataset_citations.core.accession_mentions import merge_accession_mentions
+from dataset_citations.core.citation_utils import write_citation_json_if_changed
+from dataset_citations.sources.accession import accession_search_terms
+from dataset_citations.sources.models import FetchSuccess
+from dataset_citations.sources.nemar_catalog import get_or_fetch_catalog
+
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+)
+logger = logging.getLogger(__name__)
+
+
+def _load_source_id_map(
+    cache_path: Path | None, max_age_seconds: int
+) -> dict[str, str]:
+    """Return a {dataset_id: source_id} map for catalog datasets that have one.
+
+    `source_id` is the OpenNeuro `ds-` number for `on-*` datasets, which is the
+    accession people actually cite. On catalog failure we log and return {};
+    the search then falls back to the dataset id alone.
+    """
+    result = get_or_fetch_catalog(
+        cache_path=cache_path, max_age_seconds=max_age_seconds
+    )
+    if not isinstance(result, FetchSuccess):
+        logger.warning(
+            "could not load catalog (%s): %s; searching dataset ids only",
+            result.reason,
+            result.detail,
+        )
+        return {}
+    return {row.dataset_id: row.source_id for row in result.value if row.source_id}
+
+
+def _dataset_ids(args: argparse.Namespace, json_dir: str) -> list[str]:
+    if args.dataset_list_file:
+        with open(args.dataset_list_file, encoding="utf-8") as f:
+            return [line.strip() for line in f if line.strip()]
+    return sorted(
+        os.path.basename(p).removesuffix("_citations.json")
+        for p in glob.glob(os.path.join(json_dir, "*_citations.json"))
+    )
+
+
+def run_find_mentions(args: argparse.Namespace) -> None:
+    """Merge accession-mention citations into each dataset's citation JSON.
+
+    Raises SystemExit(2) if every processed dataset failed to write.
+    """
+    json_dir = args.citations_dir
+    source_ids = _load_source_id_map(args.catalog_cache, args.catalog_cache_max_age)
+    backend = AccessionSearchBackend(max_results=args.max_results)
+
+    dataset_ids = _dataset_ids(args, json_dir)
+    logger.info("searching accession mentions for %d dataset(s)", len(dataset_ids))
+
+    processed = 0
+    updated = 0
+    no_terms = 0
+    missing = 0
+    write_failures = 0
+    total_mentions = 0
+    for dataset_id in dataset_ids:
+        filepath = os.path.join(json_dir, f"{dataset_id}_citations.json")
+        if not os.path.isfile(filepath):
+            missing += 1
+            continue
+        terms = accession_search_terms(dataset_id, source_ids.get(dataset_id))
+        if not terms:
+            no_terms += 1
+            continue
+        try:
+            with open(filepath, encoding="utf-8") as f:
+                citation_json = json.load(f)
+        except (OSError, json.JSONDecodeError) as e:
+            logger.warning("%s: could not read (%s); skipping", dataset_id, e)
+            continue
+        processed += 1
+        mentions = backend.search(terms)
+        total_mentions += len(mentions)
+        merged = merge_accession_mentions(citation_json, mentions, terms)
+        try:
+            if write_citation_json_if_changed(filepath, merged):
+                updated += 1
+        except OSError as e:
+            logger.error("Failed to write %s: %s", filepath, e)
+            write_failures += 1
+            continue
+        logger.info(
+            "%s: %d mention(s) for %s", dataset_id, len(mentions), ",".join(terms)
+        )
+
+    logger.info(
+        "accession-mention run complete: %d processed, %d updated, %d mentions found, "
+        "%d no-terms, %d missing-json, %d write failures.",
+        processed,
+        updated,
+        total_mentions,
+        no_terms,
+        missing,
+        write_failures,
+    )
+    if processed and write_failures == processed:
+        raise SystemExit(2)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Find dataset accession-mention citations via OpenAlex full-text "
+            "search and merge them into the per-dataset citation JSON."
+        ),
+    )
+    parser.add_argument(
+        "--citations-dir",
+        default="citations/json_opencite",
+        help="Directory of <id>_citations.json files (default: citations/json_opencite).",
+    )
+    parser.add_argument(
+        "--dataset-list-file",
+        default=None,
+        help="Optional file of dataset IDs (one per line). Defaults to all JSONs in --citations-dir.",
+    )
+    parser.add_argument(
+        "--catalog-cache",
+        type=Path,
+        default=Path.home() / ".cache" / "dataset_citations" / "catalog.json",
+        help="Cached api.nemar.org/datasets response (for the on-* -> ds-* alias).",
+    )
+    parser.add_argument(
+        "--catalog-cache-max-age",
+        type=int,
+        default=3600,
+        help="Seconds before the catalog cache is considered stale (default: 3600).",
+    )
+    parser.add_argument(
+        "--max-results",
+        type=int,
+        default=200,
+        help="Max OpenAlex works to pull per accession term (default: 200).",
+    )
+    args = parser.parse_args()
+    run_find_mentions(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/dataset_citations/core/accession_mentions.py
+++ b/src/dataset_citations/core/accession_mentions.py
@@ -114,10 +114,15 @@ def merge_accession_mentions(
     citation_json["num_citations"] = len(details)
     meta = citation_json.setdefault("metadata", {})
     meta["searched_accessions"] = list(searched_accessions)
+    # Provenance: papers found purely via the accession search.
     meta["num_accession_mentions"] = sum(
         1 for c in details if c.get("discovery_method") == "accession_mention"
     )
-    meta["num_anchor_citations"] = sum(
-        1 for c in details if c.get("discovery_method") != "accession_mention"
-    )
+    # The two toggle buckets, recorded explicitly so the dashboard / leaderboard
+    # keys on them rather than re-deriving (and never compares a raw
+    # num_citations from a find-mentions-processed dataset against a not-yet-
+    # processed one). num_citations stays the deduped total of both buckets.
+    dataset_bucket = sum(1 for c in details if cites_dataset(c))
+    meta["num_dataset_citations"] = dataset_bucket
+    meta["num_datapaper_citations"] = len(details) - dataset_bucket
     return citation_json

--- a/src/dataset_citations/core/accession_mentions.py
+++ b/src/dataset_citations/core/accession_mentions.py
@@ -1,0 +1,98 @@
+"""Merge accession-mention citations into a dataset's citation JSON.
+
+Accession-mention citations (papers that name the dataset accession in text)
+are discovered by `backends/accession_search.py` and folded into the same
+`citation_details[]` list as anchor-based citations, each tagged
+`discovery_method="accession_mention"`. The toggle (#169) buckets:
+  - "cites dataset"   = accession mentions + anchor citations whose
+                        source_relation is IsVersionOf / IsIdenticalTo
+  - "cites data paper"= the remaining anchor citations (References /
+                        IsDerivedFrom)
+
+This module is pure (no network / I/O) and deterministic so repeated runs are
+content-idempotent (issue #165). Issue #169.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+# source_relation values whose anchor IS the dataset (vs the data paper).
+_DATASET_RELATIONS = frozenset({"IsVersionOf", "IsIdenticalTo"})
+
+
+def _key(citation: dict[str, Any]) -> str:
+    """Dedup key: DOI, else OpenAlex id, else title (all lowercased)."""
+    for field in ("doi", "openalex_id", "title"):
+        value = citation.get(field)
+        if value:
+            return str(value).strip().lower()
+    return ""
+
+
+def cites_dataset(citation: dict[str, Any]) -> bool:
+    """True if `citation` belongs in the 'cites dataset' bucket."""
+    if citation.get("discovery_method") == "accession_mention":
+        return True
+    if citation.get("mentions_accession"):
+        return True
+    return citation.get("source_relation") in _DATASET_RELATIONS
+
+
+def merge_accession_mentions(
+    citation_json: dict[str, Any],
+    mentions: list[dict[str, Any]],
+    searched_accessions: list[str],
+) -> dict[str, Any]:
+    """Fold accession `mentions` into `citation_json` (mutated and returned).
+
+    - A mention whose paper is already a citation flags that existing entry
+      (`mentions_accession=True` + `matched_accession`) so a paper that both
+      cites the data paper and names the accession lands in BOTH buckets. An
+      existing accession-mention entry is left untouched (idempotent).
+    - A mention not already present is appended.
+    - When new mentions are appended, the stale top-level `confidence_scoring`
+      block is dropped so the downstream score step (its `--skip-existing`
+      skips files that already carry the block) re-scores the dataset.
+    - `num_citations` is recomputed; `metadata` records the searched accessions
+      and the per-bucket breakdown.
+
+    All counts derive from the final state (not deltas), so a re-run with the
+    same mentions produces byte-identical output.
+    """
+    details: list[dict[str, Any]] = citation_json.setdefault("citation_details", [])
+    by_key: dict[str, dict[str, Any]] = {}
+    for citation in details:
+        key = _key(citation)
+        if key:
+            by_key.setdefault(key, citation)
+
+    appended = 0
+    for mention in mentions:
+        key = _key(mention)
+        if not key:
+            continue
+        existing = by_key.get(key)
+        if existing is None:
+            details.append(mention)
+            by_key[key] = mention
+            appended += 1
+        elif existing.get("discovery_method") != "accession_mention":
+            # Anchor citation that also names the accession -> flag for both
+            # buckets (no-op if already flagged, keeping re-runs idempotent).
+            existing["mentions_accession"] = True
+            existing.setdefault("matched_accession", mention.get("matched_accession"))
+
+    if appended:
+        citation_json.pop("confidence_scoring", None)
+
+    citation_json["num_citations"] = len(details)
+    meta = citation_json.setdefault("metadata", {})
+    meta["searched_accessions"] = list(searched_accessions)
+    meta["num_accession_mentions"] = sum(
+        1 for c in details if c.get("discovery_method") == "accession_mention"
+    )
+    meta["num_anchor_citations"] = sum(
+        1 for c in details if c.get("discovery_method") != "accession_mention"
+    )
+    return citation_json

--- a/src/dataset_citations/core/accession_mentions.py
+++ b/src/dataset_citations/core/accession_mentions.py
@@ -21,13 +21,20 @@ from typing import Any
 _DATASET_RELATIONS = frozenset({"IsVersionOf", "IsIdenticalTo"})
 
 
-def _key(citation: dict[str, Any]) -> str:
-    """Dedup key: DOI, else OpenAlex id, else title (all lowercased)."""
-    for field in ("doi", "openalex_id", "title"):
+def _ids(citation: dict[str, Any]) -> list[str]:
+    """Strong identifiers (DOI + OpenAlex id, lowercased) for dedup matching."""
+    out: list[str] = []
+    for field in ("doi", "openalex_id"):
         value = citation.get(field)
         if value:
-            return str(value).strip().lower()
-    return ""
+            out.append(str(value).strip().lower())
+    return out
+
+
+def _title_key(citation: dict[str, Any]) -> str:
+    """Lowercased title, used as a dedup fallback only when no strong ids exist."""
+    title = citation.get("title")
+    return str(title).strip().lower() if title else ""
 
 
 def cites_dataset(citation: dict[str, Any]) -> bool:
@@ -61,21 +68,39 @@ def merge_accession_mentions(
     same mentions produces byte-identical output.
     """
     details: list[dict[str, Any]] = citation_json.setdefault("citation_details", [])
-    by_key: dict[str, dict[str, Any]] = {}
+    # Index existing citations by EVERY strong identifier (DOI and OpenAlex id),
+    # plus title as a fallback, so a mention is recognised as a duplicate when it
+    # shares ANY identifier with an existing citation -- not just the first one.
+    # This is what prevents double-counting a paper found by both the anchor and
+    # accession-mention paths when the two copies don't carry the same id set.
+    by_id: dict[str, dict[str, Any]] = {}
+    by_title: dict[str, dict[str, Any]] = {}
     for citation in details:
-        key = _key(citation)
-        if key:
-            by_key.setdefault(key, citation)
+        for ident in _ids(citation):
+            by_id.setdefault(ident, citation)
+        title = _title_key(citation)
+        if title:
+            by_title.setdefault(title, citation)
+
+    def _register(citation: dict[str, Any]) -> None:
+        for ident in _ids(citation):
+            by_id.setdefault(ident, citation)
+        title = _title_key(citation)
+        if title:
+            by_title.setdefault(title, citation)
 
     appended = 0
     for mention in mentions:
-        key = _key(mention)
-        if not key:
-            continue
-        existing = by_key.get(key)
+        mention_ids = _ids(mention)
+        existing = next((by_id[i] for i in mention_ids if i in by_id), None)
+        if existing is None and not mention_ids:
+            # No DOI / OpenAlex id to match on; fall back to exact title.
+            existing = by_title.get(_title_key(mention))
         if existing is None:
+            if not mention_ids and not _title_key(mention):
+                continue  # nothing to dedup or display by; drop it
             details.append(mention)
-            by_key[key] = mention
+            _register(mention)
             appended += 1
         elif existing.get("discovery_method") != "accession_mention":
             # Anchor citation that also names the accession -> flag for both

--- a/src/dataset_citations/core/citation_utils.py
+++ b/src/dataset_citations/core/citation_utils.py
@@ -59,6 +59,35 @@ def strip_volatile_timestamps(payload: Dict[str, Any]) -> Dict[str, Any]:
     return clone
 
 
+def write_citation_json_if_changed(filepath: str, payload: Dict[str, Any]) -> bool:
+    """Write `payload` as pretty JSON unless only volatile timestamps differ.
+
+    Compares against the file already on disk after stripping volatile
+    timestamps; when the substantive content matches, the existing file is left
+    byte-for-byte untouched so the nightly pipeline emits no spurious diff
+    (issue #165).
+
+    Returns:
+        True if the file was written, False if left unchanged.
+
+    Raises:
+        OSError: If the file exists but cannot be written.
+    """
+    if os.path.isfile(filepath):
+        try:
+            with open(filepath, encoding="utf-8") as f:
+                existing = json.load(f)
+        except (OSError, json.JSONDecodeError):
+            existing = None
+        if isinstance(existing, dict) and strip_volatile_timestamps(
+            existing
+        ) == strip_volatile_timestamps(payload):
+            return False
+    with open(filepath, "w", encoding="utf-8") as f:
+        json.dump(payload, f, indent=2, ensure_ascii=False)
+    return True
+
+
 def create_citation_json_structure(
     dataset_id: str, citations_df: pd.DataFrame, fetch_date: Optional[datetime] = None
 ) -> Dict[str, Any]:

--- a/src/dataset_citations/sources/accession.py
+++ b/src/dataset_citations/sources/accession.py
@@ -1,0 +1,47 @@
+"""Derive the accession strings to search for dataset-mention citations.
+
+People rarely cite a dataset's DOI (OpenNeuro / NEMAR DOIs aren't indexed in
+OpenAlex); they mention the **accession number** in their methods / data-
+availability text, e.g. "ds002718", "on005964", "nm000207". For NEMAR-imported
+OpenNeuro datasets the OpenNeuro `ds-` number (carried in the catalog
+`source_id`) is the one that actually appears in the literature, so it must be
+searched in addition to the `on-` id.
+
+This module is pure: no network, no I/O. The caller feeds the catalog
+`dataset_id` + `source_id` and gets back the validated, de-duplicated set of
+accession tokens to hand to OpenAlex `fulltext.search`.
+"""
+
+from __future__ import annotations
+
+import re
+
+# A well-formed OpenNeuro / NEMAR accession: ds/on/nm followed by exactly six
+# digits. Anchoring on this avoids searching free-text noise (a stray "ds1" in
+# a paper would match far too much).
+_ACCESSION_RE = re.compile(r"^(?:ds|on|nm)\d{6}$")
+
+
+def accession_search_terms(dataset_id: str, source_id: str | None = None) -> list[str]:
+    """Return the validated accession tokens to full-text search for a dataset.
+
+    Includes the dataset's own id and, when present and distinct, its catalog
+    `source_id` (the OpenNeuro `ds-` number for `on-*` datasets). Order is
+    stable (dataset_id first) and duplicates are removed; malformed inputs are
+    dropped rather than searched.
+
+    Args:
+        dataset_id: The catalog dataset id (e.g. "on005964", "ds002718").
+        source_id: The catalog source id, if any (e.g. "ds005964").
+
+    Returns:
+        De-duplicated list of lowercase accession tokens (possibly empty).
+    """
+    terms: list[str] = []
+    for candidate in (dataset_id, source_id):
+        if not candidate:
+            continue
+        token = candidate.strip().lower()
+        if _ACCESSION_RE.match(token) and token not in terms:
+            terms.append(token)
+    return terms

--- a/tests/test_accession_mentions.py
+++ b/tests/test_accession_mentions.py
@@ -1,0 +1,116 @@
+"""Tests for accession-mention merge + bucket logic (pure, no network). Issue #169."""
+
+from __future__ import annotations
+
+import copy
+from unittest import TestCase
+
+from dataset_citations.core.accession_mentions import (
+    cites_dataset,
+    merge_accession_mentions,
+)
+
+
+def _anchor(doi: str, relation: str = "References") -> dict:
+    return {
+        "title": f"Anchor {doi}",
+        "doi": doi,
+        "openalex_id": None,
+        "source_doi": "10.0/anchor",
+        "source_relation": relation,
+        "discovery_backend": "opencite",
+    }
+
+
+def _mention(doi: str, accession: str = "ds002718") -> dict:
+    return {
+        "title": f"Mention {doi}",
+        "doi": doi,
+        "openalex_id": None,
+        "source_doi": None,
+        "source_relation": None,
+        "discovery_backend": "openalex",
+        "discovery_method": "accession_mention",
+        "matched_accession": accession,
+    }
+
+
+def _base(details: list[dict]) -> dict:
+    return {
+        "dataset_id": "ds002718",
+        "num_citations": len(details),
+        "date_last_updated": "2026-06-18T00:00:00+00:00",
+        "metadata": {"fetch_status": "success"},
+        "citation_details": list(details),
+    }
+
+
+class CitesDatasetBucketTests(TestCase):
+    def test_accession_mention_is_dataset(self) -> None:
+        self.assertTrue(cites_dataset(_mention("10.1/a")))
+
+    def test_isversionof_anchor_is_dataset(self) -> None:
+        self.assertTrue(cites_dataset(_anchor("10.1/a", "IsVersionOf")))
+
+    def test_isidenticalto_anchor_is_dataset(self) -> None:
+        self.assertTrue(cites_dataset(_anchor("10.1/a", "IsIdenticalTo")))
+
+    def test_references_anchor_is_data_paper(self) -> None:
+        self.assertFalse(cites_dataset(_anchor("10.1/a", "References")))
+
+    def test_isderivedfrom_anchor_is_data_paper(self) -> None:
+        self.assertFalse(cites_dataset(_anchor("10.1/a", "IsDerivedFrom")))
+
+    def test_anchor_flagged_with_mention_is_dataset(self) -> None:
+        a = _anchor("10.1/a", "References")
+        a["mentions_accession"] = True
+        self.assertTrue(cites_dataset(a))
+
+
+class MergeAccessionMentionsTests(TestCase):
+    def test_appends_new_mention(self) -> None:
+        cj = _base([_anchor("10.1/anchor")])
+        merged = merge_accession_mentions(cj, [_mention("10.2/new")], ["ds002718"])
+        self.assertEqual(merged["num_citations"], 2)
+        dois = {c["doi"] for c in merged["citation_details"]}
+        self.assertIn("10.2/new", dois)
+        self.assertEqual(merged["metadata"]["num_accession_mentions"], 1)
+        self.assertEqual(merged["metadata"]["num_anchor_citations"], 1)
+        self.assertEqual(merged["metadata"]["searched_accessions"], ["ds002718"])
+
+    def test_flags_existing_anchor_that_also_mentions(self) -> None:
+        cj = _base([_anchor("10.1/both", "References")])
+        merged = merge_accession_mentions(cj, [_mention("10.1/both")], ["ds002718"])
+        # No new entry; the anchor is flagged so it lands in both buckets.
+        self.assertEqual(merged["num_citations"], 1)
+        anchor = merged["citation_details"][0]
+        self.assertTrue(anchor["mentions_accession"])
+        self.assertEqual(anchor["matched_accession"], "ds002718")
+        self.assertTrue(cites_dataset(anchor))
+
+    def test_dedupes_by_doi_case_insensitive(self) -> None:
+        cj = _base([_anchor("10.1/Anchor")])
+        merged = merge_accession_mentions(cj, [_mention("10.1/anchor")], ["ds002718"])
+        self.assertEqual(merged["num_citations"], 1)  # same paper, different case
+
+    def test_drops_confidence_scoring_when_new_mention_appended(self) -> None:
+        cj = _base([_anchor("10.1/anchor")])
+        cj["confidence_scoring"] = {"model_used": "m", "scoring_date": "x"}
+        merged = merge_accession_mentions(cj, [_mention("10.2/new")], ["ds002718"])
+        # New citation needs scoring; stale block dropped so score re-runs.
+        self.assertNotIn("confidence_scoring", merged)
+
+    def test_keeps_confidence_scoring_when_nothing_appended(self) -> None:
+        cj = _base([_anchor("10.1/anchor")])
+        cj["confidence_scoring"] = {"model_used": "m", "scoring_date": "x"}
+        merge_accession_mentions(cj, [], ["ds002718"])
+        self.assertIn("confidence_scoring", cj)
+
+    def test_idempotent_on_rerun(self) -> None:
+        cj = _base([_anchor("10.1/anchor", "References")])
+        mentions = [_mention("10.2/new"), _mention("10.1/anchor")]
+        first = merge_accession_mentions(cj, mentions, ["ds002718"])
+        snapshot = copy.deepcopy(first)
+        # Feed the same mentions back into the already-merged json.
+        second = merge_accession_mentions(first, mentions, ["ds002718"])
+        self.assertEqual(second, snapshot)

--- a/tests/test_accession_mentions.py
+++ b/tests/test_accession_mentions.py
@@ -22,7 +22,7 @@ def _anchor(doi: str, relation: str = "References") -> dict:
     }
 
 
-def _mention(doi: str, accession: str = "ds002718") -> dict:
+def _mention(doi: str | None, accession: str = "ds002718") -> dict:
     return {
         "title": f"Mention {doi}",
         "doi": doi,
@@ -92,6 +92,31 @@ class MergeAccessionMentionsTests(TestCase):
         cj = _base([_anchor("10.1/Anchor")])
         merged = merge_accession_mentions(cj, [_mention("10.1/anchor")], ["ds002718"])
         self.assertEqual(merged["num_citations"], 1)  # same paper, different case
+
+    def test_dedupes_on_openalex_id_when_doi_set_differs(self) -> None:
+        # Anchor carries only a DOI; the mention copy of the SAME paper carries
+        # only an OpenAlex id plus a (different) DOI. They must still dedup via
+        # the shared OpenAlex id rather than double-count.
+        anchor = _anchor("10.1/paper", "References")
+        anchor["openalex_id"] = "W123"
+        anchor["doi"] = None  # anchor has no DOI here, only the OpenAlex id
+        mention = _mention("10.1/paper")
+        mention["openalex_id"] = "W123"
+        mention["doi"] = None
+        merged = merge_accession_mentions(_base([anchor]), [mention], ["ds002718"])
+        self.assertEqual(merged["num_citations"], 1)
+        self.assertTrue(merged["citation_details"][0]["mentions_accession"])
+
+    def test_dedupes_cross_identifier_doi_vs_openalex(self) -> None:
+        # Anchor matched by DOI only; mention matched by OpenAlex id only; same
+        # paper -> one entry.
+        anchor = _anchor("10.1/paper", "References")
+        anchor["openalex_id"] = "W999"
+        mention = _mention(None)  # no DOI on the mention
+        mention["openalex_id"] = "W999"
+        merged = merge_accession_mentions(_base([anchor]), [mention], ["ds002718"])
+        self.assertEqual(merged["num_citations"], 1)
+        self.assertTrue(merged["citation_details"][0]["mentions_accession"])
 
     def test_drops_confidence_scoring_when_new_mention_appended(self) -> None:
         cj = _base([_anchor("10.1/anchor")])

--- a/tests/test_accession_mentions.py
+++ b/tests/test_accession_mentions.py
@@ -74,9 +74,12 @@ class MergeAccessionMentionsTests(TestCase):
         self.assertEqual(merged["num_citations"], 2)
         dois = {c["doi"] for c in merged["citation_details"]}
         self.assertIn("10.2/new", dois)
-        self.assertEqual(merged["metadata"]["num_accession_mentions"], 1)
-        self.assertEqual(merged["metadata"]["num_anchor_citations"], 1)
-        self.assertEqual(merged["metadata"]["searched_accessions"], ["ds002718"])
+        meta = merged["metadata"]
+        self.assertEqual(meta["num_accession_mentions"], 1)
+        # 1 References anchor (data paper) + 1 accession mention (dataset).
+        self.assertEqual(meta["num_dataset_citations"], 1)
+        self.assertEqual(meta["num_datapaper_citations"], 1)
+        self.assertEqual(meta["searched_accessions"], ["ds002718"])
 
     def test_flags_existing_anchor_that_also_mentions(self) -> None:
         cj = _base([_anchor("10.1/both", "References")])
@@ -139,3 +142,17 @@ class MergeAccessionMentionsTests(TestCase):
         # Feed the same mentions back into the already-merged json.
         second = merge_accession_mentions(first, mentions, ["ds002718"])
         self.assertEqual(second, snapshot)
+
+    def test_existing_entry_with_no_identifier_is_left_alone(self) -> None:
+        # A legacy entry with no doi/openalex_id/title can't be deduped against;
+        # a real mention is still appended (no phantom, no corruption).
+        empty = {"venue": "n/a", "source_relation": "References"}
+        cj = _base([empty])
+        merged = merge_accession_mentions(cj, [_mention("10.2/new")], ["ds002718"])
+        self.assertEqual(merged["num_citations"], 2)
+
+    def test_mention_with_no_identifier_is_dropped(self) -> None:
+        cj = _base([_anchor("10.1/anchor")])
+        empty_mention = {"discovery_method": "accession_mention", "venue": "n/a"}
+        merged = merge_accession_mentions(cj, [empty_mention], ["ds002718"])
+        self.assertEqual(merged["num_citations"], 1)  # nothing to dedup/display by

--- a/tests/test_accession_search.py
+++ b/tests/test_accession_search.py
@@ -12,6 +12,7 @@ import unittest
 from unittest import TestCase
 
 from dataset_citations.backends.accession_search import (
+    dedup_citations,
     reconstruct_abstract,
     work_to_citation,
 )
@@ -82,6 +83,34 @@ class WorkToCitationTests(TestCase):
         self.assertEqual(c["year"], 0)
         self.assertIsNone(c["doi"])
         self.assertIsNone(c["abstract"])
+
+
+class DedupCitationsTests(TestCase):
+    """Cross-term dedup: a paper matching both the on- and ds- accession of the
+    same dataset must appear once (the key correctness contract for on-*)."""
+
+    def _hit(self, doi: str, oaid: str, title: str = "t") -> dict:
+        return {"doi": doi, "openalex_id": oaid, "title": title}
+
+    def test_paper_in_two_terms_appears_once(self) -> None:
+        on_hits = [self._hit("10.1/p1", "W1"), self._hit("10.1/p2", "W2")]
+        ds_hits = [self._hit("10.1/p2", "W2"), self._hit("10.1/p3", "W3")]
+        result = dedup_citations([on_hits, ds_hits])
+        self.assertEqual([c["doi"] for c in result], ["10.1/p1", "10.1/p2", "10.1/p3"])
+
+    def test_stable_sort_independent_of_input_order(self) -> None:
+        a = [self._hit("10.1/c", "W3"), self._hit("10.1/a", "W1")]
+        b = [self._hit("10.1/b", "W2")]
+        self.assertEqual(
+            [c["doi"] for c in dedup_citations([a, b])],
+            [c["doi"] for c in dedup_citations([b, a])],
+        )
+
+    def test_dedupes_case_insensitive_doi(self) -> None:
+        result = dedup_citations(
+            [[self._hit("10.1/X", "W1")], [self._hit("10.1/x", "W9")]]
+        )
+        self.assertEqual(len(result), 1)
 
 
 @unittest.skipUnless(

--- a/tests/test_accession_search.py
+++ b/tests/test_accession_search.py
@@ -1,0 +1,98 @@
+"""Tests for the OpenAlex accession-search backend mappers. Issue #169.
+
+The pure mappers (work_to_citation, reconstruct_abstract) are tested against a
+realistic OpenAlex work JSON, no network. The live search is covered by a
+gated integration test (RUN_INTEGRATION_TESTS=1).
+"""
+
+from __future__ import annotations
+
+import os
+import unittest
+from unittest import TestCase
+
+from dataset_citations.backends.accession_search import (
+    reconstruct_abstract,
+    work_to_citation,
+)
+
+# Trimmed but real-shaped OpenAlex /works result.
+_WORK = {
+    "id": "https://openalex.org/W3035020590",
+    "doi": "https://doi.org/10.3389/fnins.2020.610388",
+    "title": "From BIDS-Formatted EEG Data to Sensor-Space Group Results",
+    "publication_year": 2020,
+    "cited_by_count": 42,
+    "ids": {"pmid": "https://pubmed.ncbi.nlm.nih.gov/33390894"},
+    "authorships": [
+        {"author": {"display_name": "Cyril Pernet"}},
+        {"author": {"display_name": "Marijn van Vliet"}},
+    ],
+    "primary_location": {"source": {"display_name": "Frontiers in Neuroscience"}},
+    "abstract_inverted_index": {"We": [0], "used": [1], "ds002718": [2]},
+}
+
+
+class ReconstructAbstractTests(TestCase):
+    def test_rebuilds_word_order(self) -> None:
+        self.assertEqual(
+            reconstruct_abstract({"hello": [1], "world": [2], "say": [0]}),
+            "say hello world",
+        )
+
+    def test_none_and_empty(self) -> None:
+        self.assertIsNone(reconstruct_abstract(None))
+        self.assertIsNone(reconstruct_abstract({}))
+
+
+class WorkToCitationTests(TestCase):
+    def setUp(self) -> None:
+        self.c = work_to_citation(_WORK, "ds002718")
+
+    def test_bare_doi_lowercased(self) -> None:
+        self.assertEqual(self.c["doi"], "10.3389/fnins.2020.610388")
+
+    def test_openalex_id_shortened(self) -> None:
+        self.assertEqual(self.c["openalex_id"], "W3035020590")
+
+    def test_pmid_shortened(self) -> None:
+        self.assertEqual(self.c["pmid"], "33390894")
+
+    def test_authors_joined(self) -> None:
+        self.assertEqual(self.c["author"], "Cyril Pernet, Marijn van Vliet")
+
+    def test_venue_and_year_and_cited_by(self) -> None:
+        self.assertEqual(self.c["venue"], "Frontiers in Neuroscience")
+        self.assertEqual(self.c["year"], 2020)
+        self.assertEqual(self.c["cited_by"], 42)
+
+    def test_abstract_reconstructed(self) -> None:
+        self.assertEqual(self.c["abstract"], "We used ds002718")
+
+    def test_tagged_as_accession_mention(self) -> None:
+        self.assertEqual(self.c["discovery_method"], "accession_mention")
+        self.assertEqual(self.c["matched_accession"], "ds002718")
+        self.assertIsNone(self.c["source_doi"])
+        self.assertIsNone(self.c["source_relation"])
+
+    def test_missing_fields_default_safely(self) -> None:
+        c = work_to_citation({"title": "bare"}, "nm000001")
+        self.assertEqual(c["author"], "n/a")
+        self.assertEqual(c["venue"], "n/a")
+        self.assertEqual(c["year"], 0)
+        self.assertIsNone(c["doi"])
+        self.assertIsNone(c["abstract"])
+
+
+@unittest.skipUnless(
+    os.environ.get("RUN_INTEGRATION_TESTS") == "1",
+    "live OpenAlex call; set RUN_INTEGRATION_TESTS=1 to enable",
+)
+class LiveAccessionSearchTests(TestCase):
+    def test_finds_known_accession(self) -> None:
+        from dataset_citations.backends.accession_search import AccessionSearchBackend
+
+        results = AccessionSearchBackend(max_results=5).search(["ds002718"])
+        self.assertGreater(len(results), 0)
+        for c in results:
+            self.assertEqual(c["discovery_method"], "accession_mention")

--- a/tests/test_citation_utils.py
+++ b/tests/test_citation_utils.py
@@ -368,5 +368,62 @@ class TestStripVolatileTimestamps(unittest.TestCase):
         self.assertEqual(stripped, {"dataset_id": "x"})
 
 
+class TestWriteCitationJsonIfChanged(unittest.TestCase):
+    """write_citation_json_if_changed underpins the #165 idempotency guarantee."""
+
+    def _payload(self, *, date: str, num: int = 1) -> dict:
+        return {
+            "dataset_id": "ds000001",
+            "num_citations": num,
+            "date_last_updated": date,
+            "metadata": {"fetch_date": date, "fetch_status": "success"},
+            "citation_details": [],
+        }
+
+    def test_creates_new_file(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, "ds000001_citations.json")
+            wrote = citation_utils.write_citation_json_if_changed(
+                path, self._payload(date="2026-06-18T00:00:00+00:00")
+            )
+            self.assertTrue(wrote)
+            self.assertTrue(os.path.isfile(path))
+
+    def test_no_op_when_only_timestamps_differ(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, "ds000001_citations.json")
+            citation_utils.write_citation_json_if_changed(
+                path, self._payload(date="2026-06-14T00:00:00+00:00")
+            )
+            before = Path(path).read_text()
+            wrote = citation_utils.write_citation_json_if_changed(
+                path, self._payload(date="2026-06-18T00:00:00+00:00")
+            )
+            self.assertFalse(wrote)
+            self.assertEqual(Path(path).read_text(), before)  # old timestamp kept
+
+    def test_rewrites_on_substantive_change(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, "ds000001_citations.json")
+            citation_utils.write_citation_json_if_changed(
+                path, self._payload(date="2026-06-14T00:00:00+00:00", num=1)
+            )
+            wrote = citation_utils.write_citation_json_if_changed(
+                path, self._payload(date="2026-06-14T00:00:00+00:00", num=2)
+            )
+            self.assertTrue(wrote)
+            self.assertEqual(json.loads(Path(path).read_text())["num_citations"], 2)
+
+    def test_rewrites_when_existing_file_is_corrupt(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, "ds000001_citations.json")
+            Path(path).write_text("not json at all")
+            wrote = citation_utils.write_citation_json_if_changed(
+                path, self._payload(date="2026-06-18T00:00:00+00:00")
+            )
+            self.assertTrue(wrote)
+            self.assertEqual(json.loads(Path(path).read_text())["num_citations"], 1)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_cli_find_mentions.py
+++ b/tests/test_cli_find_mentions.py
@@ -1,0 +1,136 @@
+"""Tests for run_find_mentions orchestration. Issue #169.
+
+No network, no Mocks: an empty catalog cache file short-circuits the catalog
+fetch, and a real substitute backend (`_FakeBackend`) returns canned mentions in
+place of OpenAlex. Real files on disk.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import stat
+import tempfile
+from pathlib import Path
+from unittest import TestCase
+
+from dataset_citations.cli import find_mentions as cli
+
+
+class _FakeBackend:
+    """Real substitute for AccessionSearchBackend (no network)."""
+
+    def __init__(self, *args: object, **kwargs: object) -> None:
+        pass
+
+    def search(self, terms: list[str]) -> list[dict]:
+        return []
+
+
+def _args(
+    citations_dir: Path,
+    *,
+    dataset_list_file: str | None = None,
+    max_results: int = 0,
+) -> argparse.Namespace:
+    cache = citations_dir.parent / "catalog.json"
+    cache.write_text("[]")  # empty catalog -> _load_source_id_map hits no network
+    return argparse.Namespace(
+        citations_dir=str(citations_dir),
+        dataset_list_file=dataset_list_file,
+        catalog_cache=cache,
+        catalog_cache_max_age=3600,
+        max_results=max_results,
+    )
+
+
+def _seed(citations_dir: Path, dataset_id: str) -> Path:
+    citations_dir.mkdir(parents=True, exist_ok=True)
+    path = citations_dir / f"{dataset_id}_citations.json"
+    path.write_text(
+        json.dumps(
+            {
+                "dataset_id": dataset_id,
+                "num_citations": 0,
+                "date_last_updated": "2026-06-18T00:00:00+00:00",
+                "metadata": {"fetch_status": "success"},
+                "citation_details": [],
+            },
+            indent=2,
+        )
+    )
+    return path
+
+
+class RunFindMentionsTests(TestCase):
+    def setUp(self) -> None:
+        self._orig_backend = cli.AccessionSearchBackend
+        cli.AccessionSearchBackend = _FakeBackend  # type: ignore[misc,assignment]
+
+    def tearDown(self) -> None:
+        cli.AccessionSearchBackend = self._orig_backend  # type: ignore[misc]
+
+    def test_processes_valid_datasets_via_glob(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            cdir = Path(tmp) / "json_opencite"
+            _seed(cdir, "ds002718")
+            _seed(cdir, "nm000207")
+            cli.run_find_mentions(_args(cdir))
+            # Processed datasets gain the searched_accessions marker.
+            for did, acc in (("ds002718", "ds002718"), ("nm000207", "nm000207")):
+                data = json.loads((cdir / f"{did}_citations.json").read_text())
+                self.assertEqual(data["metadata"]["searched_accessions"], [acc])
+
+    def test_dataset_list_file_branch(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            cdir = Path(tmp) / "json_opencite"
+            _seed(cdir, "ds002718")
+            _seed(cdir, "ds000247")  # present but NOT in the list -> untouched
+            list_file = Path(tmp) / "list.txt"
+            list_file.write_text("ds002718\n")
+            cli.run_find_mentions(_args(cdir, dataset_list_file=str(list_file)))
+            listed = json.loads((cdir / "ds002718_citations.json").read_text())
+            self.assertIn("searched_accessions", listed["metadata"])
+            unlisted = json.loads((cdir / "ds000247_citations.json").read_text())
+            self.assertNotIn("searched_accessions", unlisted["metadata"])
+
+    def test_skips_missing_json(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            cdir = Path(tmp) / "json_opencite"
+            cdir.mkdir(parents=True)
+            list_file = Path(tmp) / "list.txt"
+            list_file.write_text("ds999999\n")  # no JSON on disk
+            # Should return normally (nothing processed), no exit.
+            cli.run_find_mentions(_args(cdir, dataset_list_file=str(list_file)))
+            self.assertFalse((cdir / "ds999999_citations.json").exists())
+
+    def test_skips_dataset_with_no_valid_accession(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            cdir = Path(tmp) / "json_opencite"
+            _seed(cdir, "experiment-1")  # fails the accession regex
+            cli.run_find_mentions(_args(cdir))
+            data = json.loads((cdir / "experiment-1_citations.json").read_text())
+            # Skipped before merge -> no marker written.
+            self.assertNotIn("searched_accessions", data["metadata"])
+
+    def test_all_writes_fail_exits_2(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            cdir = Path(tmp) / "json_opencite"
+            path = _seed(cdir, "ds002718")
+            os.chmod(path, stat.S_IRUSR)  # read-only file -> open('w') raises
+            try:
+                with self.assertRaises(SystemExit) as ctx:
+                    cli.run_find_mentions(_args(cdir))
+                self.assertEqual(ctx.exception.code, 2)
+            finally:
+                os.chmod(path, stat.S_IRWXU)
+
+    def test_idempotent_second_run_leaves_file_unchanged(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            cdir = Path(tmp) / "json_opencite"
+            path = _seed(cdir, "ds002718")
+            cli.run_find_mentions(_args(cdir))
+            after_first = path.read_text()
+            cli.run_find_mentions(_args(cdir))
+            self.assertEqual(path.read_text(), after_first)

--- a/tests/test_sources_accession.py
+++ b/tests/test_sources_accession.py
@@ -1,0 +1,41 @@
+"""Tests for accession-term derivation (no network, pure function). Issue #169."""
+
+from __future__ import annotations
+
+from unittest import TestCase
+
+from dataset_citations.sources.accession import accession_search_terms
+
+
+class AccessionSearchTermsTests(TestCase):
+    def test_legacy_ds_returns_single_term(self) -> None:
+        self.assertEqual(accession_search_terms("ds002718"), ["ds002718"])
+
+    def test_on_dataset_includes_openneuro_ds_alias(self) -> None:
+        # on-* carries its OpenNeuro ds-number in source_id; people cite the ds.
+        self.assertEqual(
+            accession_search_terms("on005964", "ds005964"),
+            ["on005964", "ds005964"],
+        )
+
+    def test_nm_dataset(self) -> None:
+        self.assertEqual(accession_search_terms("nm000207"), ["nm000207"])
+
+    def test_dedupes_when_source_id_equals_dataset_id(self) -> None:
+        self.assertEqual(accession_search_terms("ds002718", "ds002718"), ["ds002718"])
+
+    def test_case_insensitive_and_stripped(self) -> None:
+        self.assertEqual(accession_search_terms(" DS002718 "), ["ds002718"])
+
+    def test_malformed_inputs_dropped(self) -> None:
+        # Wrong prefix, wrong digit count, empty, or None are not searched.
+        self.assertEqual(accession_search_terms("dataset-1"), [])
+        self.assertEqual(accession_search_terms("ds123"), [])
+        self.assertEqual(accession_search_terms("ds0027180"), [])
+        self.assertEqual(accession_search_terms(""), [])
+        self.assertEqual(accession_search_terms("on005964", None), ["on005964"])
+
+    def test_malformed_source_id_dropped_keeps_valid_dataset_id(self) -> None:
+        self.assertEqual(
+            accession_search_terms("nm000207", "not-an-accession"), ["nm000207"]
+        )


### PR DESCRIPTION
Part of #169 (Phase 2a: discovery backend; the UI toggle is Phase 2b, follow-up).

## Why
People cite datasets by **accession number** in running text (`ds002718`, `on005964`, `nm000207`), not by DOI, and OpenNeuro/NEMAR DOIs aren't indexed in OpenAlex. So the DOI-anchored pipeline finds essentially **no** "cites dataset" citations. This automates the maintainer's old manual workflow (search the accession, keep high-confidence hits) via OpenAlex `fulltext.search`.

## What
- **`sources/accession.py`** - derive validated accession search terms: the `dataset_id` plus the OpenNeuro `ds-` alias carried in the catalog `source_id` for `on-*` datasets (the number people actually cite). Strict `^(ds|on|nm)\d{6}$` so we don't search noise.
- **`backends/accession_search.py`** - reuse opencite's `OpenAlexClient` (no new HTTP dep) to `fulltext.search` each term; map works to the existing citation-detail shape (abstract rebuilt from the inverted index), tagged `discovery_method="accession_mention"`. Deduped + stably sorted for idempotency.
- **`core/accession_mentions.py`** - merge into `citation_details[]`: append new mentions, flag anchor citations that *also* mention the accession (so they land in both buckets), recompute `num_citations`, record `metadata.{searched_accessions,num_accession_mentions,num_anchor_citations}`. Drops the stale `confidence_scoring` block when new mentions are added so the score step (`--skip-existing`) re-scores. Deterministic -> content-idempotent (#165).
- **`cli/find_mentions.py`** + `dataset-citations-find-mentions`, wired into the hallu cron **between `update` and `score-confidence`**.
- `core/citation_utils.write_citation_json_if_changed` helper (idempotent write).

## Bucket definition (for Phase 2b)
"cites dataset" = `discovery_method=accession_mention` OR `mentions_accession` OR `source_relation in {IsVersionOf, IsIdenticalTo}`; everything else (`References`/`IsDerivedFrom`) = "cites data paper". Exposed as `core.accession_mentions.cites_dataset`.

## Tests (real data, no mocks)
- Pure unit tests: accession-term derivation; `work_to_citation` + abstract reconstruction; merge append/flag/dedup/idempotency/confidence-drop/counts; `cites_dataset` bucketing.
- **Live OpenAlex integration test** (gated `RUN_INTEGRATION_TESTS=1`).
- Manual real-data run: ds000246/247/248 (0 anchors) gained 1-3 mentions each; ds000117 -> **53** mentions incl. its data paper; re-run idempotent (0 updated).

## Note for review
`num_citations` now includes accession mentions (deduped), so per-dataset totals will rise for datasets with accession mentions. Bucket counts are in `metadata`. If you'd rather keep `num_citations` anchor-only, it's a one-line change, flagging for a decision.

`ruff` clean, `ty` clean on new files, full suite green.
