### PR TITLE
fix(quality): classify journal analysis-method papers as methodology (#131)

### DIFF
--- a/src/dataset_citations/quality/llm_client.py
+++ b/src/dataset_citations/quality/llm_client.py
@@ -163,7 +163,7 @@ Choose exactly one class from this taxonomy:
 
 - data_paper: the paper IS this dataset's data paper, dataset preprint, or curation paper. It introduces, describes, or releases the data in this specific dataset.
 - umbrella: the paper is a multi-dataset / multi-study initiative (e.g. HBN, UK Biobank, ABCD) that this dataset belongs to, but the paper is NOT this specific dataset's data paper.
-- methodology: the paper is a software tool, analysis method, or technical specification that this dataset's protocol uses (e.g. MNE-Python, EEGLAB, BIDS-EEG spec, FieldTrip).
+- methodology: the paper is a software tool, analysis method, algorithm, or technical specification that this dataset's protocol or a downstream analysis uses (e.g. MNE-Python, EEGLAB, BIDS-EEG spec, FieldTrip, or an analysis-method paper in a journal such as NeuroImage). A peer-reviewed method/algorithm paper is methodology, NOT data_paper, even when it reads like a normal research article: it describes a technique reused across many studies, it does not introduce THIS dataset.
 - related_work: the paper is topically related (same brain region, task, modality) but does not describe this dataset specifically.
 - irrelevant: the paper has no meaningful relationship to this dataset (mis-attached anchor, token-collision false positive).
 
@@ -200,6 +200,11 @@ Example 3 (methodology tool):
   dataset_id: ds000117 (anchor DOI 10.3389/fnins.2013.00267)
   candidate paper: "MEG and EEG data analysis with MNE-Python"
   Correct output: {{"classification": "methodology", "reason": "Describes the MNE-Python analysis library; tool used in the protocol, not a paper about this dataset."}}
+
+Example 4 (analysis-method paper in a journal -> methodology, NOT data_paper):
+  dataset_id: ds004362 (anchor DOI 10.1016/j.neuroimage.2020.xxxxxx)
+  candidate paper: "An automated pipeline for EEG artifact rejection and independent component analysis" (NeuroImage)
+  Correct output: {{"classification": "methodology", "reason": "Describes a general EEG analysis method reused across many studies; a journal method paper, not a description of this dataset."}}
 
 Now classify the candidate paper for dataset {dataset_id}. Respond with the JSON object only."""
 

--- a/src/dataset_citations/quality/llm_client.py
+++ b/src/dataset_citations/quality/llm_client.py
@@ -146,9 +146,10 @@ def build_anchor_prompt(
     Kept as a module-level pure function so phases 2/3/4 all build identical
     prompts. The opening lays out the taxonomy with one-line definitions,
     then hands the model the dataset description + candidate paper + the
-    DataCite `source_relation` value, then three few-shot examples covering
-    the acceptance-gate cases from epic #76 (HBN umbrella, dataset preprint,
-    MNE-Python methodology).
+    DataCite `source_relation` value, then four few-shot examples (HBN
+    umbrella, dataset preprint, MNE-Python methodology, and a journal
+    analysis-method paper added for issue #131 to stop e4b misclassifying
+    method papers as data_paper).
     """
     description = _truncate(dataset_description, _DATASET_DESCRIPTION_CHAR_LIMIT)
     abstract = _truncate(paper_abstract, _ABSTRACT_CHAR_LIMIT)
@@ -202,7 +203,7 @@ Example 3 (methodology tool):
   Correct output: {{"classification": "methodology", "reason": "Describes the MNE-Python analysis library; tool used in the protocol, not a paper about this dataset."}}
 
 Example 4 (analysis-method paper in a journal -> methodology, NOT data_paper):
-  dataset_id: ds004362 (anchor DOI 10.1016/j.neuroimage.2020.xxxxxx)
+  dataset_id: ds004362 (anchor DOI 10.1016/j.neuroimage.2020.117465)
   candidate paper: "An automated pipeline for EEG artifact rejection and independent component analysis" (NeuroImage)
   Correct output: {{"classification": "methodology", "reason": "Describes a general EEG analysis method reused across many studies; a journal method paper, not a description of this dataset."}}
 

--- a/tests/test_quality_llm_client.py
+++ b/tests/test_quality_llm_client.py
@@ -63,6 +63,21 @@ class BuildAnchorPromptTests(TestCase):
         # JSON-only directive is critical for parsing.
         self.assertIn("strict JSON only", prompt)
 
+    def test_prompt_distinguishes_journal_method_papers(self) -> None:
+        # Issue #131: e4b misclassified analysis-method papers published as
+        # journal articles (e.g. NeuroImage) as data_paper. The taxonomy
+        # definition and a dedicated few-shot example must steer methodology.
+        prompt = build_anchor_prompt(
+            dataset_id="ds004362",
+            dataset_description="EEG dataset.",
+            anchor_doi="10.1016/j.neuroimage.2020.117465",
+            anchor_relation="References",
+            paper_title="An automated pipeline for EEG artifact rejection",
+            paper_abstract="A general analysis method for EEG.",
+        )
+        self.assertIn("method/algorithm paper is methodology, NOT data_paper", prompt)
+        self.assertIn("analysis-method paper in a journal", prompt)
+
     def test_prompt_handles_missing_abstract(self) -> None:
         prompt = build_anchor_prompt(
             dataset_id="ds000999",


### PR DESCRIPTION
## Summary
Fix the residual anchor over-spread from #131: `gemma4:e4b` misclassified analysis-**method** papers published as journal articles (the NeuroImage method DOIs that the attribution audit flagged across 5-12 datasets) as `data_paper` instead of `methodology`. The root cause is in `build_anchor_prompt`: the only `methodology` few-shot example was MNE-Python (a software *library*), so the model had no signal that a peer-reviewed method/algorithm paper in a journal is also `methodology`.

## Change (prompt only)
- Sharpened the `methodology` taxonomy definition: a peer-reviewed method/algorithm paper is `methodology`, NOT `data_paper`, even when it reads like a normal research article, because it describes a technique reused across many studies and does not introduce THIS dataset.
- Added a 4th few-shot example: a journal analysis-method paper (NeuroImage-style EEG artifact/ICA pipeline) -> `methodology`.
- Added `test_prompt_distinguishes_journal_method_papers` pinning both.

## Validation
- [x] `uv run pytest tests/` -> 396 passed, 19 skipped; ruff clean.
- [ ] **Effect is GPU-gated:** this only re-classifies the affected anchors after a re-judge on hallu (`dataset-citations-judge-anchors --skip-existing 0`). Confirmation = the attribution audit (`dataset-citations-audit-attribution`) clearing the 5 over-spread method anchors and dropping below the current 1.56x. That run happens on the hallu host, not in CI.

Because the payoff is confirmed only by the hallu re-judge, this **references** #131 rather than closing it; close once the next audit confirms. Part of epic #180 (the "one counting policy" goal; unblocks the dashboard-heuristic deletion).
