### PR TITLE
feat(dashboard): citation API for the nemar.org modal (#170)

### DIFF
--- a/.github/workflows/deploy-dashboard.yml
+++ b/.github/workflows/deploy-dashboard.yml
@@ -59,6 +59,11 @@ jobs:
         run: |
           mkdir -p deploy/citations
           cp -r web/dist/. deploy/citations/
+          # Cloudflare Pages reads _headers from the DEPLOY ROOT, not
+          # deploy/citations/, so the CORS rule for the citation API the
+          # nemar.org modal fetches (#170) must live there. Source of truth is
+          # web/public/_headers (also copied under citations/, harmlessly).
+          cp web/public/_headers deploy/_headers
 
       - name: Deploy to Cloudflare Pages
         uses: cloudflare/wrangler-action@v4

--- a/web/public/_headers
+++ b/web/public/_headers
@@ -1,0 +1,8 @@
+# Cloudflare Pages headers for the citations dashboard.
+# The nemar.org dataset page fetches citation detail + counts cross-origin for
+# the "citations: N" modal (Phase 3, issue #170); static assets carry no
+# per-response headers, so CORS is declared here.
+/citations/api/*
+  Access-Control-Allow-Origin: *
+  Access-Control-Allow-Methods: GET, OPTIONS
+  Cache-Control: public, max-age=3600

--- a/web/public/_headers
+++ b/web/public/_headers
@@ -5,4 +5,5 @@
 /citations/api/*
   Access-Control-Allow-Origin: *
   Access-Control-Allow-Methods: GET, OPTIONS
+  Access-Control-Allow-Headers: *
   Cache-Control: public, max-age=3600

--- a/web/src/pages/api/dataset/[id].json.ts
+++ b/web/src/pages/api/dataset/[id].json.ts
@@ -6,8 +6,10 @@
  * opens the "citations: N" modal (Phase 3, issue #170). The COUNT lives on
  * nemar-cli's D1 so the catalog can order datasets by it without loading
  * citations; the DETAIL stays here as JSON so D1 isn't inflated with per-paper
- * rows. Slimmed to what the modal renders. CORS is set in public/_headers
- * (static files can't carry per-response headers).
+ * rows. Includes only the counted (high-confidence, methods-excluded) citations
+ * — low-confidence ones are deliberately omitted; each carries its confidence
+ * score. CORS is set in public/_headers (static files can't carry per-response
+ * headers).
  */
 import type { APIRoute } from "astro";
 import { loadAll } from "../../../lib/data";
@@ -20,11 +22,10 @@ export function getStaticPaths() {
 export const GET: APIRoute = ({ params }) => {
   const { datasets } = loadAll();
   const d = datasets.find((x) => x.id === params.id);
+  // Unreachable: getStaticPaths enumerates exactly these ids, so static output
+  // only invokes GET for a known dataset. Guard as a build-time invariant.
   if (!d) {
-    return new Response(JSON.stringify({ error: "dataset not found" }), {
-      status: 404,
-      headers: { "Content-Type": "application/json" },
-    });
+    throw new Error(`dataset ${params.id} not present in loadAll()`);
   }
   const body = {
     dataset_id: d.id,
@@ -41,6 +42,8 @@ export const GET: APIRoute = ({ params }) => {
       url: c.url,
       doi: c.doi,
       cited_by: c.citedBy,
+      // Relevance score (>= 0.4 here; the counted set is high-confidence only).
+      confidence: c.confidence,
       // "dataset" = cites the dataset (accession mention / version / own DOI);
       // "paper" = cites a publication.
       kind: c.provenance.kind,

--- a/web/src/pages/api/dataset/[id].json.ts
+++ b/web/src/pages/api/dataset/[id].json.ts
@@ -1,0 +1,52 @@
+/**
+ * Per-dataset citation detail, emitted as a static file at build time:
+ *   dashboard.nemar.org/citations/api/dataset/<id>.json
+ *
+ * This is the payload the nemar.org dataset page fetches lazily when a user
+ * opens the "citations: N" modal (Phase 3, issue #170). The COUNT lives on
+ * nemar-cli's D1 so the catalog can order datasets by it without loading
+ * citations; the DETAIL stays here as JSON so D1 isn't inflated with per-paper
+ * rows. Slimmed to what the modal renders. CORS is set in public/_headers
+ * (static files can't carry per-response headers).
+ */
+import type { APIRoute } from "astro";
+import { loadAll } from "../../../lib/data";
+
+export function getStaticPaths() {
+  const { datasets } = loadAll();
+  return datasets.map((d) => ({ params: { id: d.id } }));
+}
+
+export const GET: APIRoute = ({ params }) => {
+  const { datasets } = loadAll();
+  const d = datasets.find((x) => x.id === params.id);
+  if (!d) {
+    return new Response(JSON.stringify({ error: "dataset not found" }), {
+      status: 404,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+  const body = {
+    dataset_id: d.id,
+    name: d.name,
+    num_citations: d.numCitations,
+    num_dataset_citations: d.numDatasetCitations,
+    num_datapaper_citations: d.numDataPaperCitations,
+    // Highest-cited first (already sorted in the data layer).
+    citations: d.citations.map((c) => ({
+      title: c.title,
+      authors: c.authors,
+      year: c.year,
+      venue: c.venue,
+      url: c.url,
+      doi: c.doi,
+      cited_by: c.citedBy,
+      // "dataset" = cites the dataset (accession mention / version / own DOI);
+      // "paper" = cites a publication.
+      kind: c.provenance.kind,
+    })),
+  };
+  return new Response(JSON.stringify(body), {
+    headers: { "Content-Type": "application/json" },
+  });
+};

--- a/web/src/pages/api/index.json.ts
+++ b/web/src/pages/api/index.json.ts
@@ -1,0 +1,28 @@
+/**
+ * Citation counts manifest, emitted as a static file at build time:
+ *   dashboard.nemar.org/citations/api/index.json
+ *
+ * One row per dataset with citations. nemar-cli ingests this into D1 (citation
+ * count columns) so the catalog can order datasets by citation count without
+ * loading any per-paper detail (Phase 3, issue #170). The detail lives in the
+ * per-dataset endpoints; this manifest stays small (counts only).
+ */
+import type { APIRoute } from "astro";
+import { loadAll } from "../../lib/data";
+
+export const GET: APIRoute = () => {
+  const { datasets, overview } = loadAll();
+  const body = {
+    schema: "nemar-citations/counts@1",
+    last_updated: overview.lastUpdated,
+    datasets: datasets.map((d) => ({
+      dataset_id: d.id,
+      num_citations: d.numCitations,
+      num_dataset_citations: d.numDatasetCitations,
+      num_datapaper_citations: d.numDataPaperCitations,
+    })),
+  };
+  return new Response(JSON.stringify(body), {
+    headers: { "Content-Type": "application/json" },
+  });
+};


### PR DESCRIPTION
Part of #170 (Phase 3). This is the **in-repo** half: serve the citation surface the nemar.org dataset page consumes, from the existing dashboard deploy. The cross-repo UI is tracked in sibling issues (below).

## What
- **`/citations/api/dataset/<id>.json`** — slim per-dataset citation detail (`title, authors, year, venue, url, doi, cited_by, kind`), one static file per dataset (~15KB), lazily fetched when the modal opens. `kind` = `dataset` | `paper`.
- **`/citations/api/index.json`** — counts manifest (`num_citations` / `num_dataset_citations` / `num_datapaper_citations` per dataset) for nemar-cli to ingest into D1 so the catalog can order by citation count.
- **`public/_headers` + deploy step** — CORS (`Access-Control-Allow-Origin: *`) on `/citations/api/*`, placed at the Cloudflare Pages deploy root (where `_headers` is read).

## Why this split
Per-paper detail stays out of D1 (would inflate it); only the orderable COUNT goes to D1. Detail is fetched lazily from the dashboard on modal open.

## Verified
`astro check` 0 errors, `biome` clean, build emits 252 detail files + the manifest; `_headers` lands at the deploy root.

## Cross-repo follow-ups (filed)
- **nemarOrg/nemar-cli#804** — ingest the counts manifest into D1, expose + order `/datasets` by citation count.
- **nemarOrg/website#126** — citation pill + modal on the dataset page, citation count on discovery cards, and a new dataset sort (latest / earliest / most subjects / most citations) that composes with the left-side filters.
