### PR TITLE
fix: reuse cached datasets/ for ds-* DOI extraction (#174)

### DIFF
--- a/scripts/hallu_cron_pipeline.sh
+++ b/scripts/hallu_cron_pipeline.sh
@@ -130,10 +130,14 @@ uv run dataset-citations-judge-anchors \
 # new judgments immediately, manually re-run `dataset-citations-update`
 # with `--max-age-days 0` once, then resume the normal weekly cron.
 echo "--- update (skip-existing default 7d) ---"
+# --datasets-dir lets ds-* DOI extraction reuse the dataset_description cached
+# by retrieve-metadata above instead of refetching it from GitHub, which on a
+# cold .fetch_state.json would otherwise exhaust the GitHub rate limit (#174).
 OPENCITE_CONCURRENCY=4 \
   uv run dataset-citations-update \
     --dataset-list-file "$DATASETS_LIST" \
-    --output-dir citations/ || {
+    --output-dir citations/ \
+    --datasets-dir datasets || {
   echo "ERROR: dataset-citations-update failed; aborting before score." >&2
   exit 2
 }

--- a/src/dataset_citations/cli/update.py
+++ b/src/dataset_citations/cli/update.py
@@ -245,6 +245,7 @@ def run_opencite_backend(args: argparse.Namespace) -> None:
             backend=backend,
             catalog_doi=catalog_dois.get(dataset_id),
             use_checkpoint=True,
+            local_metadata_dir=args.datasets_dir,
         )
         # Content-idempotent write. The opencite payload never carries the
         # confidence_scoring block (the separate score step adds it), so we
@@ -329,6 +330,16 @@ def main():
         "--output-dir",
         default="citations",
         help="Directory to save output files (default: citations/).",
+    )
+    parser.add_argument(
+        "--datasets-dir",
+        default="datasets",
+        help=(
+            "Directory of retrieve-metadata output (<id>_datasets.json). When a "
+            "ds-* dataset's cached dataset_description is present here, DOI "
+            "extraction parses it instead of refetching from GitHub, avoiding "
+            "the cold-start GitHub rate limit (issue #174). Default: datasets/."
+        ),
     )
     parser.add_argument(
         "--catalog-cache",

--- a/src/dataset_citations/cli/update.py
+++ b/src/dataset_citations/cli/update.py
@@ -195,6 +195,17 @@ def run_opencite_backend(args: argparse.Namespace) -> None:
         concurrency = 4
     backend = OpenCiteBackend(concurrency=concurrency)
 
+    # A missing datasets-dir means every ds-* dataset silently falls back to a
+    # live GitHub fetch for DOI extraction -- the cold-start rate-limit storm
+    # #174 fixes. Surface it loudly rather than let a misconfigured path stall
+    # the run invisibly.
+    if not os.path.isdir(args.datasets_dir):
+        logger.warning(
+            "datasets-dir %s not found; ds-* DOI extraction will fall back to "
+            "GitHub (rate-limit risk)",
+            args.datasets_dir,
+        )
+
     # Load the catalog once so each dataset can be seeded with its own
     # NEMAR-minted DOI as an additional opencite anchor. The catalog cache
     # is shared with the discover step in the same workflow run, so this

--- a/src/dataset_citations/core/opencite_pipeline.py
+++ b/src/dataset_citations/core/opencite_pipeline.py
@@ -72,6 +72,7 @@ def fetch_dataset_citations_via_opencite(
     checkpoint_store: CheckpointStore | None = None,
     use_checkpoint: bool = False,
     judgments_dir: Path | str | None = None,
+    local_metadata_dir: str | None = None,
 ) -> dict[str, Any]:
     """Return a schema-v2 citation JSON dict for one dataset.
 
@@ -122,7 +123,9 @@ def fetch_dataset_citations_via_opencite(
         # .nemar/metadata.json so the same source handles them.
         source: Any = nemar_source or NemarMetadataSource(github_token=github_token)
     elif dataset_id.startswith("ds"):
-        source = bids_source or BidsMetadataSource(github_token=github_token)
+        source = bids_source or BidsMetadataSource(
+            github_token=github_token, local_metadata_dir=local_metadata_dir
+        )
     else:
         return _stub_payload(
             dataset_id, when, fetch_status=f"unsupported_prefix:{dataset_id[:2]}"

--- a/src/dataset_citations/sources/bids_metadata.py
+++ b/src/dataset_citations/sources/bids_metadata.py
@@ -123,7 +123,12 @@ class BidsMetadataSource:
         try:
             with open(path, encoding="utf-8") as f:
                 data = json.load(f)
-        except (OSError, json.JSONDecodeError):
+        except (OSError, json.JSONDecodeError) as e:
+            logger.warning(
+                "could not read cached metadata %s (%s); falling back to GitHub",
+                path,
+                e,
+            )
             return None
         desc = data.get("dataset_description") if isinstance(data, dict) else None
         return desc if isinstance(desc, dict) and desc else None

--- a/src/dataset_citations/sources/bids_metadata.py
+++ b/src/dataset_citations/sources/bids_metadata.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 from typing import Any
 
 from github.GithubException import GithubException
@@ -45,12 +46,27 @@ class BidsMetadataSource:
     """Reads `dataset_description.json` from an OpenNeuroDatasets ds-repo and
     returns DOI/PMID/arXiv references suitable for opencite lookup."""
 
-    def __init__(self, github_token: str | None = None) -> None:
+    def __init__(
+        self,
+        github_token: str | None = None,
+        *,
+        local_metadata_dir: str | None = None,
+    ) -> None:
         self.github = build_github(github_token)
+        # When set, get_doi_references parses the cached dataset_description
+        # from `<local_metadata_dir>/<id>_datasets.json` (written by
+        # retrieve-metadata) instead of refetching from GitHub. This avoids the
+        # cold-start GitHub rate-limit storm on the ~463 legacy ds-* datasets
+        # (issue #174). GitHub remains the fallback when the cache is absent.
+        self._local_metadata_dir = local_metadata_dir
 
     def get_doi_references(
         self, dataset_id: str, org: str = "OpenNeuroDatasets"
     ) -> FetchResult[list[DoiReference]]:
+        cached = self._cached_description(dataset_id)
+        if cached is not None:
+            return FetchSuccess(parse_bids_description(cached))
+
         try:
             repo = self.github.get_repo(f"{org}/{dataset_id}")
         except GithubException as e:
@@ -90,6 +106,27 @@ class BidsMetadataSource:
             return FetchError("parse", "dataset_description.json root is not an object")
 
         return FetchSuccess(parse_bids_description(payload))
+
+    def _cached_description(self, dataset_id: str) -> dict[str, Any] | None:
+        """Return the cached dataset_description dict, or None to use GitHub.
+
+        Reads `<local_metadata_dir>/<id>_datasets.json` (retrieve-metadata's
+        output). Returns None when no cache dir is configured, the file is
+        missing / unreadable, or it carries no non-empty `dataset_description`
+        object, so the caller falls back to the live GitHub fetch.
+        """
+        if not self._local_metadata_dir:
+            return None
+        path = os.path.join(self._local_metadata_dir, f"{dataset_id}_datasets.json")
+        if not os.path.isfile(path):
+            return None
+        try:
+            with open(path, encoding="utf-8") as f:
+                data = json.load(f)
+        except (OSError, json.JSONDecodeError):
+            return None
+        desc = data.get("dataset_description") if isinstance(data, dict) else None
+        return desc if isinstance(desc, dict) and desc else None
 
 
 def parse_bids_description(desc: dict[str, Any]) -> list[DoiReference]:

--- a/tests/test_cli_update_backend.py
+++ b/tests/test_cli_update_backend.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import argparse
 import io
 import json
+import os
 import sys
 import tempfile
 from contextlib import redirect_stdout
@@ -54,7 +55,10 @@ def _make_args(
     return argparse.Namespace(
         dataset_list_file=str(list_file),
         output_dir=out_dir,
-        datasets_dir=out_dir,
+        # Distinct from output_dir and intentionally empty: these tests stub the
+        # pipeline or use unsupported prefixes, so DOI extraction never reads the
+        # cache. The cache-hit path is covered in test_sources_bids_metadata.py.
+        datasets_dir=os.path.join(out_dir, "datasets"),
         catalog_cache=cache_path,
         catalog_cache_max_age=3600,
         max_age_days=max_age_days,

--- a/tests/test_cli_update_backend.py
+++ b/tests/test_cli_update_backend.py
@@ -54,6 +54,7 @@ def _make_args(
     return argparse.Namespace(
         dataset_list_file=str(list_file),
         output_dir=out_dir,
+        datasets_dir=out_dir,
         catalog_cache=cache_path,
         catalog_cache_max_age=3600,
         max_age_days=max_age_days,

--- a/tests/test_sources_bids_metadata.py
+++ b/tests/test_sources_bids_metadata.py
@@ -8,6 +8,7 @@ parse_bids_description function. No mocks, no network.
 from __future__ import annotations
 
 import json
+import tempfile
 from pathlib import Path
 from unittest import TestCase
 
@@ -203,9 +204,11 @@ class GetDoiReferencesDecodeGuard(TestCase):
 
     def _source_returning(self, content: object) -> BidsMetadataSource:
         # Bypass __init__ (which builds a real Github client) and inject a real
-        # fake; the only attribute get_doi_references uses is `self.github`.
+        # fake; with no local cache configured these tests exercise the GitHub
+        # decode path.
         src = BidsMetadataSource.__new__(BidsMetadataSource)
         src.github = _FakeGithub(content)  # type: ignore[attr-defined]
+        src._local_metadata_dir = None  # type: ignore[attr-defined]
         return src
 
     def test_undecodable_blob_returns_parse_error_not_raises(self) -> None:
@@ -230,3 +233,54 @@ class GetDoiReferencesDecodeGuard(TestCase):
         assert isinstance(result, FetchSuccess)
         self.assertEqual(len(result.value), 1)
         self.assertEqual(result.value[0].identifier, "10.1038/sdata.2015.1")
+
+
+class _ExplodingGithub:
+    """GitHub client that fails if touched -- proves the cache path skips it."""
+
+    def get_repo(self, full_name: str) -> object:
+        raise AssertionError("GitHub must not be called when the cache is present")
+
+
+class GetDoiReferencesCacheTests(TestCase):
+    """get_doi_references parses the cached dataset_description from
+    local_metadata_dir instead of hitting GitHub, avoiding the cold-start
+    rate-limit storm; it falls back to GitHub when the cache is absent. #174."""
+
+    _DESC = {"ReferencesAndLinks": ["https://doi.org/10.1038/sdata.2015.1"]}
+
+    def _source(self, github: object, local_dir: str | None) -> BidsMetadataSource:
+        src = BidsMetadataSource.__new__(BidsMetadataSource)
+        src.github = github  # type: ignore[attr-defined]
+        src._local_metadata_dir = local_dir  # type: ignore[attr-defined]
+        return src
+
+    def _write_cache(self, tmp: str, dataset_id: str, body: dict) -> None:
+        (Path(tmp) / f"{dataset_id}_datasets.json").write_text(json.dumps(body))
+
+    def test_uses_cache_without_calling_github(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            self._write_cache(tmp, "ds002718", {"dataset_description": self._DESC})
+            result = self._source(_ExplodingGithub(), tmp).get_doi_references(
+                "ds002718"
+            )
+            assert isinstance(result, FetchSuccess)
+            self.assertEqual(result.value[0].identifier, "10.1038/sdata.2015.1")
+
+    def test_falls_back_to_github_when_cache_file_missing(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            payload = json.dumps(self._DESC).encode("utf-8")
+            result = self._source(_FakeGithub(_BytesContent(payload)), tmp)
+            self.assertEqual(len(result.get_doi_references("ds999999").value), 1)  # type: ignore[union-attr]
+
+    def test_falls_back_when_cache_has_no_description(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            self._write_cache(tmp, "ds002718", {"dataset_id": "ds002718"})
+            payload = json.dumps(self._DESC).encode("utf-8")
+            result = self._source(_FakeGithub(_BytesContent(payload)), tmp)
+            self.assertEqual(len(result.get_doi_references("ds002718").value), 1)  # type: ignore[union-attr]
+
+    def test_no_local_dir_configured_uses_github(self) -> None:
+        payload = json.dumps(self._DESC).encode("utf-8")
+        result = self._source(_FakeGithub(_BytesContent(payload)), None)
+        self.assertEqual(len(result.get_doi_references("ds002718").value), 1)  # type: ignore[union-attr]


### PR DESCRIPTION
Closes #174. Part of epic #167.

## Problem
On a cold `.fetch_state.json` (first run after #165, or a fresh checkout), `update` processes every dataset and its DOI-extraction path refetches `dataset_description.json` from GitHub for the ~463 legacy `ds-*` datasets, exhausting the 5000/hr GitHub budget (`403`, ~59 min backoff) and stalling the nightly pipeline for hours. Observed live on hallu 2026-06-18: the verification run sat on the first GitHub backoff and never progressed past the start of `update`. `retrieve-metadata` (which runs earlier in the same cron) already caches the parsed `dataset_description` into `datasets/<id>_datasets.json`, so the refetch is pure waste.

## Fix
`BidsMetadataSource(local_metadata_dir=...)` parses the cached `dataset_description` via the existing pure `parse_bids_description`, only falling back to GitHub when the cache is absent/empty. Threaded as `--datasets-dir` (default `datasets`) through `dataset-citations-update` -> `fetch_dataset_citations_via_opencite` -> `BidsMetadataSource`, and passed explicitly in the hallu cron `update` step.

Scope: `ds-*` only (the rate-limit offender). `nm-*`/`on-*` extract DOIs from `data.nemar.org` over HTTP and only hit GitHub on a rare fallback, so they're unaffected.

## Tests (real data, no mocks)
- `get_doi_references` returns the cached refs and does **not** call GitHub (injected `_ExplodingGithub` raises if touched).
- Falls back to GitHub when the cache file is missing, when the cache has no `dataset_description`, and when no `local_metadata_dir` is configured.

364 passed; `ruff` + `ty` clean (the one `ty` note is a pre-existing `# type: ignore`d line).
