### PR TITLE
docs(research): anchor-classification model bake-off findings (#131, #180)

### DIFF
--- a/.context/research/anchor_model_bakeoff_2026-06-21.json
+++ b/.context/research/anchor_model_bakeoff_2026-06-21.json
@@ -1,0 +1,361 @@
+{
+  "models": {
+    "gemma4:e4b": {
+      "exact_acc": 0.22,
+      "exact_acc_with_prior": 0.22,
+      "kept_acc": 0.22,
+      "kept_acc_with_prior": 0.78,
+      "avg_ms": 1012,
+      "n_scored": 9,
+      "rows": [
+        {
+          "dataset_id": "on007052",
+          "anchor_doi": "10.1016/j.neuroimage.2020.117465",
+          "expected": "methodology",
+          "model_class": "data_paper",
+          "prior_class": "related_work",
+          "ms": 3187
+        },
+        {
+          "dataset_id": "on007069",
+          "anchor_doi": "10.1016/j.neuroimage.2020.117465",
+          "expected": "methodology",
+          "model_class": "data_paper",
+          "prior_class": "related_work",
+          "ms": 753
+        },
+        {
+          "dataset_id": "on005505",
+          "anchor_doi": "10.1101/2024.10.03.615261",
+          "expected": "umbrella",
+          "model_class": "data_paper",
+          "prior_class": "related_work",
+          "ms": 767
+        },
+        {
+          "dataset_id": "on005510",
+          "anchor_doi": "10.1101/2024.10.03.615261",
+          "expected": "umbrella",
+          "model_class": "data_paper",
+          "prior_class": "related_work",
+          "ms": 720
+        },
+        {
+          "dataset_id": "ds004118",
+          "anchor_doi": "10.3389/fnins.2014.00155",
+          "expected": "related_work",
+          "model_class": "data_paper",
+          "prior_class": "related_work",
+          "ms": 701
+        },
+        {
+          "dataset_id": "nm000163",
+          "anchor_doi": "10.1016/j.neuroimage.2023.120446",
+          "expected": "methodology",
+          "model_class": "data_paper",
+          "prior_class": "related_work",
+          "ms": 797
+        },
+        {
+          "dataset_id": "on000117",
+          "anchor_doi": "10.1038/sdata.2015.1",
+          "expected": "data_paper",
+          "model_class": "data_paper",
+          "prior_class": "related_work",
+          "ms": 716
+        },
+        {
+          "dataset_id": "on005779",
+          "anchor_doi": "10.1016/j.brs.2024.01.001",
+          "expected": "data_paper",
+          "model_class": "related_work",
+          "prior_class": "related_work",
+          "ms": 799
+        },
+        {
+          "dataset_id": "on005028",
+          "anchor_doi": "10.1101/2022.06.24.22276882",
+          "expected": "data_paper",
+          "model_class": "data_paper",
+          "prior_class": "data_paper",
+          "ms": 669
+        }
+      ]
+    },
+    "gemma4:26b": {
+      "exact_acc": 0.17,
+      "exact_acc_with_prior": 0.0,
+      "kept_acc": 0.17,
+      "kept_acc_with_prior": 0.67,
+      "avg_ms": 908,
+      "n_scored": 6,
+      "rows": [
+        {
+          "dataset_id": "on007052",
+          "anchor_doi": "10.1016/j.neuroimage.2020.117465",
+          "error": "llm:ollama HTTP transport error (ReadTimeout): timed out"
+        },
+        {
+          "dataset_id": "on007069",
+          "anchor_doi": "10.1016/j.neuroimage.2020.117465",
+          "expected": "methodology",
+          "model_class": "data_paper",
+          "prior_class": "related_work",
+          "ms": 1214
+        },
+        {
+          "dataset_id": "on005505",
+          "anchor_doi": "10.1101/2024.10.03.615261",
+          "expected": "umbrella",
+          "model_class": "data_paper",
+          "prior_class": "related_work",
+          "ms": 757
+        },
+        {
+          "dataset_id": "on005510",
+          "anchor_doi": "10.1101/2024.10.03.615261",
+          "expected": "umbrella",
+          "model_class": "data_paper",
+          "prior_class": "related_work",
+          "ms": 789
+        },
+        {
+          "dataset_id": "ds004118",
+          "anchor_doi": "10.3389/fnins.2014.00155",
+          "error": "llm:ollama returned non-JSON content: Unterminated string starting at: line 1 column 44 (char 43)"
+        },
+        {
+          "dataset_id": "nm000163",
+          "anchor_doi": "10.1016/j.neuroimage.2023.120446",
+          "expected": "methodology",
+          "model_class": "data_paper",
+          "prior_class": "related_work",
+          "ms": 905
+        },
+        {
+          "dataset_id": "on000117",
+          "anchor_doi": "10.1038/sdata.2015.1",
+          "expected": "data_paper",
+          "model_class": "data_paper",
+          "prior_class": "related_work",
+          "ms": 818
+        },
+        {
+          "dataset_id": "on005779",
+          "anchor_doi": "10.1016/j.brs.2024.01.001",
+          "expected": "data_paper",
+          "model_class": "related_work",
+          "prior_class": "related_work",
+          "ms": 964
+        },
+        {
+          "dataset_id": "on005028",
+          "anchor_doi": "10.1101/2022.06.24.22276882",
+          "error": "llm:ollama HTTP transport error (ReadTimeout): timed out"
+        }
+      ]
+    },
+    "gemma4:31b": {
+      "exact_acc": 0.33,
+      "exact_acc_with_prior": 0.33,
+      "kept_acc": 0.44,
+      "kept_acc_with_prior": 0.78,
+      "avg_ms": 5161,
+      "n_scored": 9,
+      "rows": [
+        {
+          "dataset_id": "on007052",
+          "anchor_doi": "10.1016/j.neuroimage.2020.117465",
+          "expected": "methodology",
+          "model_class": "methodology",
+          "prior_class": "methodology",
+          "ms": 15391
+        },
+        {
+          "dataset_id": "on007069",
+          "anchor_doi": "10.1016/j.neuroimage.2020.117465",
+          "expected": "methodology",
+          "model_class": "umbrella",
+          "prior_class": "umbrella",
+          "ms": 3280
+        },
+        {
+          "dataset_id": "on005505",
+          "anchor_doi": "10.1101/2024.10.03.615261",
+          "expected": "umbrella",
+          "model_class": "data_paper",
+          "prior_class": "related_work",
+          "ms": 4125
+        },
+        {
+          "dataset_id": "on005510",
+          "anchor_doi": "10.1101/2024.10.03.615261",
+          "expected": "umbrella",
+          "model_class": "data_paper",
+          "prior_class": "related_work",
+          "ms": 4105
+        },
+        {
+          "dataset_id": "ds004118",
+          "anchor_doi": "10.3389/fnins.2014.00155",
+          "expected": "related_work",
+          "model_class": "data_paper",
+          "prior_class": "related_work",
+          "ms": 3618
+        },
+        {
+          "dataset_id": "nm000163",
+          "anchor_doi": "10.1016/j.neuroimage.2023.120446",
+          "expected": "methodology",
+          "model_class": "data_paper",
+          "prior_class": "related_work",
+          "ms": 4763
+        },
+        {
+          "dataset_id": "on000117",
+          "anchor_doi": "10.1038/sdata.2015.1",
+          "expected": "data_paper",
+          "model_class": "data_paper",
+          "prior_class": "related_work",
+          "ms": 4212
+        },
+        {
+          "dataset_id": "on005779",
+          "anchor_doi": "10.1016/j.brs.2024.01.001",
+          "expected": "data_paper",
+          "model_class": "irrelevant",
+          "prior_class": "irrelevant",
+          "ms": 3735
+        },
+        {
+          "dataset_id": "on005028",
+          "anchor_doi": "10.1101/2022.06.24.22276882",
+          "expected": "data_paper",
+          "model_class": "data_paper",
+          "prior_class": "data_paper",
+          "ms": 3222
+        }
+      ]
+    },
+    "qwen3.6:27b": {
+      "exact_acc": 0.0,
+      "exact_acc_with_prior": 0.0,
+      "kept_acc": 0.0,
+      "kept_acc_with_prior": 0.0,
+      "avg_ms": 0,
+      "n_scored": 0,
+      "rows": [
+        {
+          "dataset_id": "on007052",
+          "anchor_doi": "10.1016/j.neuroimage.2020.117465",
+          "error": "llm:ollama returned non-JSON content: Expecting value: line 1 column 1 (char 0)"
+        },
+        {
+          "dataset_id": "on007069",
+          "anchor_doi": "10.1016/j.neuroimage.2020.117465",
+          "error": "llm:ollama returned non-JSON content: Expecting value: line 1 column 1 (char 0)"
+        },
+        {
+          "dataset_id": "on005505",
+          "anchor_doi": "10.1101/2024.10.03.615261",
+          "error": "llm:ollama returned non-JSON content: Expecting value: line 1 column 1 (char 0)"
+        },
+        {
+          "dataset_id": "on005510",
+          "anchor_doi": "10.1101/2024.10.03.615261",
+          "error": "llm:ollama returned non-JSON content: Expecting value: line 1 column 1 (char 0)"
+        },
+        {
+          "dataset_id": "ds004118",
+          "anchor_doi": "10.3389/fnins.2014.00155",
+          "error": "llm:ollama returned non-JSON content: Expecting value: line 1 column 1 (char 0)"
+        },
+        {
+          "dataset_id": "nm000163",
+          "anchor_doi": "10.1016/j.neuroimage.2023.120446",
+          "error": "llm:ollama returned non-JSON content: Expecting value: line 1 column 1 (char 0)"
+        },
+        {
+          "dataset_id": "on000117",
+          "anchor_doi": "10.1038/sdata.2015.1",
+          "error": "llm:ollama returned non-JSON content: Expecting value: line 1 column 1 (char 0)"
+        },
+        {
+          "dataset_id": "on005779",
+          "anchor_doi": "10.1016/j.brs.2024.01.001",
+          "error": "llm:ollama returned non-JSON content: Expecting value: line 1 column 1 (char 0)"
+        },
+        {
+          "dataset_id": "on005028",
+          "anchor_doi": "10.1101/2022.06.24.22276882",
+          "error": "llm:ollama returned non-JSON content: Expecting value: line 1 column 1 (char 0)"
+        }
+      ]
+    }
+  },
+  "pairs": [
+    {
+      "dataset_id": "on007052",
+      "anchor_doi": "10.1016/j.neuroimage.2020.117465",
+      "expected": "methodology",
+      "relation": "References",
+      "title": "ERP CORE: An open resource for human event-related potential research"
+    },
+    {
+      "dataset_id": "on007069",
+      "anchor_doi": "10.1016/j.neuroimage.2020.117465",
+      "expected": "methodology",
+      "relation": "References",
+      "title": "ERP CORE: An open resource for human event-related potential research"
+    },
+    {
+      "dataset_id": "on005505",
+      "anchor_doi": "10.1101/2024.10.03.615261",
+      "expected": "umbrella",
+      "relation": "References",
+      "title": "HBN-EEG: The FAIR implementation of the Healthy Brain Network (HBN) electroencephalography dataset"
+    },
+    {
+      "dataset_id": "on005510",
+      "anchor_doi": "10.1101/2024.10.03.615261",
+      "expected": "umbrella",
+      "relation": "References",
+      "title": "HBN-EEG: The FAIR implementation of the Healthy Brain Network (HBN) electroencephalography dataset"
+    },
+    {
+      "dataset_id": "ds004118",
+      "anchor_doi": "10.3389/fnins.2014.00155",
+      "expected": "related_work",
+      "relation": "IsDerivedFrom",
+      "title": "Estimating endogenous changes in task performance from EEG"
+    },
+    {
+      "dataset_id": "nm000163",
+      "anchor_doi": "10.1016/j.neuroimage.2023.120446",
+      "expected": "methodology",
+      "relation": "References",
+      "title": "Burst c-VEP Based BCI: Optimizing stimulus design for enhanced classification with minimal calibration data and improved user experience"
+    },
+    {
+      "dataset_id": "on000117",
+      "anchor_doi": "10.1038/sdata.2015.1",
+      "expected": "data_paper",
+      "relation": "References",
+      "title": "A multi-subject, multi-modal human neuroimaging dataset"
+    },
+    {
+      "dataset_id": "on005779",
+      "anchor_doi": "10.1016/j.brs.2024.01.001",
+      "expected": "data_paper",
+      "relation": "IsDescribedBy",
+      "title": "Cortico-cortical paired associative stimulation highlights asymmetrical communication between rostral premotor cortices and primary motor cortex"
+    },
+    {
+      "dataset_id": "on005028",
+      "anchor_doi": "10.1101/2022.06.24.22276882",
+      "expected": "data_paper",
+      "relation": "IsDescribedBy",
+      "title": "Comparing P300 flashing paradigms in online typing with language models"
+    }
+  ]
+}

--- a/.context/research/anchor_model_bakeoff_2026-06-21.md
+++ b/.context/research/anchor_model_bakeoff_2026-06-21.md
@@ -1,0 +1,57 @@
+# Anchor-classification model bake-off (2026-06-21)
+
+Epic #180 / issue #131. Investigation into why citation attribution over-spreads
+(an anchor's citers leak across many datasets), and whether a better judgment
+model or a relation-type prior fixes it. Reproduce with
+`scripts/bench_anchor_models.py` (raw output: `anchor_model_bakeoff_2026-06-21.json`).
+
+## Setup
+- Hand-labeled set of 9 `(dataset, anchor)` pairs: 6 over-attribution cases
+  (a shared resource/method paper a *different* dataset reuses, must NOT be
+  `data_paper`) + 3 genuine data-paper controls (`IsDescribedBy`-ish).
+- Models served by Ollama on the hallu RTX 4090 (24 GB): `gemma4:e4b` (the cron
+  model), `gemma4:26b`, `gemma4:31b`, `qwen3.6:27b`.
+- Metric: exact 5-class accuracy and the decision-relevant `data_paper`-vs-not
+  binary (that binary is what drives whether an anchor's citers get attributed),
+  with and without a deterministic relation-type prior.
+
+## Results
+
+| model | exact | data_paper-binary | + relation prior | avg latency |
+|---|---|---|---|---|
+| gemma4:e4b (cron) | 0.22 | 0.22 | 0.78* | ~1.0 s |
+| gemma4:26b | 0.17 | 0.17 | 0.67* | ~0.9 s (2 timeouts, 1 malformed) |
+| gemma4:31b | 0.33 | 0.44 | 0.78* | ~5.2 s |
+| qwen3.6:27b | — | — | — | emitted non-JSON (reasoning tokens); unusable without client changes |
+
+## Findings
+1. **No bare model reliably makes the call.** All models default the
+   over-attribution cases (ERP CORE, HBN-EEG, c-VEP method papers) to
+   `data_paper`. gemma4:31b was the only one to correctly call ERP CORE
+   `methodology` for even one dataset, at 5x the latency. The distinction
+   ("this resource has its own data, but the dataset in front of me is a
+   *different* dataset that merely reuses it") is not reliably inferrable from
+   title/abstract by a 4B-31B model.
+2. **`*` The relation-type prior's gain is illusory.** It lifts binary accuracy
+   to 0.78, but it does so by discarding a genuine data paper:
+   - `on000117` <- `10.1038/sdata.2015.1` (Wakeman & Henson, the real ds000117
+     data paper) is tagged **`References`** in our metadata, identical to ERP
+     CORE. The prior downgrades it.
+   - `on004100` <- `10.1038/s41597-019-0105-7` (iEEG-**BIDS** standard, NOT a
+     data paper) is tagged **`IsDescribedBy`**.
+   So `relation_type` is noise in **both** directions and cannot drive a clean
+   count.
+
+## Conclusion
+The root cause is **upstream metadata quality** (`relation_type` assignment), not
+the downstream judgment model. Neither a bigger model nor a deterministic prior
+fixes the over-attribution cleanly. The fix belongs in `nemar-cli` enrichment
+(haiku), which sees full dataset context: filed as **nemarOrg/nemar-cli#826**.
+
+Consequences:
+- **#131** (prompt/model fix) is effectively a dead end for over-attribution;
+  PR #191's prompt change is kept only because it helps genuine method papers.
+- **#192** (delete the dashboard `METHODS_SPREAD`/`DENYLIST` heuristic) is
+  **blocked on nemar-cli#826** — the heuristic is compensating for the
+  unreliable upstream signal, so the current dashboard count is the *correct*
+  one. Deleting it before enrichment is fixed would regress counts.

--- a/scripts/bench_anchor_models.py
+++ b/scripts/bench_anchor_models.py
@@ -1,0 +1,251 @@
+"""Throwaway bake-off: compare Ollama models on the anchor-classification task.
+
+Investigation for issue #131 / epic #180. The over-attribution problem is that
+gemma4:e4b (the cron model) classifies shared resource/paradigm papers (ERP CORE,
+HBN-EEG) as `data_paper` for datasets that merely reuse them, so their citers
+leak across many datasets. This script measures, on a small HAND-LABELED set:
+
+  * per-model accuracy (exact 5-class + the decision-relevant data_paper-vs-not)
+  * per-model latency
+  * the same metrics with a deterministic relation-type prior layered on top
+    (an external journal DOI linked via `References` is implausible as THIS
+    dataset's data paper; downgrade a model `data_paper` call in that case).
+
+Run against hallu's Ollama via the tunnel (per probe_anchor_judgment docstring):
+    ssh -fN -L 21434:localhost:11434 hallu
+    OLLAMA_BASE_URL=http://localhost:21434 \
+        uv run python scripts/bench_anchor_models.py --output /tmp/bench.json
+
+Writes no sidecars. Not part of the pipeline.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import time
+from pathlib import Path
+from typing import Any
+
+from dataset_citations.backends import OpenCiteBackend
+from dataset_citations.quality.dataset_metadata import (
+    DatasetMetadataRetriever,
+    extract_dataset_text,
+)
+from dataset_citations.quality.llm_client import (
+    LlmJudgmentError,
+    OllamaJudgmentClient,
+    build_anchor_prompt,
+)
+from dataset_citations.sources.models import FetchSuccess
+
+# (dataset_id, anchor_doi, expected_class). expected_class drives both the
+# exact-class score and the binary kept score (kept == data_paper).
+LABELED_PAIRS: list[tuple[str, str, str]] = [
+    # --- over-attribution cases: a shared resource/method paper a DIFFERENT
+    #     dataset reuses; must NOT be data_paper (kept=False) ---
+    (
+        "on007052",
+        "10.1016/j.neuroimage.2020.117465",
+        "methodology",
+    ),  # ERP CORE x PURSUE N400
+    (
+        "on007069",
+        "10.1016/j.neuroimage.2020.117465",
+        "methodology",
+    ),  # ERP CORE x PURSUE MMN
+    ("on005505", "10.1101/2024.10.03.615261", "umbrella"),  # HBN-EEG x an HBN sibling
+    ("on005510", "10.1101/2024.10.03.615261", "umbrella"),  # HBN-EEG x an HBN sibling
+    (
+        "ds004118",
+        "10.3389/fnins.2014.00155",
+        "related_work",
+    ),  # EEG task-perf method paper
+    ("nm000163", "10.1016/j.neuroimage.2023.120446", "methodology"),  # c-VEP BCI method
+    # --- controls: genuine data papers (IsDescribedBy); MUST stay data_paper ---
+    (
+        "on000117",
+        "10.1038/sdata.2015.1",
+        "data_paper",
+    ),  # multimodal neuroimaging dataset
+    ("on005779", "10.1016/j.brs.2024.01.001", "data_paper"),
+    ("on005028", "10.1101/2022.06.24.22276882", "data_paper"),
+]
+
+DEFAULT_MODELS = ["gemma4:e4b", "gemma4:26b", "gemma4:31b", "qwen3.6:27b"]
+
+# Relations under which an anchor is a plausible data paper for THIS dataset.
+_DATA_PAPER_RELATIONS = {
+    "IsDescribedBy",
+    "IsSupplementTo",
+    "IsVersionOf",
+    "IsIdenticalTo",
+}
+# The dataset's own record DOIs (OpenNeuro / NEMAR) — always plausible self-anchors.
+_OWN_DOI_PREFIXES = ("10.18112/openneuro.",)
+
+
+def _lookup_relation(dataset_id: str, anchor_doi: str) -> str:
+    """Read the source_relation for this (dataset, anchor) from the citation JSON."""
+    path = Path("citations/json_opencite") / f"{dataset_id}_citations.json"
+    target = anchor_doi.lower().replace("doi:", "")
+    try:
+        payload = json.loads(path.read_text())
+    except OSError:
+        return "References"
+    for c in payload.get("citation_details") or []:
+        if (c.get("source_doi") or "").lower().replace("doi:", "") == target:
+            return c.get("source_relation") or "References"
+    return "References"
+
+
+def _data_paper_plausible(relation: str, anchor_doi: str) -> bool:
+    """Relation-type prior: could this anchor be THIS dataset's data paper?"""
+    if relation in _DATA_PAPER_RELATIONS:
+        return True
+    doi = anchor_doi.lower().replace("doi:", "")
+    return any(doi.startswith(p) for p in _OWN_DOI_PREFIXES)
+
+
+def _apply_prior(model_class: str, relation: str, anchor_doi: str) -> str:
+    """Downgrade an implausible data_paper call; otherwise pass through."""
+    if model_class == "data_paper" and not _data_paper_plausible(relation, anchor_doi):
+        return "related_work"  # kept=False; "not this dataset's data paper"
+    return model_class
+
+
+def _build_cache(
+    backend: OpenCiteBackend, retriever: DatasetMetadataRetriever
+) -> dict[str, Any]:
+    """Fetch each dataset description + anchor paper exactly once."""
+    desc_cache: dict[str, str] = {}
+    paper_cache: dict[str, Any] = {}
+    relation: dict[tuple[str, str], str] = {}
+    for ds, doi, _ in LABELED_PAIRS:
+        if ds not in desc_cache:
+            md = retriever.get_dataset_metadata(ds)
+            desc_cache[ds] = extract_dataset_text(md)
+        if doi not in paper_cache:
+            res = backend.get_paper(doi)
+            paper_cache[doi] = res.value if isinstance(res, FetchSuccess) else None
+        relation[(ds, doi)] = _lookup_relation(ds, doi)
+    return {"desc": desc_cache, "paper": paper_cache, "relation": relation}
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--models", nargs="+", default=DEFAULT_MODELS)
+    parser.add_argument("--output", type=Path, default=None)
+    parser.add_argument("--timeout", type=int, default=180)
+    args = parser.parse_args()
+
+    backend = OpenCiteBackend()
+    retriever = DatasetMetadataRetriever()
+    print(f"Fetching context for {len(LABELED_PAIRS)} labeled pairs (once)...")
+    cache = _build_cache(backend, retriever)
+
+    results: dict[str, Any] = {"models": {}, "pairs": []}
+    for ds, doi, expected in LABELED_PAIRS:
+        results["pairs"].append(
+            {
+                "dataset_id": ds,
+                "anchor_doi": doi,
+                "expected": expected,
+                "relation": cache["relation"][(ds, doi)],
+                "title": getattr(cache["paper"].get(doi), "title", None),
+            }
+        )
+
+    for model in args.models:
+        client = OllamaJudgmentClient(model=model, timeout=args.timeout)
+        rows: list[dict[str, Any]] = []
+        latencies: list[float] = []
+        print(f"\n=== {model} ===")
+        for ds, doi, expected in LABELED_PAIRS:
+            paper = cache["paper"].get(doi)
+            relation = cache["relation"][(ds, doi)]
+            if paper is None:
+                rows.append({"dataset_id": ds, "anchor_doi": doi, "error": "no_paper"})
+                print(f"  [SKIP] {ds} <- {doi}: paper unresolved")
+                continue
+            prompt = build_anchor_prompt(
+                dataset_id=ds,
+                dataset_description=cache["desc"][ds],
+                anchor_doi=doi,
+                anchor_relation=relation,
+                paper_title=paper.title,
+                paper_abstract=paper.abstract,
+                paper_venue=paper.venue,
+                paper_authors=paper.authors,
+                paper_year=paper.year,
+            )
+            t0 = time.perf_counter()
+            try:
+                judgment = client.judge_anchor(prompt)
+                cls = judgment["classification"]
+            except LlmJudgmentError as exc:
+                rows.append(
+                    {"dataset_id": ds, "anchor_doi": doi, "error": f"llm:{exc}"}
+                )
+                print(f"  [ERR] {ds} <- {doi}: {exc}")
+                continue
+            ms = (time.perf_counter() - t0) * 1000
+            latencies.append(ms)
+            with_prior = _apply_prior(cls, relation, doi)
+            rows.append(
+                {
+                    "dataset_id": ds,
+                    "anchor_doi": doi,
+                    "expected": expected,
+                    "model_class": cls,
+                    "prior_class": with_prior,
+                    "ms": round(ms),
+                }
+            )
+            flag = "ok " if cls == expected else "MISS"
+            pflag = "" if with_prior == cls else f" -> prior:{with_prior}"
+            print(
+                f"  [{flag}] {ds} <- {doi[:34]:34s} exp={expected:12s} got={cls:12s}{pflag} ({round(ms)}ms)"
+            )
+
+        scored = [r for r in rows if "model_class" in r]
+        n = len(scored) or 1
+
+        def kept(c: str) -> bool:
+            return c == "data_paper"
+
+        exact = sum(r["model_class"] == r["expected"] for r in scored)
+        exact_prior = sum(r["prior_class"] == r["expected"] for r in scored)
+        binacc = sum(kept(r["model_class"]) == kept(r["expected"]) for r in scored)
+        binacc_prior = sum(
+            kept(r["prior_class"]) == kept(r["expected"]) for r in scored
+        )
+        avg_ms = round(sum(latencies) / (len(latencies) or 1))
+        results["models"][model] = {
+            "exact_acc": round(exact / n, 2),
+            "exact_acc_with_prior": round(exact_prior / n, 2),
+            "kept_acc": round(binacc / n, 2),
+            "kept_acc_with_prior": round(binacc_prior / n, 2),
+            "avg_ms": avg_ms,
+            "n_scored": len(scored),
+            "rows": rows,
+        }
+        print(
+            f"  -> exact {exact}/{n} (prior {exact_prior}/{n}) | "
+            f"data_paper-binary {binacc}/{n} (prior {binacc_prior}/{n}) | avg {avg_ms}ms"
+        )
+
+    print("\n=== SUMMARY (model: exact | exact+prior | kept | kept+prior | avg ms) ===")
+    for m, s in results["models"].items():
+        print(
+            f"  {m:14s} {s['exact_acc']:.2f} | {s['exact_acc_with_prior']:.2f} | "
+            f"{s['kept_acc']:.2f} | {s['kept_acc_with_prior']:.2f} | {s['avg_ms']}ms"
+        )
+
+    if args.output:
+        args.output.write_text(json.dumps(results, indent=2))
+        print(f"\nwrote {args.output}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
Records the 2026-06-21 investigation into citation over-attribution (epic #180 / #131) and adds a reproducible harness. Docs + one throwaway script only; no pipeline code changes.

- `scripts/bench_anchor_models.py` — bake-off harness (fetch context once, loop models, relation-type prior, score accuracy + latency). No sidecar writes.
- `.context/research/anchor_model_bakeoff_2026-06-21.{md,json}` — findings + raw results.

## Key conclusion
No judgment model (gemma4 e4b/26b/31b, qwen3.6:27b) reliably distinguishes a dataset's data paper from a reused resource paper (best binary acc 0.44), and a deterministic relation-type prior over-corrects because `relation_type` is unreliable in both directions (on000117's real data paper is tagged `References`; iEEG-BIDS is tagged `IsDescribedBy`). Root cause is upstream enrichment metadata, filed as **nemarOrg/nemar-cli#826**.

Consequences documented: #131's prompt fix is insufficient (PR #191 kept only for genuine method papers), and **#192 (delete dashboard heuristic) is blocked on nemar-cli#826** — the heuristic compensates for the unreliable upstream signal.

## Test plan
- [x] `ruff format`/`check` clean on the new script.
- [x] No production code touched; full suite unaffected.

Refs #131, #180, #192. Upstream: nemarOrg/nemar-cli#826.