### PR TITLE
feat(dashboard): dataset vs data-paper citation toggle (#169 phase 2b)

### DIFF
--- a/web/src/components/CitationItem.astro
+++ b/web/src/components/CitationItem.astro
@@ -18,7 +18,7 @@ const provTitle = prov.anchorTitle
     : prov.label;
 ---
 
-<li class="cite">
+<li class="cite" data-kind={prov.kind}>
   {
     href ? (
       <a class="cite__title" href={href} target="_blank" rel="noopener noreferrer">

--- a/web/src/lib/data.ts
+++ b/web/src/lib/data.ts
@@ -89,6 +89,11 @@ export interface DatasetDetail {
   id: string;
   /** High-confidence, non-methods citations — the counted set. */
   numCitations: number;
+  /** Of numCitations, those that cite the dataset itself (accession mention /
+   * version / own DOI). The leaderboard ranks on this (issue #169). */
+  numDatasetCitations: number;
+  /** Of numCitations, those that cite a data paper / publication. */
+  numDataPaperCitations: number;
   name: string;
   citations: Citation[];
   /** Low-confidence citations (kept for the detail view, not counted). */
@@ -147,9 +152,18 @@ interface RawCitation {
   openalex_id?: string | null;
   source_doi?: string | null;
   source_relation?: string | null;
+  /** "accession_mention" = found by full-text search for the dataset accession
+   * (issue #169); absent/"anchor" = the DOI-anchored opencite path. */
+  discovery_method?: string | null;
+  /** True when an anchor citation also names the dataset accession in text. */
+  mentions_accession?: boolean | null;
   cited_by?: number | null;
   confidence_scoring?: { confidence_score?: number | null } | null;
 }
+
+/** source_relation values whose anchor IS the dataset (vs a data paper). Mirrors
+ * core.accession_mentions._DATASET_RELATIONS. */
+const DATASET_RELATIONS = new Set(["IsVersionOf", "IsIdenticalTo"]);
 
 /** anchor DOI (normalized) -> its judged classification + paper title. */
 type AnchorMap = Map<string, { classification: string; title: string | null }>;
@@ -191,6 +205,16 @@ function isHighConf(c: RawCitation): boolean {
 /** Classify where a citation was found from its source anchor DOI + the
  * dataset's anchor-judgment sidecar. */
 function provenanceOf(c: RawCitation, anchors: AnchorMap): CitationProvenance {
+  // Accession mentions (the paper names the dataset accession in text) and
+  // version/identical anchors ARE dataset citations even though they carry no
+  // OpenNeuro source DOI. Keep in sync with core.accession_mentions.cites_dataset.
+  if (
+    c.discovery_method === "accession_mention" ||
+    c.mentions_accession === true ||
+    (c.source_relation != null && DATASET_RELATIONS.has(c.source_relation))
+  ) {
+    return { kind: "dataset", label: "Cites dataset", anchorTitle: null };
+  }
   const sd = c.source_doi ? normalizeDoi(c.source_doi) : null;
   if (sd && DATASET_DOI_RE.test(sd)) {
     return { kind: "dataset", label: "Cites dataset", anchorTitle: null };
@@ -396,10 +420,13 @@ export function loadAll(): LoadedData {
     if (counted.length > 0 || lowConf.length > 0) {
       counted.sort((a, b) => b.citedBy - a.citedBy);
       lowConf.sort((a, b) => b.citedBy - a.citedBy);
+      const numDatasetCitations = counted.filter((c) => c.provenance.kind === "dataset").length;
       datasets.push({
         id,
         name: readDatasetName(id),
         numCitations: counted.length,
+        numDatasetCitations,
+        numDataPaperCitations: counted.length - numDatasetCitations,
         citations: counted,
         lowConfCitations: lowConf,
         methodsExcluded,

--- a/web/src/pages/dataset/[id].astro
+++ b/web/src/pages/dataset/[id].astro
@@ -30,14 +30,14 @@ const base = import.meta.env.BASE_URL.replace(/\/$/, "");
   {
     dataset.citations.length > 0 && (
       <div class="filter" role="group" aria-label="Filter citations by what they reference">
-        <button type="button" class="filter__btn is-active" data-filter="all">
+        <button type="button" class="filter__btn is-active" data-filter="all" aria-pressed="true">
           All <span class="filter__n">{fmt(dataset.numCitations)}</span>
         </button>
-        <button type="button" class="filter__btn" data-filter="dataset">
+        <button type="button" class="filter__btn" data-filter="dataset" aria-pressed="false">
           Cites dataset <span class="filter__n">{fmt(dataset.numDatasetCitations)}</span>
         </button>
-        <button type="button" class="filter__btn" data-filter="paper">
-          Cites data paper <span class="filter__n">{fmt(dataset.numDataPaperCitations)}</span>
+        <button type="button" class="filter__btn" data-filter="paper" aria-pressed="false">
+          Cites a paper <span class="filter__n">{fmt(dataset.numDataPaperCitations)}</span>
         </button>
       </div>
     )
@@ -88,6 +88,7 @@ const base = import.meta.env.BASE_URL.replace(/\/$/, "");
           const filter = btn.dataset.filter;
           for (const b of buttons) {
             b.classList.toggle("is-active", b === btn);
+            b.setAttribute("aria-pressed", String(b === btn));
           }
           let visible = 0;
           for (const li of items) {

--- a/web/src/pages/dataset/[id].astro
+++ b/web/src/pages/dataset/[id].astro
@@ -28,12 +28,33 @@ const base = import.meta.env.BASE_URL.replace(/\/$/, "");
   </p>
 
   {
+    dataset.citations.length > 0 && (
+      <div class="filter" role="group" aria-label="Filter citations by what they reference">
+        <button type="button" class="filter__btn is-active" data-filter="all">
+          All <span class="filter__n">{fmt(dataset.numCitations)}</span>
+        </button>
+        <button type="button" class="filter__btn" data-filter="dataset">
+          Cites dataset <span class="filter__n">{fmt(dataset.numDatasetCitations)}</span>
+        </button>
+        <button type="button" class="filter__btn" data-filter="paper">
+          Cites data paper <span class="filter__n">{fmt(dataset.numDataPaperCitations)}</span>
+        </button>
+      </div>
+    )
+  }
+
+  {
     dataset.citations.length > 0 ? (
-      <ol class="cites" role="list">
-        {dataset.citations.map((citation) => (
-          <CitationItem citation={citation} />
-        ))}
-      </ol>
+      <Fragment>
+        <ol class="cites" id="cites-main" role="list">
+          {dataset.citations.map((citation) => (
+            <CitationItem citation={citation} />
+          ))}
+        </ol>
+        <p class="filter__empty" hidden>
+          No citations of that kind for this dataset.
+        </p>
+      </Fragment>
     ) : (
       <p class="empty">No high-confidence citations yet for this dataset.</p>
     )
@@ -53,6 +74,34 @@ const base = import.meta.env.BASE_URL.replace(/\/$/, "");
       </details>
     )
   }
+
+  <script>
+    // Client-side filter for the counted citation list: show all, only the
+    // citations that cite the dataset, or only those that cite a data paper.
+    const buttons = document.querySelectorAll<HTMLButtonElement>(".filter__btn");
+    const list = document.getElementById("cites-main");
+    const emptyMsg = document.querySelector<HTMLElement>(".filter__empty");
+    if (list) {
+      const items = Array.from(list.querySelectorAll<HTMLLIElement>(".cite"));
+      for (const btn of buttons) {
+        btn.addEventListener("click", () => {
+          const filter = btn.dataset.filter;
+          for (const b of buttons) {
+            b.classList.toggle("is-active", b === btn);
+          }
+          let visible = 0;
+          for (const li of items) {
+            const show = filter === "all" || li.dataset.kind === filter;
+            li.hidden = !show;
+            if (show) visible += 1;
+          }
+          if (emptyMsg) {
+            emptyMsg.hidden = visible !== 0;
+          }
+        });
+      }
+    }
+  </script>
 </Base>
 
 <style>
@@ -73,9 +122,40 @@ const base = import.meta.env.BASE_URL.replace(/\/$/, "");
   .ds-sub__excl {
     color: var(--color-fg-subtle);
   }
+  .filter {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-2);
+    margin-top: var(--space-6);
+  }
+  .filter__btn {
+    font-size: var(--fs-sm);
+    padding: var(--space-1) var(--space-3);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-sm, 4px);
+    background: var(--color-bg-subtle);
+    color: var(--color-fg-muted);
+    cursor: pointer;
+  }
+  .filter__btn:hover {
+    color: var(--color-fg);
+  }
+  .filter__btn.is-active {
+    color: var(--color-fg);
+    border-color: var(--brand-teal);
+    background: color-mix(in srgb, var(--brand-teal) 12%, transparent);
+  }
+  .filter__n {
+    color: var(--color-fg-subtle);
+    font-variant-numeric: tabular-nums;
+  }
+  .filter__empty {
+    margin-top: var(--space-6);
+    color: var(--color-fg-muted);
+  }
   .cites {
     list-style: none;
-    margin-top: var(--space-6);
+    margin-top: var(--space-4);
     border-top: 1px solid var(--color-border);
   }
   .empty {

--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -17,6 +17,7 @@ const topDataset = [...datasets]
   .sort((a, b) => b.numDatasetCitations - a.numDatasetCitations)
   .slice(0, 30);
 const topPaper = [...datasets]
+  .filter((d) => d.numDataPaperCitations > 0)
   .sort((a, b) => b.numDataPaperCitations - a.numDataPaperCitations)
   .slice(0, 30);
 const base = import.meta.env.BASE_URL.replace(/\/$/, "");
@@ -134,11 +135,15 @@ const modSlices =
     <div class="browse__head">
       <h2>Top datasets</h2>
       <div class="rank" role="group" aria-label="Rank datasets by">
-        <button type="button" class="rank__btn is-active" data-rank="total">
+        <button type="button" class="rank__btn is-active" data-rank="total" aria-pressed="true">
           All citations
         </button>
-        <button type="button" class="rank__btn" data-rank="dataset">Cites dataset</button>
-        <button type="button" class="rank__btn" data-rank="paper">Cites data paper</button>
+        <button type="button" class="rank__btn" data-rank="dataset" aria-pressed="false">
+          Cites dataset
+        </button>
+        <button type="button" class="rank__btn" data-rank="paper" aria-pressed="false">
+          Cites a paper
+        </button>
       </div>
     </div>
 
@@ -179,15 +184,19 @@ const modSlices =
 
     <ol class="ds-list" data-rank-list="paper" role="list" hidden>
       {
-        topPaper.map((d) => (
-          <li class="ds">
-            <a class="ds__name" href={datasetLink(d.id)}>
-              {d.name}
-            </a>
-            <span class="ds__id">{d.id}</span>
-            <span class="ds__count">{fmt(d.numDataPaperCitations)}</span>
-          </li>
-        ))
+        topPaper.length > 0 ? (
+          topPaper.map((d) => (
+            <li class="ds">
+              <a class="ds__name" href={datasetLink(d.id)}>
+                {d.name}
+              </a>
+              <span class="ds__id">{d.id}</span>
+              <span class="ds__count">{fmt(d.numDataPaperCitations)}</span>
+            </li>
+          ))
+        ) : (
+          <li class="ds ds--empty">No data-paper citations yet.</li>
+        )
       }
     </ol>
   </section>
@@ -201,6 +210,7 @@ const modSlices =
         const rank = btn.dataset.rank;
         for (const b of rankButtons) {
           b.classList.toggle("is-active", b === btn);
+          b.setAttribute("aria-pressed", String(b === btn));
         }
         for (const ol of rankLists) {
           ol.hidden = ol.dataset.rankList !== rank;

--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -8,7 +8,17 @@ import { MODALITY_META, MODALITY_ORDER, loadModalities } from "../lib/modality";
 
 const { overview, datasets, charts } = loadAll();
 const fmt = (n: number) => n.toLocaleString("en-US");
+// Three leaderboards, pre-sorted server-side; the toggle swaps which is shown
+// (the top-30 by total citations differs from the top-30 by dataset citations,
+// so a client-side re-sort of one rendered list would be wrong). Issue #169.
 const top = datasets.slice(0, 30);
+const topDataset = [...datasets]
+  .filter((d) => d.numDatasetCitations > 0)
+  .sort((a, b) => b.numDatasetCitations - a.numDatasetCitations)
+  .slice(0, 30);
+const topPaper = [...datasets]
+  .sort((a, b) => b.numDataPaperCitations - a.numDataPaperCitations)
+  .slice(0, 30);
 const base = import.meta.env.BASE_URL.replace(/\/$/, "");
 const datasetLink = (id: string) => `${base}/dataset/${id}`;
 
@@ -121,8 +131,18 @@ const modSlices =
   }
 
   <section class="browse">
-    <h2>Most-cited datasets</h2>
-    <ol class="ds-list" role="list">
+    <div class="browse__head">
+      <h2>Top datasets</h2>
+      <div class="rank" role="group" aria-label="Rank datasets by">
+        <button type="button" class="rank__btn is-active" data-rank="total">
+          All citations
+        </button>
+        <button type="button" class="rank__btn" data-rank="dataset">Cites dataset</button>
+        <button type="button" class="rank__btn" data-rank="paper">Cites data paper</button>
+      </div>
+    </div>
+
+    <ol class="ds-list" data-rank-list="total" role="list">
       {
         top.map((d) => (
           <li class="ds">
@@ -135,7 +155,59 @@ const modSlices =
         ))
       }
     </ol>
+
+    <ol class="ds-list" data-rank-list="dataset" role="list" hidden>
+      {
+        topDataset.length > 0 ? (
+          topDataset.map((d) => (
+            <li class="ds">
+              <a class="ds__name" href={datasetLink(d.id)}>
+                {d.name}
+              </a>
+              <span class="ds__id">{d.id}</span>
+              <span class="ds__count">{fmt(d.numDatasetCitations)}</span>
+            </li>
+          ))
+        ) : (
+          <li class="ds ds--empty">
+            No dataset-accession citations yet — this populates as the pipeline
+            finds papers that mention dataset accession numbers.
+          </li>
+        )
+      }
+    </ol>
+
+    <ol class="ds-list" data-rank-list="paper" role="list" hidden>
+      {
+        topPaper.map((d) => (
+          <li class="ds">
+            <a class="ds__name" href={datasetLink(d.id)}>
+              {d.name}
+            </a>
+            <span class="ds__id">{d.id}</span>
+            <span class="ds__count">{fmt(d.numDataPaperCitations)}</span>
+          </li>
+        ))
+      }
+    </ol>
   </section>
+
+  <script>
+    // Swap which pre-sorted leaderboard is visible.
+    const rankButtons = document.querySelectorAll<HTMLButtonElement>(".rank__btn");
+    const rankLists = document.querySelectorAll<HTMLOListElement>("[data-rank-list]");
+    for (const btn of rankButtons) {
+      btn.addEventListener("click", () => {
+        const rank = btn.dataset.rank;
+        for (const b of rankButtons) {
+          b.classList.toggle("is-active", b === btn);
+        }
+        for (const ol of rankLists) {
+          ol.hidden = ol.dataset.rankList !== rank;
+        }
+      });
+    }
+  </script>
 </Base>
 
 <style>
@@ -194,8 +266,40 @@ const modSlices =
   .browse {
     margin-top: var(--space-12);
   }
-  .browse h2 {
+  .browse__head {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: var(--space-3);
     margin-bottom: var(--space-4);
+  }
+  .rank {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-2);
+  }
+  .rank__btn {
+    font-size: var(--fs-sm);
+    padding: var(--space-1) var(--space-3);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-sm, 4px);
+    background: var(--color-bg-subtle);
+    color: var(--color-fg-muted);
+    cursor: pointer;
+  }
+  .rank__btn:hover {
+    color: var(--color-fg);
+  }
+  .rank__btn.is-active {
+    color: var(--color-fg);
+    border-color: var(--brand-teal);
+    background: color-mix(in srgb, var(--brand-teal) 12%, transparent);
+  }
+  .ds--empty {
+    display: block;
+    color: var(--color-fg-muted);
+    font-size: var(--fs-sm);
   }
   .ds-list {
     list-style: none;


### PR DESCRIPTION
Closes #169. Part of epic #167. Completes Phase 2 (2a discovery backend + this 2b UI).

## What
Surfaces the two citation buckets in the `web/` dashboard:
- **Data layer** (`data.ts`): `provenanceOf` now buckets accession-mention citations (`discovery_method=accession_mention` / `mentions_accession`) and `IsVersionOf`/`IsIdenticalTo` anchors as **cites dataset**, mirroring `core.accession_mentions.cites_dataset`. `DatasetDetail` gains `numDatasetCitations` / `numDataPaperCitations`.
- **Per-dataset page**: a filter (`All` / `Cites dataset` / `Cites data paper`) with live counts that client-side-filters the citation list (each `CitationItem` carries `data-kind`).
- **Main page**: the "Top datasets" leaderboard gains a ranking toggle that swaps between three server-pre-sorted lists (by total / dataset / data-paper citations). Three lists because the top-30 differ per metric, a client-side re-sort of one rendered list would be wrong.

## Verification
- `astro check` 0 errors, `biome` clean, `bun run build` renders 255 pages.
- Against current local data (accession mentions not live yet), 252 dataset pages already show "Cites dataset" badges from version/own-DOI anchors; the bucket grows once the find-mentions pipeline (2a) lands accession data.

## Notes
- Labels match the existing badge ("Cites dataset" / "Cites data paper") for consistency. The maintainer noted ordinary readers don't know the DataCite relation types, so these are kept plain; open to relabeling after visual review.
- The leaderboard's "Cites dataset" view is mostly empty until the accession data lands (an explicit empty-state message says so).

Frontend-only; the Python required checks pass trivially. The dashboard build is exercised by `deploy-dashboard.yml` on merge.
